### PR TITLE
Add multiple recording indicator options

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -52,7 +52,9 @@
       },
       "pause_recording": {
         "enabled": true,
-        "includeSilence": false
+        "include_silence": false,
+        "indicator_banner": false,
+        "indicator_permanent": true
       },
       "activity_reservation_handler": {
         "enabled": false,

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/README.md
@@ -10,7 +10,12 @@ This feature adds a Pause/Resume Recording button to the call canvas to allow th
 
 Recording must be enabled either via the dual channel recording feature in this repository, or via the "Call Recording" setting in Twilio Console > Flex > Manage > Voice. Do not enable both recording methods simultaneously, or only one of the recordings will be paused.
 
-There are no additional setup steps required, only enabling the feature in the flex-config asset for your environment. There is also a `includeSilence` configuration property to choose whether the paused portion of the call recording should be included as silence.
+There are no additional setup steps required, only enabling the feature in the flex-config asset for your environment.
+
+There are some additional configuration properties you may change if desired:
+- `include_silence` - whether the paused portion of the call recording should be included as silence
+- `indicator_banner` - whether recording indicator is displayed temporarily in a notification banner
+- `indicator_permanent` - whether a permanent 'Call Recording Paused' indicator is shown while paused
 
 # how it works
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseStatusPanel/PauseStatusPanel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseStatusPanel/PauseStatusPanel.tsx
@@ -2,25 +2,20 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState, reduxNamespace } from '../../../../flex-hooks/states';
 import {
-  IconButton,
   TaskHelper,
   ITask
 } from '@twilio/flex-ui';
-
-import { pauseRecording, resumeRecording } from "../../helpers/pauseRecordingHelper";
+import {Text} from '@twilio-paste/core/text';
 import PauseRecordingStrings, { StringTemplates } from '../../flex-hooks/strings/PauseRecording';
 
 export interface OwnProps {
   task?: ITask
 }
 
