### PR TITLE
Local development enhancements

### DIFF
--- a/.github/workflows/flex_deploy_dev.yaml
+++ b/.github/workflows/flex_deploy_dev.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - local_development_enhancements
 
   # Enable running this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/flex_deploy_dev.yaml
+++ b/.github/workflows/flex_deploy_dev.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - local_development_enhancements
 
   # Enable running this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -146,4 +146,5 @@ test-results/
 # vscode
 .vscode
 
+appConfig.js
 

--- a/flex-config/index.js
+++ b/flex-config/index.js
@@ -102,9 +102,22 @@ async function deployConfigurationData({ map, auth, environment }) {
       },
     });
 
-    console.log("Configuration updated:");
-    console.log("UI Attributes", configurationUpdated.ui_attributes);
-    console.log("TaskRouter Skills", configurationUpdated.taskrouter_skills);
+
+    console.log("Configuration updated: (following output formatted for readability)");
+    
+    var readableFeatures = []
+    Object.entries(configurationUpdated.ui_attributes.custom_data.features).forEach( feature => {
+      { readableFeatures.push( { name: feature[0], enabled: feature[1].enabled}  )};
+    });
+    var readableAttributes = configurationUpdated.ui_attributes;
+    readableAttributes.custom_data.features = readableFeatures;
+
+    console.log("UI Attributes");
+    console.dir(readableAttributes, { depth: null });
+    console.log("TaskRouter Skills:");
+    configurationUpdated.taskrouter_skills.forEach(element => {
+      console.log(`\t${element.name}`);
+    })
   } catch (error) {
     console.error("error caught", error);
     console.log("Auth", error.config?.auth);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,32 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
+        "concurrently": "^7.5.0",
         "shelljs": "^0.8.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/balanced-match": {
@@ -29,11 +54,126 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concurrently": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.5.0.tgz",
+      "integrity": "sha512-5E3mwiS+i2JYBzr5BpXkFxOnleZTMsG+WnE/dCG4/P+oiVXrbmrBwJ2ozn4SxwB2EZDrKR568X+puVohxz3/Mg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.29.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -46,6 +186,15 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -77,6 +226,15 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -115,6 +273,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -164,6 +337,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -177,6 +359,24 @@
       "bin": {
         "resolve": "bin/resolve"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -198,6 +398,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -210,14 +457,97 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     }
   },
   "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -234,10 +564,92 @@
         "concat-map": "0.0.1"
       }
     },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "concurrently": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.5.0.tgz",
+      "integrity": "sha512-5E3mwiS+i2JYBzr5BpXkFxOnleZTMsG+WnE/dCG4/P+oiVXrbmrBwJ2ozn4SxwB2EZDrKR568X+puVohxz3/Mg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.29.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
+      }
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "fs.realpath": {
@@ -250,6 +662,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "glob": {
@@ -274,6 +692,12 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -305,6 +729,18 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -345,6 +781,12 @@
         "resolve": "^1.1.6"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -355,6 +797,21 @@
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
+    },
+    "rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "shell-quote": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.5",
@@ -367,16 +824,101 @@
         "rechoir": "^0.6.2"
       }
     },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "postinstall": "(cd serverless-functions && npm install && cp -n .env.example .env); (cd flex-config && npm install && cp -n .env.example .env); (cd plugin-flex-ts-template-v2 && npm install)",
     "remove-features": "node scripts/remove-features.js",
-    "rename-template": "node scripts/rename-template.js"
+    "rename-template": "node scripts/rename-template.js",
+    "start:serverless" : "cd serverless-functions && twilio serverless:start --inspect=localhost --port=3001 --env .env",
+    "start:plugin": "cd plugin-flex-ts-template-v2 && twilio flex:plugins:start",
+    "start:local": "concurrently --kill-others \"npm run start:serverless\" \"npm run start:plugin\""
   },
   "repository": {
     "type": "git",
@@ -18,6 +21,7 @@
   },
   "homepage": "https://github.com/twilio-professional-services/twilio-proserv-flex-project-template#readme",
   "devDependencies": {
+    "concurrently": "^7.5.0",
     "shelljs": "^0.8.5"
   }
 }

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template",
-  "version": "9.0.21",
+  "version": "9.0.22",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/public/appConfig.example.js
+++ b/plugin-flex-ts-template-v2/public/appConfig.example.js
@@ -1,0 +1,14 @@
+var appConfig = {
+  pluginService: {
+    enabled: true,
+    url: "/plugins",
+  },
+  ytica: false,
+  logLevel: "info",
+  showSupervisorDesktopView: true,
+  custom_data: {
+    serverless_functions_protocol: "http",
+    serverless_functions_port: "3001",
+    serverless_functions_domain: "localhost"
+  },
+};

