### PR TITLE
Fix potential crash when ending held conference

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plugin-flex-ts-template",
-  "version": "9.0.19",
+  "version": "9.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plugin-flex-ts-template",
-      "version": "9.0.19",
+      "version": "9.0.21",
       "dependencies": {
         "@twilio-paste/core": "^15.3.0",
         "@twilio-paste/icons": "^9.2.0",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template",
-  "version": "9.0.20",
+  "version": "9.0.21",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HangupCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HangupCall.ts
@@ -27,11 +27,15 @@ export function handleConferenceHangup(flex: typeof Flex, manager: Flex.Manager)
       conference.participants.forEach(async (participant: Flex.ConferenceParticipant) => {
         const { participantType, workerSid, callSid } = participant;
         if (participant.onHold && participant.status === "joined") {
-          await flex.Actions.invokeAction("UnholdParticipant", {
-            participantType,
-            task: payload.task,
-            targetSid: participantType === 'worker' ? workerSid : callSid
-          });
+          try {
+            await flex.Actions.invokeAction("UnholdParticipant", {
+              participantType,
+              task: payload.task,
+              targetSid: participantType === 'worker' ? workerSid : callSid
+            });
+          } catch (error) {
+            console.log('Conference: unable to unhold participant', error)
+          }
         }
       });
   


### PR DESCRIPTION
### Summary

Simple try/catch block to fix a Flex crash I was running into. Basically the conference was already ended by the time this action was being hit.

### Checklist
- [x] Tested changes end to end
- [x] Updated build number in package.json when modifying a flex plugin
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