-const PauseRecordingButton = (props: OwnProps) => {
+const PauseStatusPanel = (props: OwnProps) => {
   const [ paused, setPaused ] = useState(false);
-  const [ waiting, setWaiting ] = useState(false);
   
   const { pausedRecordings } = useSelector((state: AppState) => state[reduxNamespace].pauseRecording);
-  
-  const isLiveCall = props.task ? TaskHelper.isLiveCall(props.task) : false;
   
   useEffect(() => {
     updatePausedState();
@@ -31,6 +26,8 @@ const PauseRecordingButton = (props: OwnProps) => {
   }, [pausedRecordings, props.task?.sid]);
   
   const updatePausedState = () => {
+    const isLiveCall = props.task ? TaskHelper.isLiveCall(props.task) : false;
+    
     if (!isLiveCall || !props.task) {
       setPaused(false);
       return;
@@ -43,31 +40,17 @@ const PauseRecordingButton = (props: OwnProps) => {
     }
   }
   
-  const handleClick = async () => {
-    if (!isLiveCall || !props.task) {
-      return;
-    }
-    
-    setWaiting(true);
-    
-    if (paused) {
-      await resumeRecording(props.task);
-    } else {
-      await pauseRecording(props.task);
-    }
-    
-    setWaiting(false);
-  }
-  
   return (
-    <IconButton
-      icon="MonitorOffLarge"
-      disabled={!isLiveCall || waiting}
-      onClick={handleClick}
-      variant={ paused ? "primary" : "secondary" }
-      title={ paused ? PauseRecordingStrings[StringTemplates.RESUME_TOOLTIP] : PauseRecordingStrings[StringTemplates.PAUSE_TOOLTIP] }
-    />
+    <>
+    { paused && (
+      <Text
+        as='p'
+        textAlign='center'
+        fontWeight='fontWeightBold'
+        padding='space50'>{PauseRecordingStrings[StringTemplates.RECORDING_PAUSED_LABEL]}</Text>
+    )}
+    </>
   );
 }
 
-export default PauseRecordingButton;
+export default PauseStatusPanel;

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseStatusPanel/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseStatusPanel/index.ts
@@ -1,0 +1,3 @@
+import PauseStatusPanel from './PauseStatusPanel';
+
+export default PauseStatusPanel;

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvas.tsx
@@ -1,0 +1,15 @@
+import * as Flex from '@twilio/flex-ui';
+import PauseStatusPanel from '../../custom-components/PauseStatusPanel';
+import { UIAttributes } from 'types/manager/ServiceConfiguration';
+
+const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { enabled = false, indicator_permanent = false } = custom_data?.features?.pause_recording || {}
+
+export function addPauseStatusPanel(flex: typeof Flex, manager: Flex.Manager) {
+  
+  if (!enabled || !indicator_permanent) return;
+
+  flex.CallCanvas.Content.add(<PauseStatusPanel key="pause-status-panel" />, {
+    sortOrder: -1
+  });
+}

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvasActions.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvasActions.tsx
@@ -1,5 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
-import PauseRecordingButton from '../../custom-components/PauseRecordingButton'
+import PauseRecordingButton from '../../custom-components/PauseRecordingButton';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
 const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/states/PauseRecordingSlice.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/states/PauseRecordingSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { PausedRecording } from '../../types/PausedRecording';
+
+export interface PauseRecordingState {
+  pausedRecordings: Array<PausedRecording>;
+}
+
+const initialState = { pausedRecordings: [] } as PauseRecordingState
+
+const pauseRecordingSlice = createSlice({
+  name: 'pauseRecording',
+  initialState,
+  reducers: {
+    pause(state, action: PayloadAction<PausedRecording>) {
+      state.pausedRecordings.push(action.payload);
+    },
+    resume(state, action: PayloadAction<number>) {
+      state.pausedRecordings.splice(action.payload, 1);
+    },
+  },
+})
+
+export const { pause, resume } = pauseRecordingSlice.actions
+export default pauseRecordingSlice.reducer

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/strings/PauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/strings/PauseRecording.ts
@@ -1,14 +1,20 @@
 // Export the template names as an enum for better maintainability when accessing them elsewhere
 export enum StringTemplates {
   RECORDING_PAUSED = 'PSRecordingPaused',
+  RECORDING_PAUSED_LABEL = 'PSRecordingPausedLabel',
   RESUME_RECORDING = 'PSResumeRecording',
-  PAUSE_FAILED = 'PSPauseFailed',
-  RESUME_FAILED = 'PSResumeFailed',
+  PAUSE_FAILED = 'PSPauseRecordingFailed',
+  RESUME_FAILED = 'PSResumeRecordingFailed',
+  PAUSE_TOOLTIP = 'PSPauseRecordingTooltip',
+  RESUME_TOOLTIP = 'PSResumeRecordingTooltip',
 }
 
 export default {
   [StringTemplates.RECORDING_PAUSED]: 'Call recording has been paused. Please remember to resume call recording when appropriate.',
+  [StringTemplates.RECORDING_PAUSED_LABEL]: 'Call Recording Paused',
   [StringTemplates.RESUME_RECORDING]: 'Resumed recording this call.',
   [StringTemplates.PAUSE_FAILED]: 'Failed to pause call recording. Please try again.',
   [StringTemplates.RESUME_FAILED]: 'Failed to resume call recording. Please try again.',
+  [StringTemplates.PAUSE_TOOLTIP]: 'Pause Recording',
+  [StringTemplates.RESUME_TOOLTIP]: 'Resume Recording',
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
@@ -12,7 +12,7 @@ const { custom_data } =
     .ui_attributes as UIAttributes) || {};
 const { enabled: dualChannelEnabled = false, channel } =
   custom_data?.features?.dual_channel_recording || {};
-  const { includeSilence = false } =
+  const { include_silence = false, indicator_banner = false } =
     custom_data?.features?.pause_recording || {};
 
 const getDualChannelCallSid = (task: ITask): string | null => {
@@ -62,13 +62,13 @@ export const pauseRecording = async (task: ITask): Promise<boolean> => {
       const callSid = getDualChannelCallSid(task);
       
       if (callSid) {
-        const recording = await RecordingService.pauseCallRecording(callSid, includeSilence ? "silence" : "skip");
+        const recording = await RecordingService.pauseCallRecording(callSid, include_silence ? "silence" : "skip");
         recordingSid = recording.sid;
       } else {
         console.error('Unable to get call SID to pause recording');
       }
     } else if (task.conference) {
-      const recording = await RecordingService.pauseConferenceRecording(task.conference?.conferenceSid, includeSilence ? "silence" : "skip");
+      const recording = await RecordingService.pauseConferenceRecording(task.conference?.conferenceSid, include_silence ? "silence" : "skip");
       recordingSid = recording.sid;
     }
     
@@ -77,7 +77,7 @@ export const pauseRecording = async (task: ITask): Promise<boolean> => {
         reservationSid: task.sid,
         recordingSid
       }));
-      Notifications.showNotification(NotificationIds.RECORDING_PAUSED);
+      if (indicator_banner) Notifications.showNotification(NotificationIds.RECORDING_PAUSED);
       return true;
     }
   } catch (error) {
@@ -118,7 +118,7 @@ export const resumeRecording = async (task: ITask): Promise<boolean> => {
     
     if (success) {
       manager.store.dispatch(resume(recordingIndex));
-      Notifications.showNotification(NotificationIds.RESUME_RECORDING);
+      if (indicator_banner) Notifications.showNotification(NotificationIds.RESUME_RECORDING);
       return true;
     }
   } catch (error) {

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/PausedRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/PausedRecording.ts
@@ -1,0 +1,4 @@
+export type PausedRecording = {
+  reservationSid: string;
+  recordingSid: string;
+}

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/ServiceConfiguration.ts
@@ -1,4 +1,6 @@
 export default interface PauseRecordingConfig {
   enabled: boolean;
-  includeSilence: boolean;
+  include_silence: boolean;
+  indicator_banner: boolean;
+  indicator_permanent: boolean;
 }

--- a/plugin-flex-ts-template-v2/src/flex-hooks/components/components.ts
+++ b/plugin-flex-ts-template-v2/src/flex-hooks/components/components.ts
@@ -19,10 +19,15 @@ import { addChatTransferButton } from "../../feature-library/chat-transfer/flex-
 import { addChatTransferCustomization } from "../../feature-library/chat-transfer/flex-hooks/components/WorkerDirectory";
 import { replaceWorkerProfileInfo } from "../../feature-library/activity-skill-filter/flex-hooks/components/WorkerProfile";
 import { addPauseRecordingButton } from "../../feature-library/pause-recording/flex-hooks/components/CallCanvasActions";
+import { addPauseStatusPanel } from "../../feature-library/pause-recording/flex-hooks/components/CallCanvas";
 
 const componentHandlers: Components = {
   AgentDesktopView: [],
-  CallCanvas: [addConferenceToCallCanvas, addSupervisorCoachingPanelToAgent],
+  CallCanvas: [
+    addConferenceToCallCanvas,
+    addSupervisorCoachingPanelToAgent,
+    addPauseStatusPanel
+  ],
   CallCanvasActions: [
     addConferenceToCallCanvasActions,
     removeDirectoryFromInternalCalls,

--- a/plugin-flex-ts-template-v2/src/flex-hooks/states/states.ts
+++ b/plugin-flex-ts-template-v2/src/flex-hooks/states/states.ts
@@ -10,15 +10,20 @@ import {
   SupervisorBargeCoachState,
   SupervisorBargeCoachReducer,
 } from "../../feature-library/supervisor-barge-coach/flex-hooks/states/SupervisorBargeCoach";
+import PauseRecordingReducer, {
+  PauseRecordingState
+} from "../../feature-library/pause-recording/flex-hooks/states/PauseRecordingSlice";
 
 export interface CustomState {
   outboundCallerIdSelector: OutboundCallerIDSelectorState;
   callbackAndVoicemail: CallbackAndVoicemailState;
   supervisorBargeCoach: SupervisorBargeCoachState;
+  pauseRecording: PauseRecordingState;
 }
 
 export const customReducers = {
   outboundCallerIdSelector: OutboundCallerIDSelectorReducer,
   callbackAndVoicemail: CallbackAndVoicemailReducer,
   supervisorBargeCoach: SupervisorBargeCoachReducer,
+  pauseRecording: PauseRecordingReducer
 };


### PR DESCRIPTION
### Summary

- Moved pause recording state into redux
- Added 'Call Recording Paused' indicator to call canvas
- Added config options to enable or disable existing notification banners and permanent label

### Checklist
- [x] Tested changes end to end
- [x] Any Flex config changes added to all environment files
- [x] For Flex features added, ensure the feature list on the README on the project root folder is updated
- [x] For Flex v2 features, ensured pluginsLoaded event handler is added 
- [x] Completed README template for new features
  - [x] Feature summary - _high level summary of what the feature does_
  - [x] Flex User Experience with animations - _animations with descriptions if necessary of the user experience in Flex_
  - [x] Setup and dependencies - _description of any setup steps required for this feature_
  - [x] How does it work? - _description of plumbing supporting feature_
- [ ] Updated build number in package.json when modifying a flex plugin
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