--- a/plugin-flex-ts-template-v2/public/appConfig.js
+++ b/plugin-flex-ts-template-v2/public/appConfig.js
@@ -1,9 +1,0 @@
-var appConfig = {
-  pluginService: {
-    enabled: true,
-    url: "/plugins",
-  },
-  ytica: false,
-  logLevel: "info",
-  showSupervisorDesktopView: true,
-};

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/CompleteTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/CompleteTask.ts
@@ -3,8 +3,7 @@ import WorkerState from "../../helpers/workerActivityHelper";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 import { getPendingActivity } from "../../helpers/pendingActivity";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } =
   custom_data?.features.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/SetWorkerActivity.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/SetWorkerActivity.ts
@@ -6,8 +6,7 @@ import { NotificationIds } from "../notifications/ActivityReservationHandler";
 import { systemActivities } from "../../helpers/systemActivities";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/StartOutboundCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/StartOutboundCall.ts
@@ -8,8 +8,7 @@ import {
 } from "../../helpers/systemActivities";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/components/MainHeader.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/components/MainHeader.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import PendingActivityComponent from '../../custom-components/pending-activity';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {};
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {};
 const { enabled = false } = custom_data?.features?.activity_reservation_handler || {}
 
 export function addPendingActivityComponent(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/pluginsLoaded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/pluginsLoaded.ts
@@ -3,8 +3,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { initialize } from "../../index";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskAccepted.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskAccepted.ts
@@ -9,8 +9,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskEnded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskEnded.ts
@@ -10,8 +10,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskReceived.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskReceived.ts
@@ -4,8 +4,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskWrapup.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskWrapup.ts
@@ -10,8 +10,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_reservation_handler || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helpers/systemActivities.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helpers/systemActivities.ts
@@ -2,8 +2,7 @@ import * as Flex from "@twilio/flex-ui";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 import FlexHelper from "./flexHelper";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 
 const {
   available = "Available",

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/components/MainHeader.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/components/MainHeader.tsx
@@ -3,7 +3,7 @@ import ActivityWrapperComponent from '../../custom-components/activity-wrapper';
 import { NotificationIds } from '../notifications/ActivitySkillFilter';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled, rules } = custom_data.features.activity_skill_filter;
 
 export function replaceActivityComponent(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/components/WorkerProfile.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/components/WorkerProfile.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import WorkerProfileInfo from '../../custom-components/worker-profile-info/'
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled, filter_teams_view, rules } = custom_data.features.activity_skill_filter;
 
 export function replaceWorkerProfileInfo(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/events/pluginsLoaded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/flex-hooks/events/pluginsLoaded.ts
@@ -2,8 +2,7 @@ import * as Flex from "@twilio/flex-ui";
 import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } =
   custom_data?.features?.activity_skill_filter || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/utils/AgentActivities.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/utils/AgentActivities.ts
@@ -5,7 +5,7 @@ import { UIAttributes } from 'types/manager/ServiceConfiguration';
 import { Activity } from 'types/task-router';
 import { ActivitySkillFilterRules } from '../types/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 
 export interface ActivityCssConfig {
   idx: number,

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/actions/SelectTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/actions/SelectTask.ts
@@ -13,7 +13,7 @@ export const autoSelectCallbackTaskWhenEndingCall = async (
   manager: Flex.Manager
 ) => {
   const { custom_data } =
-    (manager.serviceConfiguration.ui_attributes as UIAttributes) || {};
+    (manager.configuration as UIAttributes) || {};
   const { enabled = false, auto_select_task = false } =
     custom_data?.features?.callbacks || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
@@ -4,7 +4,7 @@ import { TaskAttributes } from '../../../../types/task-router/Task';
 import PhoneCallbackIcon from '@material-ui/icons/PhoneCallback';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {}
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {}
 const { enabled = false } = custom_data?.features?.callbacks || {}
 
 export function createCallbackChannel(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
@@ -4,7 +4,7 @@ import { TaskAttributes } from '../../../../types/task-router/Task';
 import VoicemailIcon from "@material-ui/icons/Voicemail";
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {}
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {}
 const { enabled = false } = custom_data?.features?.callbacks || {}
 
 export function createVoicemailChannel(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/components/TaskInfoPanel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/components/TaskInfoPanel.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import CallbackAndVoicemail from '../../custom-components/CallbackAndVoicemail'
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false, allow_requeue, max_attempts } = custom_data?.features?.callbacks || {}
 
 export function replaceViewForCallbackAndVoicemail(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/events/pluginsLoaded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/events/pluginsLoaded.ts
@@ -3,8 +3,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } = custom_data?.features?.callbacks || {};
 
 const pluginsLoadedHandler = (flexEvent: FlexEvent) => {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
@@ -186,7 +186,7 @@ class CallbackService extends ApiService {
     };
 
     const response = await this.fetchJsonWithReject<CreateCallbackResponse>(
-      `https://${this.serverlessDomain}/features/callbacks/flex/create-callback`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/features/callbacks/flex/create-callback`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/actions/StartOutboundCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/actions/StartOutboundCall.ts
@@ -3,8 +3,7 @@ import { AppState, reduxNamespace } from "../../../../flex-hooks/states";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } = custom_data?.features?.caller_id || {};
 
 export function applySelectedCallerIdForDialedNumbers(

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/components/OutboundDialerPanel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/components/OutboundDialerPanel.tsx
@@ -3,7 +3,7 @@ import OutboundCallerIDSelector from '../../custom-components/OutboundCallerIDSe
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features?.caller_id || {}
 
 export function addOutboundCallerIdSelectorToMainHeader(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/events/pluginsLoaded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/events/pluginsLoaded.ts
@@ -4,8 +4,7 @@ import { FlexEvent } from "../../../../types/manager/FlexEvent";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } = custom_data?.features?.caller_id || {};
 
 const pluginsLoadedHandler = (flexEvent: FlexEvent) => {

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
@@ -11,8 +11,7 @@ interface SwitchToVideoProps {
   context?: any;
 }
 
-const { custom_data } = Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Manager.getInstance().configuration as UIAttributes;
 const { serverless_functions_domain = "" } = custom_data || {};
 
 const SwitchToVideo: React.FunctionComponent<SwitchToVideoProps> = ({

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/VideoRoom/VideoRoom.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/VideoRoom/VideoRoom.tsx
@@ -27,8 +27,7 @@ interface VideoRoomProps {
   task: ITask;
 }
 
-const { custom_data } = Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Manager.getInstance().configuration as UIAttributes;
 const { serverless_functions_domain = "" } = custom_data || {}
 const BACKEND_URL = `https://${serverless_functions_domain}/features/chat-to-video-escalation`;
 

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/actions/CompleteTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/actions/CompleteTask.ts
@@ -1,8 +1,7 @@
 import * as Flex from "@twilio/flex-ui";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } =
   custom_data?.features?.chat_to_video_escalation || {};
 

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/components/TaskCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/components/TaskCanvasTabs.tsx
@@ -3,8 +3,7 @@ import VideoRoom from "../../custom-components/VideoRoom";
 
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration
-  .ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features?.chat_to_video_escalation || {};
 
 export function addVideoRoomTabToTaskCanvasTabs(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-transfer/helpers/APIHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-transfer/helpers/APIHelper.ts
@@ -134,7 +134,7 @@ class ChatTransferService extends ApiService {
     };
 
     return this.fetchJsonWithReject<TransferRESTResponse>(
-      `https://${this.serverlessDomain}/features/chat-transfer-v2-cbm/flex/chat-transfer`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/features/chat-transfer-v2-cbm/flex/chat-transfer`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-transfer/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-transfer/index.ts
@@ -2,8 +2,7 @@ import * as Flex from "@twilio/flex-ui";
 
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 const { custom_data } =
-  (Flex.Manager.getInstance().serviceConfiguration
-    .ui_attributes as UIAttributes) || {};
+  (Flex.Manager.getInstance().configuration as UIAttributes) || {};
 const { enabled = false } = custom_data?.features?.chat_transfer || {};
 
 export const isFeatureEnabled = () => {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HangupCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HangupCall.ts
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 import { ConferenceNotification } from '../notifications/Conference';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features.conference || {}
 
 export function handleConferenceHangup(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
@@ -2,7 +2,7 @@ import * as Flex from "@twilio/flex-ui";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 import ConferenceService from "../../../../utils/serverless/ConferenceService/ConferenceService";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features.conference || {};
 
 export function handleHoldConferenceParticipant(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/KickParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/KickParticipant.ts
@@ -2,7 +2,7 @@ import * as Flex from "@twilio/flex-ui";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
 import ConferenceService from "../../../../utils/serverless/ConferenceService/ConferenceService";
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features.conference || {};
 
 export function handleKickConferenceParticipant(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/CallCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/CallCanvas.tsx
@@ -4,7 +4,7 @@ import ConferenceMonitor from '../../custom-components/ConferenceMonitor';
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features?.conference || {};
 
 export function addConferenceToCallCanvas(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/CallCanvasActions.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/CallCanvasActions.tsx
@@ -3,7 +3,7 @@ import ConferenceButton from '../../custom-components/ConferenceButton';
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {}
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {}
 const { enabled = false } = custom_data?.features?.conference || {};
 
 export function addConferenceToCallCanvasActions(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/ParticipantCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/components/ParticipantCanvas.tsx
@@ -7,7 +7,7 @@ import ParticipantStatusContainer from '../../custom-components/ParticipantStatu
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features?.conference || {}
 
 export function addConferenceToParticipantCanvas(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
@@ -4,7 +4,7 @@ import IFrameCRMContainer from '../../custom-components/IFrameCRMContainer'
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.enhanced_crm_container || {};
 
 export function replaceAndSetCustomCRMContainer(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/AcceptTask.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/AcceptTask.tsx
@@ -3,7 +3,7 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 import InternalCallService from "../../../../utils/serverless/InternalCall/InternalCallService";
 import { isInternalCall } from '../../helpers/internalCall';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {};
 
 export function handleInternalAcceptTask(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/HoldCall.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/HoldCall.tsx
@@ -3,7 +3,7 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 import ConferenceService from "../../../../utils/serverless/ConferenceService/ConferenceService";
 import { isInternalCall } from '../../helpers/internalCall';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {};
 
 export function handleInternalHoldCall(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
@@ -3,7 +3,7 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 import InternalCallService from "../../../../utils/serverless/InternalCall/InternalCallService";
 import { isInternalCall } from '../../helpers/internalCall';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {};
 
 export function handleInternalRejectTask(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/UnholdCall.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/UnholdCall.tsx
@@ -3,7 +3,7 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 import ConferenceService from "../../../../utils/serverless/ConferenceService/ConferenceService";
 import { isInternalCall } from '../../helpers/internalCall';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {};
 
 export function handleInternalUnholdCall(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/components/CallCanvasActions.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/components/CallCanvasActions.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {}
 
 export function removeDirectoryFromInternalCalls(flex: typeof Flex) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/components/OutboundDialerPanel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/components/OutboundDialerPanel.tsx
@@ -3,7 +3,7 @@ import InternalDialpad from '../../custom-components/InternalDialpad';
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data?.features?.internal_call || {};
 
 export function addInternalCallToDialerPanel(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/events/pluginsLoaded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/events/pluginsLoaded.ts
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import { FlexEvent } from "../../../../types/manager/FlexEvent";
 
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled } = custom_data.features.internal_call;
 
 const pluginsLoadedHandler = (flexEvent: FlexEvent) => {

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvas.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import PauseStatusPanel from '../../custom-components/PauseStatusPanel';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false, indicator_permanent = false } = custom_data?.features?.pause_recording || {}
 
 export function addPauseStatusPanel(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvasActions.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/components/CallCanvasActions.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import PauseRecordingButton from '../../custom-components/PauseRecordingButton';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false } = custom_data?.features?.pause_recording || {}
 
 export function addPauseRecordingButton(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/schedule-manager.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/schedule-manager.ts
@@ -16,7 +16,7 @@ const delay = async (ms: number): Promise<void> => {
   return await new Promise(resolve => setTimeout(resolve, ms));
 }
 
-const { custom_data } = Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {};
+const { custom_data } = Manager.getInstance().configuration as UIAttributes || {};
 const { enabled = false } = custom_data?.features?.schedule_manager || {};
 
 export const canShowScheduleManager = (manager: Manager) => {

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
@@ -33,7 +33,7 @@ export const SupervisorBargeCoachButtons = ({task}: SupervisorBargeCoachProps) =
   const supervisorFN = useFlexSelector(state => state?.flex?.worker?.attributes?.full_name);
 
   // Confirming if Agent Coaching Panel is enabled, we will use this in the Supervisor Barge Coach component
-  const { custom_data } = Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+  const { custom_data } = Manager.getInstance().configuration as UIAttributes;
   const { agent_coaching_panel } = custom_data.features.supervisor_barge_coach;
 
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/CallCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/CallCanvas.tsx
@@ -4,7 +4,7 @@ import CoachingStatusPanel from '../../custom-components/CoachingStatusPanel'
 import { cleanStateAndSyncUponAgentHangUp } from '../actions/reservation';
 import { SyncDoc } from '../../utils/sync/Sync'
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {};
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {};
 const { enabled = false, agent_coaching_panel = false } = custom_data?.features?.supervisor_barge_coach || {}
 
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/TaskCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/TaskCanvasTabs.tsx
@@ -3,7 +3,7 @@ import { UIAttributes } from 'types/manager/ServiceConfiguration';
 import SupervisorMonitorPanel from '../../custom-components/SupervisorMonitorPanel';
 import { SyncDoc } from '../../utils/sync/Sync';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false, supervisor_monitor_panel = false } = custom_data?.features?.supervisor_barge_coach || {}
 
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/TaskOverviewCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/TaskOverviewCanvas.tsx
@@ -6,7 +6,7 @@ import { SyncDoc } from '../../utils/sync/Sync'
 import SupervisorBargeCoachButton from '../../custom-components/BargeCoachButtons'
 import SupervisorPrivateToggle from '../../custom-components/SupervisorPrivateModeButton'
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes;
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const { enabled = false, agent_coaching_panel = false } = custom_data?.features?.supervisor_barge_coach || {}
 
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/serverless/BargeCoachService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/serverless/BargeCoachService.ts
@@ -55,7 +55,7 @@ class BargeCoachService extends ApiService {
     };
 
     return this.fetchJsonWithReject<ParticipantMuteCoach>(
-      `https://${this.serverlessDomain}/features/supervisor-barge-coach/flex/participant-mute-and-coach`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/features/supervisor-barge-coach/flex/participant-mute-and-coach`,
       {
         method: 'post',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/flex-hooks/components/WorkerCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/flex-hooks/components/WorkerCanvas.tsx
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import CapacityContainer from '../../custom-components/CapacityContainer';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 
-const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {};
+const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {};
 const { enabled = false } = custom_data?.features?.supervisor_capacity || {};
 
 export function addCapacityToWorkerCanvas(flex: typeof Flex, manager: Flex.Manager) {

--- a/plugin-flex-ts-template-v2/src/types/manager/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/types/manager/ServiceConfiguration.ts
@@ -5,7 +5,9 @@ type FlexUIAttributes = Flex.ServiceConfiguration["ui_attributes"];
 
 export interface UIAttributes extends FlexUIAttributes {
   custom_data: {
+    serverless_functions_protocol: string;
     serverless_functions_domain: string;
+    serverless_functions_port: string;
     features: CustomServiceConfiguration;
   };
 }

--- a/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
@@ -10,13 +10,14 @@ function delay<T>(ms: number, result?: T) {
 export default abstract class ApiService {
   protected manager = Flex.Manager.getInstance();
   readonly serverlessDomain: string;
+  readonly serverlessProtocol: string;
 
   constructor() {
-    const { custom_data } = this.manager.serviceConfiguration
-      .ui_attributes as UIAttributes;
+    const { custom_data } = this.manager.configuration as UIAttributes;
 
     // use serverless_functions_domain from ui_attributes, or .env or set as undefined
 
+    this.serverlessProtocol = "https";
     this.serverlessDomain = "";
 
     if (process.env?.FLEX_APP_SERVERLESS_FUNCTONS_DOMAIN)
@@ -24,6 +25,12 @@ export default abstract class ApiService {
 
     if (custom_data?.serverless_functions_domain)
       this.serverlessDomain = custom_data.serverless_functions_domain;
+    
+    if(custom_data?.serverless_functions_protocol)
+      this.serverlessProtocol = custom_data.serverless_functions_protocol;
+
+    if(custom_data?.serverless_functions_port)
+      this.serverlessDomain += ":" + custom_data.serverless_functions_port
 
     if (!this.serverlessDomain)
       console.error(

--- a/plugin-flex-ts-template-v2/src/utils/serverless/ConferenceService/ConferenceService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ConferenceService/ConferenceService.ts
@@ -36,7 +36,7 @@ class ConferenceService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       }
 
-      this.fetchJsonWithReject<ParticipantResponse>(`https://${this.serverlessDomain}/common/flex/programmable-voice/hold-participant`,
+      this.fetchJsonWithReject<ParticipantResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-voice/hold-participant`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -65,7 +65,7 @@ class ConferenceService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       }
 
-      this.fetchJsonWithReject<ParticipantResponse>(`https://${this.serverlessDomain}/common/flex/programmable-voice/update-participant`,
+      this.fetchJsonWithReject<ParticipantResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-voice/update-participant`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -92,7 +92,7 @@ class ConferenceService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
 
-      this.fetchJsonWithReject<ParticipantResponse>(`https://${this.serverlessDomain}/common/flex/programmable-voice/add-participant`,
+      this.fetchJsonWithReject<ParticipantResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-voice/add-participant`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -126,7 +126,7 @@ class ConferenceService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
 
-      this.fetchJsonWithReject<RemoveParticipantResponse>(`https://${this.serverlessDomain}/common/flex/programmable-voice/remove-participant`,
+      this.fetchJsonWithReject<RemoveParticipantResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-voice/remove-participant`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -151,7 +151,7 @@ class ConferenceService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<GetCallResponse>(`https://${this.serverlessDomain}/common/flex/programmable-voice/get-call-properties`,
+      this.fetchJsonWithReject<GetCallResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-voice/get-call-properties`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/plugin-flex-ts-template-v2/src/utils/serverless/InternalCall/InternalCallService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/InternalCall/InternalCallService.ts
@@ -7,7 +7,7 @@ class InternalCallService extends ApiService {
     if (typeof reservation.task.attributes.conference !== "undefined") {
       reservation.call(
         reservation.task.attributes.from,
-        `https://${this.serverlessDomain}/features/internal-call/common/agent-join-conference?conferenceName=${reservation.task.attributes.conference.friendlyName}`,
+        `${this.serverlessProtocol}://${this.serverlessDomain}/features/internal-call/common/agent-join-conference?conferenceName=${reservation.task.attributes.conference.friendlyName}`,
         {
           accept: true,
         }
@@ -15,7 +15,7 @@ class InternalCallService extends ApiService {
     } else {
       reservation.call(
         reservation.task.attributes.from,
-        `https://${this.serverlessDomain}/features/internal-call/common/agent-outbound-join?taskSid=${taskSid}`,
+        `${this.serverlessProtocol}://${this.serverlessDomain}/features/internal-call/common/agent-outbound-join?taskSid=${taskSid}`,
         {
           accept: true,
         }
@@ -40,7 +40,7 @@ class InternalCallService extends ApiService {
       };
 
       this.fetchJsonWithReject(
-        `https://${this.serverlessDomain}/features/internal-call/flex/cleanup-rejected-task`,
+        `${this.serverlessProtocol}://${this.serverlessDomain}/features/internal-call/flex/cleanup-rejected-task`,
         {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
@@ -42,7 +42,7 @@ class PhoneNumberService extends ApiService {
     };
 
     return this.fetchJsonWithReject<ListPhoneNumbersResponse>(
-      `https://${this.serverlessDomain}/common/flex/phone-numbers/list-phone-numbers`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/phone-numbers/list-phone-numbers`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/plugin-flex-ts-template-v2/src/utils/serverless/ProgrammableChat/ProgrammableChatService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ProgrammableChat/ProgrammableChatService.ts
@@ -36,7 +36,7 @@ class ProgrammableChatService extends ApiService {
     };
 
     return this.fetchJsonWithReject<UpdateChannelAttributesResponse>(
-      `https://${this.serverlessDomain}/common/flex/programmable-chat/update-channel-attributes`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/programmable-chat/update-channel-attributes`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/plugin-flex-ts-template-v2/src/utils/serverless/Recording/RecordingService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/Recording/RecordingService.ts
@@ -16,7 +16,7 @@ class RecordingService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<RecordingResponse>(`https://${this.serverlessDomain}/features/dual-channel-recording/flex/create-recording`,
+      this.fetchJsonWithReject<RecordingResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/features/dual-channel-recording/flex/create-recording`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -40,7 +40,7 @@ class RecordingService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<RecordingResponse>(`https://${this.serverlessDomain}/features/pause-recording/flex/pause-call-recording`,
+      this.fetchJsonWithReject<RecordingResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/features/pause-recording/flex/pause-call-recording`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -64,7 +64,7 @@ class RecordingService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<RecordingResponse>(`https://${this.serverlessDomain}/features/pause-recording/flex/resume-call-recording`,
+      this.fetchJsonWithReject<RecordingResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/features/pause-recording/flex/resume-call-recording`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -88,7 +88,7 @@ class RecordingService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<RecordingResponse>(`https://${this.serverlessDomain}/features/pause-recording/flex/pause-conference-recording`,
+      this.fetchJsonWithReject<RecordingResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/features/pause-recording/flex/pause-conference-recording`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -112,7 +112,7 @@ class RecordingService extends ApiService {
         Token: encodeURIComponent(this.manager.user.token)
       };
   
-      this.fetchJsonWithReject<RecordingResponse>(`https://${this.serverlessDomain}/features/pause-recording/flex/resume-conference-recording`,
+      this.fetchJsonWithReject<RecordingResponse>(`${this.serverlessProtocol}://${this.serverlessDomain}/features/pause-recording/flex/resume-conference-recording`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/plugin-flex-ts-template-v2/src/utils/serverless/ScheduleManager/ScheduleManagerService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ScheduleManager/ScheduleManagerService.ts
@@ -10,7 +10,7 @@ class ScheduleManagerService extends ApiService {
   constructor() {
     super();
     
-    const { custom_data } = Flex.Manager.getInstance().serviceConfiguration.ui_attributes as UIAttributes || {};
+    const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes || {};
     const { serverless_domain } = custom_data?.features?.schedule_manager || {};
     
     this.scheduleManagerServerlessDomain = serverless_domain;

--- a/plugin-flex-ts-template-v2/src/utils/serverless/TaskRouter/TaskRouterService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/TaskRouter/TaskRouterService.ts
@@ -100,7 +100,7 @@ class TaskRouterService extends ApiService {
     };
 
     return this.fetchJsonWithReject<UpdateTaskAttributesResponse>(
-      `https://${this.serverlessDomain}/common/flex/taskrouter/update-task-attributes`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/taskrouter/update-task-attributes`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -119,7 +119,7 @@ class TaskRouterService extends ApiService {
     };
 
     return this.fetchJsonWithReject<GetQueuesResponse>(
-      `https://${this.serverlessDomain}/common/flex/taskrouter/get-queues`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/taskrouter/get-queues`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -137,7 +137,7 @@ class TaskRouterService extends ApiService {
     };
   
     return this.fetchJsonWithReject<GetWorkerChannelsResponse>(
-      `https://${this.serverlessDomain}/common/flex/taskrouter/get-worker-channels`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/taskrouter/get-worker-channels`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -163,7 +163,7 @@ class TaskRouterService extends ApiService {
     };
 
     return this.fetchJsonWithReject<UpdateWorkerChannelResponse>(
-      `https://${this.serverlessDomain}/common/flex/taskrouter/update-worker-channel`,
+      `${this.serverlessProtocol}://${this.serverlessDomain}/common/flex/taskrouter/update-worker-channel`,
       {
         method: "post",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },


### PR DESCRIPTION
### Summary

Updated the way we load the serverless domain name.  It can now be used from appConfig.js in local development and attributes here will override whats loaded from flex-config

```js
custom_data: {
    serverless_functions_protocol: "http",
    serverless_functions_port: "3001",
    serverless_functions_domain: "localhost"
}
```

Also introduced convenience script for running serverless and plugin locally, with inspection enabled.  
to run
```bash
npm run start:local
```

Then simply add the following launch.json to your .vscode folder to attach from vscode or your tool of choice

```json
{
  "version": "0.2.0",
  "configurations": [
      {
	"address": "localhost",
	"localRoot": "${workspaceFolder}/serverless-functions",
	"name": "Attach To Serverless Remote",
	"port": 9229,
	"remoteRoot": "${workspaceFolder}/serverless-functions",
	"request": "attach",
	"skipFiles": [
		"<node_internals>/**"
	],
	"type": "node"
    }
  ]
}
```


### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
