### PR TITLE
Reduce boilerplate

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Actions, ITask, Manager } from "@twilio/flex-ui";
+import { Actions, ITask, Manager, ConversationState } from "@twilio/flex-ui";
 import { Flex, Button } from "@twilio-paste/core";
 import { VideoOnIcon } from "@twilio-paste/icons/esm/VideoOnIcon";
 
@@ -9,14 +9,20 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 interface SwitchToVideoProps {
   task: ITask;
   context?: any;
+  conversation?: ConversationState;
 }
 
 const { custom_data } = Manager.getInstance().configuration as UIAttributes;
-const { serverless_functions_domain = "" } = custom_data || {};
+const {
+  serverless_functions_domain = "",
+  serverless_functions_port = "",
+  serverless_functions_protocol = "",
+} = custom_data || {};
 
 const SwitchToVideo: React.FunctionComponent<SwitchToVideoProps> = ({
   task,
   context,
+  conversation
 }) => {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -39,9 +45,20 @@ const SwitchToVideo: React.FunctionComponent<SwitchToVideoProps> = ({
         "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
       },
     };
+    
+    let serverlessDomain = serverless_functions_domain;
+    let serverlessProtocol = "https";
+    
+    if (serverless_functions_port) {
+      serverlessDomain += ":" + serverless_functions_port;
+    }
+    
+    if (serverless_functions_protocol) {
+      serverlessProtocol = serverless_functions_protocol;
+    }
 
     await fetch(
-      `https://${serverless_functions_domain}/features/chat-to-video-escalation/generate-unique-code?taskSid=${taskSid}`,
+      `${serverlessProtocol}://${serverlessDomain}/features/chat-to-video-escalation/generate-unique-code?taskSid=${taskSid}`,
       options
     )
       .then((response) => response.json())
@@ -49,7 +66,7 @@ const SwitchToVideo: React.FunctionComponent<SwitchToVideoProps> = ({
         console.log("SwitchToVideo: unique link created:", response);
         return Actions.invokeAction("SendMessage", {
           body: `Please join me using this unique video link: ${response.full_url}`,
-          conversationSid: channelSid,
+          conversation,
           messageAttributes: {
             hasVideo: true,
             videoUrl: response.full_url,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
@@ -5,7 +5,7 @@ import TaskRouterService from '../../../utils/serverless/TaskRouter/TaskRouterSe
 
 /* 
     this filter only works when a supporting backend solution is keeping
-    worker data up-to-date with an array of queue sids that they aer eligible
+    worker data up-to-date with an array of queue sids that they are eligible
     to work
 */
 

--- a/serverless-functions/.boiler-plate-function
+++ b/serverless-functions/.boiler-plate-function
@@ -1,48 +1,18 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/parameter-validator"
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const VoiceOperations = require(Runtime.getFunctions()[
+  "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function MYFUNCTIONNAME(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "requiredParamOneName", purpose: "parameter descirption" },
-    { key: "requiredParamTwoName", purpose: "parameter descirption" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "requiredParamOneName", purpose: "parameter description" },
+  { key: "requiredParamTwoName", purpose: "parameter description" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    // perform action
     callback(null, response);
-  } else {
-    try {
-      // perform action
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
-    }
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -8,7 +8,6 @@ const requiredParameters = [];
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const result = await PhoneNumberOpertions.listPhoneNumbers({
-      scriptName: context.PATH,
       context,
       attempts: 0,
     });

--- a/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
+++ b/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
@@ -1,63 +1,29 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ChatOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-chat"
 ].path);
 
-exports.handler = TokenValidator(async function updateChannelAttributes(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
+const requiredParameters = [
+  { key: "channelSid", purpose: "channel to be updated" },
+  { key: "attributes", purpose: "new attributes" },
+];
 
-  const requiredParameters = [
-    { key: "channelSid", purpose: "channel to be updated" },
-    { key: "attributes", purpose: "new attributes" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
-
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { channelSid, attributes } = event;
+    console.log(attributes);
+    const result = await ChatOperations.updateChannelAttributes({
+      scriptName: context.PATH,
+      context,
+      channelSid,
+      attributes,
+      attempts: 0,
+    });
+    
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success });
     callback(null, response);
-  } else {
-    try {
-      const { channelSid, attributes } = event;
-      console.log(attributes);
-      const result = await ChatOperations.updateChannelAttributes({
-        scriptName,
-        context,
-        channelSid,
-        attributes,
-        attempts: 0,
-      });
-
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
+++ b/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
@@ -13,7 +13,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const { channelSid, attributes } = event;
     console.log(attributes);
     const result = await ChatOperations.updateChannelAttributes({
-      scriptName: context.PATH,
       context,
       channelSid,
       attributes,

--- a/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
@@ -15,7 +15,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await ConferenceOperations.addParticipant({
       context,
-      scriptName: context.PATH,
       taskSid,
       to,
       from,

--- a/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
@@ -1,62 +1,33 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/conference-participant"
 ].path);
 
-exports.handler = TokenValidator(async function addParticipant(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "taskSid", purpose: "unique ID of task to update" },
-    { key: "to", purpose: "number to add to the conference" },
-    { key: "from", purpose: "caller ID to use when adding to the conference" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "taskSid", purpose: "unique ID of task to update" },
+  { key: "to", purpose: "number to add to the conference" },
+  { key: "from", purpose: "caller ID to use when adding to the conference" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { taskSid, to, from } = event;
-
+    
     const result = await ConferenceOperations.addParticipant({
       context,
-      scriptName,
+      scriptName: context.PATH,
       taskSid,
       to,
       from,
       attempts: 0,
     });
-
+    
     const { success, participantsResponse, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
@@ -14,7 +14,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.coldTransfer({
       context,
-      scriptName: context.PATH,
       callSid,
       to,
       attempts: 0,

--- a/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
@@ -1,60 +1,31 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function coldTransfer(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "callSid", purpose: "unique ID of call to update" },
-    { key: "to", purpose: "phone number to transfer to" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "callSid", purpose: "unique ID of call to update" },
+  { key: "to", purpose: "phone number to transfer to" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, to } = event;
-
+    
     const result = await VoiceOperations.coldTransfer({
       context,
-      scriptName,
+      scriptName: context.PATH,
       callSid,
       to,
       attempts: 0,
     });
-
+    
     const { success, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -13,7 +13,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.fetchProperties({
       context,
-      scriptName: context.PATH,
       callSid,
       attempts: 0,
     });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -1,4 +1,4 @@
-const { prepareFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
@@ -7,7 +7,7 @@ const requiredParameters = [
   { key: "callSid", purpose: "unique ID of call to fetch" },
 ];
 
-exports.handler = prepareFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid } = event;
     

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -1,58 +1,29 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function getCallProperties(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "callSid", purpose: "unique ID of call to fetch" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "callSid", purpose: "unique ID of call to fetch" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid } = event;
-
+    
     const result = await VoiceOperations.fetchProperties({
       context,
-      scriptName,
+      scriptName: context.PATH,
       callSid,
       attempts: 0,
     });
-
+    
     const { success, callProperties, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, callProperties });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
@@ -15,7 +15,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await ConferenceOperations.holdParticipant({
       context,
-      scriptName: context.PATH,
       conference,
       participant,
       hold: hold === "true",

--- a/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
@@ -1,62 +1,33 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/conference-participant"
 ].path);
 
-exports.handler = TokenValidator(async function holdParticipant(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conference", purpose: "unique ID of conference to update" },
-    { key: "participant", purpose: "unique ID of participant to update" },
-    { key: "hold", purpose: "whether to hold or unhold the participant" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conference", purpose: "unique ID of conference to update" },
+  { key: "participant", purpose: "unique ID of participant to update" },
+  { key: "hold", purpose: "whether to hold or unhold the participant" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant, hold } = event;
-
+    
     const result = await ConferenceOperations.holdParticipant({
       context,
-      scriptName,
+      scriptName: context.PATH,
       conference,
       participant,
       hold: hold === "true",
       attempts: 0,
     });
-
+    
     const { success, participantsResponse, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
@@ -14,7 +14,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await ConferenceOperations.removeParticipant({
       context,
-      scriptName: context.PATH,
       conference,
       participant,
       attempts: 0,

--- a/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
@@ -1,60 +1,31 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/conference-participant"
 ].path);
 
-exports.handler = TokenValidator(async function removeParticipant(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conference", purpose: "unique ID of conference to update" },
-    { key: "participant", purpose: "unique ID of participant to update" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conference", purpose: "unique ID of conference to update" },
+  { key: "participant", purpose: "unique ID of participant to update" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant } = event;
-
+    
     const result = await ConferenceOperations.removeParticipant({
       context,
-      scriptName,
+      scriptName: context.PATH,
       conference,
       participant,
       attempts: 0,
     });
-
+    
     const { success, participantsResponse, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await ConferenceOperations.updateParticipant({
       context,
-      scriptName: context.PATH,
       conference,
       participant,
       endConferenceOnExit: endConferenceOnExit === "true",

--- a/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
@@ -1,65 +1,36 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/conference-participant"
 ].path);
 
-exports.handler = TokenValidator(async function updateParticipant(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conference", purpose: "unique ID of conference to update" },
-    { key: "participant", purpose: "unique ID of participant to update" },
-    {
-      key: "endConferenceOnExit",
-      purpose: "whether to end conference when the participant leaves",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conference", purpose: "unique ID of conference to update" },
+  { key: "participant", purpose: "unique ID of participant to update" },
+  {
+    key: "endConferenceOnExit",
+    purpose: "whether to end conference when the participant leaves",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant, endConferenceOnExit } = event;
-
+    
     const result = await ConferenceOperations.updateParticipant({
       context,
-      scriptName,
+      scriptName: context.PATH,
       conference,
       participant,
       endConferenceOnExit: endConferenceOnExit === "true",
       attempts: 0,
     });
-
+    
     const { success, participantsResponse, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
@@ -1,24 +1,14 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskRouterOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = TokenValidator(async function getQueues(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
+const requiredParameters = [];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const result = await TaskRouterOperations.getQueues({
-      scriptName,
+      scriptName: context.PATH,
       context,
       attempts: 0,
     });
@@ -33,9 +23,6 @@ exports.handler = TokenValidator(async function getQueues(
     response.setBody({ success, queues, message });
     callback(null, response);
   } catch (error) {
-    console.log(error);
-    response.setStatusCode(500);
-    response.setBody({ data: null, message: error.message });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
@@ -8,7 +8,6 @@ const requiredParameters = [];
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const result = await TaskRouterOperations.getQueues({
-      scriptName: context.PATH,
       context,
       attempts: 0,
     });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
@@ -11,7 +11,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   try {
     const { workerSid } = event;
     const result = await TaskRouterOperations.getWorkerChannels({
-      scriptName: context.PATH,
       context,
       attempts: 0,
       workerSid,

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
@@ -1,57 +1,27 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskRouterOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = TokenValidator(async function getWorkerChannels(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "workerSid", purpose: "unique ID of the worker" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "workerSid", purpose: "unique ID of the worker" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-  
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { workerSid } = event;
     const result = await TaskRouterOperations.getWorkerChannels({
-      scriptName,
+      scriptName: context.PATH,
       context,
       attempts: 0,
       workerSid,
     });
     const { success, status, workerChannels } = result;
-  
+    
     response.setStatusCode(status);
     response.setBody({ success, workerChannels });
     callback(null, response);
   } catch (error) {
-    console.log(error);
-    response.setStatusCode(500);
-    response.setBody({ data: null, message: error.message });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
@@ -1,64 +1,30 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
-const TaskOperations = require(Runtime.getFunctions()[
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const TaskRouterOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = TokenValidator(async function updateTaskAttributes(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "taskSid", purpose: "unique ID of task to update" },
-    {
-      key: "attributesUpdate",
-      purpose: "object to overwrite on existing task attributes",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "taskSid", purpose: "unique ID of task to update" },
+  {
+    key: "attributesUpdate",
+    purpose: "object to overwrite on existing task attributes",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    console.error("update-attributes invalid parameters passed");
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { taskSid, attributesUpdate } = event;
+    const result = await TaskOperations.updateTaskAttributes({
+      scriptName: context.PATH,
+      context,
+      taskSid,
+      attributesUpdate,
+      attempts: 0,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success });
     callback(null, response);
-  } else {
-    try {
-      const { taskSid, attributesUpdate } = event;
-      const result = await TaskOperations.updateTaskAttributes({
-        scriptName,
-        context,
-        taskSid,
-        attributesUpdate,
-        attempts: 0,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
@@ -14,8 +14,7 @@ const requiredParameters = [
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { taskSid, attributesUpdate } = event;
-    const result = await TaskOperations.updateTaskAttributes({
-      scriptName: context.PATH,
+    const result = await TaskRouterOperations.updateTaskAttributes({
       context,
       taskSid,
       attributesUpdate,

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
@@ -1,45 +1,20 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskRouterOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = TokenValidator(async function updateWorkerChannel(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "workerSid", purpose: "unique ID of the worker" },
-    {
-      key: "workerChannelSid",
-      purpose: "unique ID of the workerChannelSid to update",
-    },
-    { key: "capacity", purpose: "the new capacity" },
-    { key: "available", purpose: "whether the channel is enabled or not" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "workerSid", purpose: "unique ID of the worker" },
+  {
+    key: "workerChannelSid",
+    purpose: "unique ID of the workerChannelSid to update",
+  },
+  { key: "capacity", purpose: "the new capacity" },
+  { key: "available", purpose: "whether the channel is enabled or not" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error("update-attributes invalid parameters passed");
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
     // Make sure that this user is allowed to perform this action
     if (!(event.TokenResult.roles.includes('supervisor') || event.TokenResult.roles.includes('admin'))) {
       response.setStatusCode(403)
@@ -47,27 +22,22 @@ exports.handler = TokenValidator(async function updateWorkerChannel(
       return callback(null, response);
     }
     
-    try {
-      const { workerSid, workerChannelSid, capacity, available } = event;
-      const result = await TaskRouterOperations.updateWorkerChannel({
-        scriptName,
-        context,
-        attempts: 0,
-        workerSid,
-        workerChannelSid,
-        capacity: Number(capacity),
-        available: available === "true",
-      });
-      const { success, message, status, workerChannelCapacity } = result;
-
-      response.setStatusCode(status);
-      response.setBody({ success, message, workerChannelCapacity });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+    const { workerSid, workerChannelSid, capacity, available } = event;
+    const result = await TaskRouterOperations.updateWorkerChannel({
+      scriptName: context.PATH,
+      context,
+      attempts: 0,
+      workerSid,
+      workerChannelSid,
+      capacity: Number(capacity),
+      available: available === "true",
+    });
+    const { success, message, status, workerChannelCapacity } = result;
+    
+    response.setStatusCode(status);
+    response.setBody({ success, message, workerChannelCapacity });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
@@ -24,7 +24,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const { workerSid, workerChannelSid, capacity, available } = event;
     const result = await TaskRouterOperations.updateWorkerChannel({
-      scriptName: context.PATH,
       context,
       attempts: 0,
       workerSid,

--- a/serverless-functions/src/functions/common/helpers/prepare-function.private.js
+++ b/serverless-functions/src/functions/common/helpers/prepare-function.private.js
@@ -1,0 +1,48 @@
+const TokenValidator = require("twilio-flex-token-validator").functionValidator;
+const ParameterValidator = require(Runtime.getFunctions()[
+  "common/helpers/parameter-validator"
+].path);
+
+/**
+ * Prepares the function for execution. Validates the token and other required parameters, then prepares
+ * the response object with the appropriate headers, as well as an error handling function.
+ *
+ * @param requiredParameters    array of parameters required and their description
+ * @param handlerFn             the Twilio Runtime handler function to execute
+ */
+exports.prepareFunction = (requiredParameters, handlerFn) => {
+  return TokenValidator((context, event, callback) => {
+    
+    const response = new Twilio.Response();
+    const parameterError = ParameterValidator.validate(
+      context.PATH,
+      event,
+      requiredParameters
+    );
+    
+    response.appendHeader("Access-Control-Allow-Origin", "*");
+    response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
+    response.appendHeader("Content-Type", "application/json");
+    response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+    
+    if (parameterError) {
+      console.error(`(${context.PATH}) invalid parameters passed`);
+      response.setStatusCode(400);
+      response.setBody({ data: null, message: parameterError });
+      callback(null, response);
+      return;
+    }
+    
+    const handleError = (error) => {
+      console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
+      response.setStatusCode(500);
+      response.setBody({
+        success: false,
+        message: error,
+      });
+      callback(null, response);
+    }
+    
+    return handlerFn(context, event, callback, response, handleError);
+  });
+};

--- a/serverless-functions/src/functions/common/helpers/prepare-function.private.js
+++ b/serverless-functions/src/functions/common/helpers/prepare-function.private.js
@@ -3,6 +3,40 @@ const ParameterValidator = require(Runtime.getFunctions()[
   "common/helpers/parameter-validator"
 ].path);
 
+const prepareFunction = (context, event, callback, requiredParameters, handlerFn) => {
+  const response = new Twilio.Response();
+  const parameterError = ParameterValidator.validate(
+    context.PATH,
+    event,
+    requiredParameters
+  );
+  
+  response.appendHeader("Access-Control-Allow-Origin", "*");
+  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST GET");
+  response.appendHeader("Content-Type", "application/json");
+  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+  
+  if (parameterError) {
+    console.error(`(${context.PATH}) invalid parameters passed`);
+    response.setStatusCode(400);
+    response.setBody({ data: null, message: parameterError });
+    callback(null, response);
+    return;
+  }
+  
+  const handleError = (error) => {
+    console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
+    response.setStatusCode(500);
+    response.setBody({
+      success: false,
+      message: error,
+    });
+    callback(null, response);
+  }
+  
+  return handlerFn(context, event, callback, response, handleError);
+};
+
 /**
  * Prepares the function for execution. Validates the token and other required parameters, then prepares
  * the response object with the appropriate headers, as well as an error handling function.
@@ -10,39 +44,18 @@ const ParameterValidator = require(Runtime.getFunctions()[
  * @param requiredParameters    array of parameters required and their description
  * @param handlerFn             the Twilio Runtime handler function to execute
  */
-exports.prepareFunction = (requiredParameters, handlerFn) => {
-  return TokenValidator((context, event, callback) => {
-    
-    const response = new Twilio.Response();
-    const parameterError = ParameterValidator.validate(
-      context.PATH,
-      event,
-      requiredParameters
-    );
-    
-    response.appendHeader("Access-Control-Allow-Origin", "*");
-    response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-    response.appendHeader("Content-Type", "application/json");
-    response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-    
-    if (parameterError) {
-      console.error(`(${context.PATH}) invalid parameters passed`);
-      response.setStatusCode(400);
-      response.setBody({ data: null, message: parameterError });
-      callback(null, response);
-      return;
-    }
-    
-    const handleError = (error) => {
-      console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({
-        success: false,
-        message: error,
-      });
-      callback(null, response);
-    }
-    
-    return handlerFn(context, event, callback, response, handleError);
-  });
+exports.prepareFlexFunction = (requiredParameters, handlerFn) => {
+  return TokenValidator((context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn));
+};
+
+/**
+ * Prepares the function for execution. Validates required parameters, then prepares
+ * the response object with the appropriate headers, as well as an error handling function.
+ * Note: This is only intended for protected functions, and does not validate a token.
+ *
+ * @param requiredParameters    array of parameters required and their description
+ * @param handlerFn             the Twilio Runtime handler function to execute
+ */
+exports.prepareStudioFunction = (requiredParameters, handlerFn) => {
+  return (context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn);
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -6,7 +6,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.interactionSid the Interaction Sid for this channel
@@ -16,11 +15,9 @@ const retryHandler = require(Runtime.getFunctions()[
  * @description the following method is used to create an Interaction Channel Invite
  */
 exports.participantCreateInvite = async function (parameters) {
-  const { scriptName, attempts, context, interactionSid, channelSid, routing } =
+  const { attempts, context, interactionSid, channelSid, routing } =
     parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))
@@ -50,7 +47,6 @@ exports.participantCreateInvite = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.interactionSid the Interaction Sid for this channel
@@ -62,7 +58,6 @@ exports.participantCreateInvite = async function (parameters) {
  */
 exports.participantUpdate = async function (parameters) {
   const {
-    scriptName,
     attempts,
     context,
     interactionSid,
@@ -71,8 +66,6 @@ exports.participantUpdate = async function (parameters) {
     status,
   } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))

--- a/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
@@ -5,7 +5,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @returns {Array<PhoneNumber>} An array of phone numbers for the account

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -6,7 +6,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.channelSid the channel to be updated
@@ -16,10 +15,8 @@ const retryHandler = require(Runtime.getFunctions()[
  *    to the channel object
  */
 exports.updateChannelAttributes = async function (parameters) {
-  const { scriptName, attempts, context, channelSid, attributes } = parameters;
+  const { attempts, context, channelSid, attributes } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -6,7 +6,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.callSid the unique call SID to fetch
@@ -34,7 +33,6 @@ exports.fetchProperties = async (parameters) => {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.callSid the unique call SID to fetch
@@ -67,7 +65,6 @@ exports.coldTransfer = async (parameters) => {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.callSid the unique call SID to fetch
@@ -96,7 +93,6 @@ exports.createRecording = async (parameters) => {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.callSid the unique call SID to update recording
@@ -130,7 +126,6 @@ exports.updateCallRecording = async (parameters) => {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.conferenceSid the unique conference SID to update recording

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -6,7 +6,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.uniqueName the unique name of the Sync document (optional)
@@ -16,10 +15,8 @@ const retryHandler = require(Runtime.getFunctions()[
  * @description the following method is used to create a sync document
  */
 exports.createDocument = async function (parameters) {
-  const { scriptName, attempts, context, uniqueName, ttl, data } = parameters;
+  const { attempts, context, uniqueName, ttl, data } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))
@@ -58,7 +55,6 @@ exports.createDocument = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.documentSid the sid of the Sync document
@@ -66,10 +62,8 @@ exports.createDocument = async function (parameters) {
  * @description the following method is used to fetch a sync document
  */
 exports.fetchDocument = async function (parameters) {
-  const { scriptName, attempts, context, documentSid } = parameters;
+  const { attempts, context, documentSid } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))
@@ -100,7 +94,6 @@ exports.fetchDocument = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.documentSid the sid of the Sync document
@@ -109,10 +102,8 @@ exports.fetchDocument = async function (parameters) {
  * @description the following method is used to fetch a sync document
  */
 exports.updateDocumentData = async function (parameters) {
-  const { scriptName, attempts, context, documentSid, updateData } = parameters;
+  const { attempts, context, documentSid, updateData } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -6,7 +6,6 @@ const retryHandler = require(Runtime.getFunctions()[
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {string} parameters.taskSid the task to update
  * @param {string} parameters.attributesUpdate a JSON object to merge with the task
@@ -17,12 +16,10 @@ const retryHandler = require(Runtime.getFunctions()[
  * more explained here https://www.twilio.com/docs/taskrouter/api/task#task-version
  */
 exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
-  const { attempts, scriptName, taskSid, attributesUpdate } = parameters;
+  const { attempts, taskSid, attributesUpdate } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isString(attributesUpdate))
@@ -81,7 +78,6 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.taskSid the task to update
@@ -90,12 +86,10 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
  * @description this operation safely completes the task with the given reason
  */
 exports.completeTask = async function completeTask(parameters) {
-  const { attempts, scriptName, taskSid, reason, context } = parameters;
+  const { attempts, taskSid, reason, context } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isString(reason))
@@ -126,9 +120,9 @@ exports.completeTask = async function completeTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { scriptName } = parameters;
+      const { context } = parameters;
       console.warn(
-        `${scriptName}.${arguments.callee.name}(): ${error.message}`
+        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
       );
       return {
         success: true,
@@ -142,7 +136,6 @@ exports.completeTask = async function completeTask(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.taskSid the task to update
@@ -151,12 +144,10 @@ exports.completeTask = async function completeTask(parameters) {
  * @description this operation safely completes the task reservation
  */
 exports.completeReservation = async function completeReservation(parameters) {
-  const { attempts, scriptName, context, taskSid, reservationSid } = parameters;
+  const { attempts, context, taskSid, reservationSid } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isString(reservationSid))
@@ -188,9 +179,9 @@ exports.completeReservation = async function completeReservation(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { scriptName } = parameters;
+      const { context } = parameters;
       console.warn(
-        `${scriptName}.${arguments.callee.name}(): ${error.message}`
+        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
       );
       return {
         success: true,
@@ -204,7 +195,6 @@ exports.completeReservation = async function completeReservation(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.taskSid the task to update
@@ -213,12 +203,10 @@ exports.completeReservation = async function completeReservation(parameters) {
  * @description this operation safely moves the reservation to wrapup
  */
 exports.wrapupReservation = async function wrapupReservation(parameters) {
-  const { attempts, scriptName, context, taskSid, reservationSid } = parameters;
+  const { attempts, context, taskSid, reservationSid } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isString(reservationSid))
@@ -250,9 +238,9 @@ exports.wrapupReservation = async function wrapupReservation(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { scriptName } = parameters;
+      const { context } = parameters;
       console.warn(
-        `${scriptName}.${arguments.callee.name}(): ${error.message}`
+        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
       );
       return {
         success: true,
@@ -266,7 +254,6 @@ exports.wrapupReservation = async function wrapupReservation(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.workflowSid the workflow to submit the task
@@ -279,7 +266,6 @@ exports.wrapupReservation = async function wrapupReservation(parameters) {
  */
 exports.createTask = async function createTask(parameters) {
   const {
-    scriptName,
     context,
     workflowSid,
     taskChannel,
@@ -291,8 +277,6 @@ exports.createTask = async function createTask(parameters) {
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName) || scriptName.length == 0)
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isObject(context))
     throw "Invalid parameters object passed. Parameters must contain context object";
   if (!isString(workflowSid) || workflowSid.length == 0)
@@ -333,7 +317,6 @@ exports.createTask = async function createTask(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @returns {object} An object containing an array of queues for the account
@@ -341,12 +324,10 @@ exports.createTask = async function createTask(parameters) {
  *   the queues for the account
  */
 exports.getQueues = async function getQueues(parameters) {
-  const { scriptName, context, attempts } = parameters;
+  const { context, attempts } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isObject(context))
     throw "Invalid parameters object passed. Parameters must contain context object";
 
@@ -368,7 +349,6 @@ exports.getQueues = async function getQueues(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.workerSid the worker sid to fetch channels for
@@ -378,7 +358,6 @@ exports.getQueues = async function getQueues(parameters) {
  */
 exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
   const {
-    scriptName,
     context,
     attempts,
     workerSid,
@@ -386,8 +365,6 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isObject(context))
     throw "Invalid parameters object passed. Parameters must contain context object";
   if (!isString(workerSid))
@@ -413,7 +390,6 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @returns {object} worker channel capacity object
@@ -422,7 +398,6 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
  */
 exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
   const {
-    scriptName,
     context,
     attempts,
     workerSid,
@@ -433,8 +408,6 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isObject(context))
     throw "Invalid parameters object passed. Parameters must contain context object";
   if (!isString(workerSid))
@@ -466,7 +439,6 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.taskSid the task to update
@@ -475,12 +447,10 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
  * @description updates the given task with the given params
  */
 exports.updateTask = async function updateTask(parameters) {
-  const { attempts, scriptName, taskSid, updateParams, context } = parameters;
+  const { attempts, taskSid, updateParams, context } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isObject(updateParams))
@@ -514,9 +484,9 @@ exports.updateTask = async function updateTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { scriptName } = parameters;
+      const { context } = parameters;
       console.warn(
-        `${scriptName}.${arguments.callee.name}(): ${error.message}`
+        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
       );
       return {
         success: true,
@@ -530,7 +500,6 @@ exports.updateTask = async function updateTask(parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.taskSid the task to fetch
@@ -538,12 +507,10 @@ exports.updateTask = async function updateTask(parameters) {
  * @description fetches the given task
  */
 exports.fetchTask = async function fetchTask(parameters) {
-  const { attempts, scriptName, taskSid, context } = parameters;
+  const { attempts, taskSid, context } = parameters;
 
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isString(taskSid))
     throw "Invalid parameters object passed. Parameters must contain the taskSid string";
   if (!isObject(context))
@@ -575,9 +542,9 @@ exports.fetchTask = async function fetchTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { scriptName } = parameters;
+      const { context } = parameters;
       console.warn(
-        `${scriptName}.${arguments.callee.name}(): ${error.message}`
+        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
       );
       return {
         success: true,

--- a/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
@@ -1,120 +1,87 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = TokenValidator(async function createCallbackFlex(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "numberToCall", purpose: "the number of the customer to call" },
-    {
-      key: "numberToCallFrom",
-      purpose: "the number to call the customer from",
-    },
-    {
-      key: "flexFlowSid",
-      purpose: "the SID of the Flex Flow that triggered this function",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "numberToCall", purpose: "the number of the customer to call" },
+  {
+    key: "numberToCallFrom",
+    purpose: "the number to call the customer from",
+  },
+  {
+    key: "flexFlowSid",
+    purpose: "the SID of the Flex Flow that triggered this function",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const {
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const {
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      workflowSid: overriddenWorkflowSid,
+      timeout: overriddenTimeout,
+      priority: overriddenPriority,
+      attempts: retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid,
+      recordingUrl,
+      transcriptSid,
+      transcriptText,
+      isDeleted,
+      taskChannel: overriddenTaskChannel,
+    } = event;
+    
+    // use assigned values or use defaults
+    const workflowSid =
+      overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
+    const timeout = overriddenTimeout || 86400;
+    const priority = overriddenPriority || 0;
+    const attempts = retryAttempt || 0;
+    const taskChannel = overriddenTaskChannel || "voice";
+    
+    // setup required task attributes for task
+    const attributes = {
+      taskType: recordingSid ? "voicemail" : "callback",
+      name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
+      flow_execution_sid: flexFlowSid,
+      message: message || null,
+      callBackData: {
         numberToCall,
         numberToCallFrom,
-        flexFlowSid,
-        workflowSid: overriddenWorkflowSid,
-        timeout: overriddenTimeout,
-        priority: overriddenPriority,
-        attempts: retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
+        attempts,
+        mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        utcDateTimeReceived: utcDateTimeReceived || new Date(),
         recordingSid,
         recordingUrl,
         transcriptSid,
         transcriptText,
-        isDeleted,
-        taskChannel: overriddenTaskChannel,
-      } = event;
-
-      // use assigned values or use defaults
-      const workflowSid =
-        overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
-      const timeout = overriddenTimeout || 86400;
-      const priority = overriddenPriority || 0;
-      const attempts = retryAttempt || 0;
-      const taskChannel = overriddenTaskChannel || "voice";
-
-      // setup required task attributes for task
-      const attributes = {
-        taskType: recordingSid ? "voicemail" : "callback",
-        name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
-        flow_execution_sid: flexFlowSid,
-        message: message || null,
-        callBackData: {
-          numberToCall,
-          numberToCallFrom,
-          attempts,
-          mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          utcDateTimeReceived: utcDateTimeReceived || new Date(),
-          recordingSid,
-          recordingUrl,
-          transcriptSid,
-          transcriptText,
-          isDeleted: isDeleted || false,
-        },
-        direction: "inbound",
-        conversations: {
-          conversation_id,
-        },
-      };
-
-      const result = await TaskOperations.createTask({
-        scriptName,
-        context,
-        workflowSid,
-        taskChannel,
-        attributes,
-        priority,
-        timeout,
-        attempts: 0,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success, taskSid: result.taskSid });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+        isDeleted: isDeleted || false,
+      },
+      direction: "inbound",
+      conversations: {
+        conversation_id,
+      },
+    };
+    
+    const result = await TaskOperations.createTask({
+      scriptName: context.PATH,
+      context,
+      workflowSid,
+      taskChannel,
+      attributes,
+      priority,
+      timeout,
+      attempts: 0,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success, taskSid: result.taskSid });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
@@ -69,7 +69,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     };
     
     const result = await TaskOperations.createTask({
-      scriptName: context.PATH,
       context,
       workflowSid,
       taskChannel,

--- a/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
+++ b/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
@@ -69,7 +69,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
     };
     
     const result = await TaskOperations.createTask({
-      scriptName: context.PATH,
       context,
       workflowSid,
       taskChannel,

--- a/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
+++ b/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
@@ -1,119 +1,87 @@
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
 
-exports.handler = async function createCallbackStudio(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "numberToCall", purpose: "the number of the customer to call" },
-    {
-      key: "numberToCallFrom",
-      purpose: "the number to call the customer from",
-    },
-    {
-      key: "flexFlowSid",
-      purpose: "the SID of the Flex Flow that triggered this function",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "numberToCall", purpose: "the number of the customer to call" },
+  {
+    key: "numberToCallFrom",
+    purpose: "the number to call the customer from",
+  },
+  {
+    key: "flexFlowSid",
+    purpose: "the SID of the Flex Flow that triggered this function",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const {
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const {
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      workflowSid: overriddenWorkflowSid,
+      timeout: overriddenTimeout,
+      priority: overriddenPriority,
+      attempts: retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid,
+      recordingUrl,
+      transcriptSid,
+      transcriptText,
+      isDeleted,
+      taskChannel: overriddenTaskChannel,
+    } = event;
+    
+    // use assigned values or use defaults
+    const workflowSid =
+      overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
+    const timeout = overriddenTimeout || 86400;
+    const priority = overriddenPriority || 0;
+    const attempts = retryAttempt || 0;
+    const taskChannel = overriddenTaskChannel || "voice";
+    
+    // setup required task attributes for task
+    const attributes = {
+      taskType: recordingSid ? "voicemail" : "callback",
+      name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
+      flow_execution_sid: flexFlowSid,
+      message: message || null,
+      callBackData: {
         numberToCall,
         numberToCallFrom,
-        flexFlowSid,
-        workflowSid: overriddenWorkflowSid,
-        timeout: overriddenTimeout,
-        priority: overriddenPriority,
-        attempts: retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
+        attempts,
+        mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        utcDateTimeReceived: utcDateTimeReceived || new Date(),
         recordingSid,
         recordingUrl,
         transcriptSid,
         transcriptText,
-        isDeleted,
-        taskChannel: overriddenTaskChannel,
-      } = event;
-
-      // use assigned values or use defaults
-      const workflowSid =
-        overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
-      const timeout = overriddenTimeout || 86400;
-      const priority = overriddenPriority || 0;
-      const attempts = retryAttempt || 0;
-      const taskChannel = overriddenTaskChannel || "voice";
-
-      // setup required task attributes for task
-      const attributes = {
-        taskType: recordingSid ? "voicemail" : "callback",
-        name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
-        flow_execution_sid: flexFlowSid,
-        message: message || null,
-        callBackData: {
-          numberToCall,
-          numberToCallFrom,
-          attempts,
-          mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          utcDateTimeReceived: utcDateTimeReceived || new Date(),
-          recordingSid,
-          recordingUrl,
-          transcriptSid,
-          transcriptText,
-          isDeleted: isDeleted || false,
-        },
-        direction: "inbound",
-        conversations: {
-          conversation_id,
-        },
-      };
-
-      const result = await TaskOperations.createTask({
-        scriptName,
-        context,
-        workflowSid,
-        taskChannel,
-        attributes,
-        priority,
-        timeout,
-        attempts: 0,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success, taskSid: result.taskSid });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+        isDeleted: isDeleted || false,
+      },
+      direction: "inbound",
+      conversations: {
+        conversation_id,
+      },
+    };
+    
+    const result = await TaskOperations.createTask({
+      scriptName: context.PATH,
+      context,
+      workflowSid,
+      taskChannel,
+      attributes,
+      priority,
+      timeout,
+      attempts: 0,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success, taskSid: result.taskSid });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
-};
+});

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
@@ -1,132 +1,98 @@
 const AccessToken = require("twilio").jwt.AccessToken;
 const { SyncGrant, VideoGrant } = AccessToken;
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const SyncOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/sync"
 ].path);
 
-exports.handler = TokenValidator(async function agentGetToken(
-  context,
-  event,
-  callback
-) {
-  console.log("----- agentGetToken -----");
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "DocumentSid", purpose: "used for sync document" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "DocumentSid", purpose: "used for sync document" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const { DocumentSid: document_sid } = event;
-      const client = context.getTwilioClient();
-
-      const documentData = await SyncOperations.fetchDocument({
-        scriptName,
-        attempts: 0,
-        context,
-        documentSid: document_sid,
-      });
-
-      if (!documentData) {
-        response.setStatusCode(403);
-        response.setBody({ error: `Invalid document SID.` });
-        console.log(response);
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { DocumentSid: document_sid } = event;
+    const client = context.getTwilioClient();
+    
+    const documentData = await SyncOperations.fetchDocument({
+      scriptName: context.PATH,
+      attempts: 0,
+      context,
+      documentSid: document_sid,
+    });
+    
+    if (!documentData) {
+      response.setStatusCode(403);
+      response.setBody({ error: `Invalid document SID.` });
+      console.log(response);
+      return callback(null, response);
+    }
+    
+    const { document } = documentData;
+    
+    // Check if the video room is already created
+    let room_name = document.data.room;
+    if (!room_name) {
+      // If not, then create it
+      const room_created = await client.video.rooms
+        .create({
+          recordParticipantsOnConnect: context.VIDEO_RECORD_BY_DEFAULT,
+          type: context.VIDEO_ROOM_TYPE,
+        })
+        .then((room) => {
+          room_name = room.sid;
+          console.log(document.sid, room.sid);
+          return { ...document.data, room: room.sid };
+        })
+        .then((new_document_data) =>
+          SyncOperations.updateDocumentData({
+            scriptName: context.PATH,
+            attempts: 0,
+            context,
+            documentSid: document_sid,
+            updateData: new_document_data,
+          })
+        )
+        .catch((reason) => false);
+    
+      if (!room_created) {
+        response.setStatusCode(503);
+        response.setBody({ error: `Error starting video.` });
         return callback(null, response);
       }
-
-      const { document } = documentData;
-
-      // Check if the video room is already created
-      let room_name = document.data.room;
-      if (!room_name) {
-        // If not, then create it
-        const room_created = await client.video.rooms
-          .create({
-            recordParticipantsOnConnect: context.VIDEO_RECORD_BY_DEFAULT,
-            type: context.VIDEO_ROOM_TYPE,
-          })
-          .then((room) => {
-            room_name = room.sid;
-            console.log(document.sid, room.sid);
-            return { ...document.data, room: room.sid };
-          })
-          .then((new_document_data) =>
-            SyncOperations.updateDocumentData({
-              scriptName,
-              attempts: 0,
-              context,
-              documentSid: document_sid,
-              updateData: new_document_data,
-            })
-          )
-          .catch((reason) => false);
-
-        if (!room_created) {
-          response.setStatusCode(503);
-          response.setBody({ error: `Error starting video.` });
-          return callback(null, response);
-        }
-      }
-
-      // We use the agent's FLEX identity
-      const agent_identity = event.TokenResult.identity;
-
-      /*
-        - Authorize the agent Frontend to connect to SYNC
-        - Note: not  directly utilized in this implementation
-      */
-      const syncGrant = new SyncGrant({
-        serviceSid: context.TWILIO_FLEX_SYNC_SID,
-      });
-
-      // Authorize the agent Frontend to connect to VIDEO
-      const videoGrant = new VideoGrant({
-        room: room_name,
-      });
-
-      // Create an access token which we will sign and return to the agent,
-      const token = new AccessToken(
-        context.ACCOUNT_SID,
-        context.TWILIO_API_KEY,
-        context.TWILIO_API_SECRET,
-        { identity: agent_identity }
-      );
-      token.addGrant(syncGrant);
-      token.addGrant(videoGrant);
-
-      // Respond to the AGENT frontend with a dual-use token (sync + video)
-      response.setBody({ token: token.toJwt() });
-
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
     }
+    
+    // We use the agent's FLEX identity
+    const agent_identity = event.TokenResult.identity;
+    
+    /*
+      - Authorize the agent Frontend to connect to SYNC
+      - Note: not  directly utilized in this implementation
+    */
+    const syncGrant = new SyncGrant({
+      serviceSid: context.TWILIO_FLEX_SYNC_SID,
+    });
+    
+    // Authorize the agent Frontend to connect to VIDEO
+    const videoGrant = new VideoGrant({
+      room: room_name,
+    });
+    
+    // Create an access token which we will sign and return to the agent,
+    const token = new AccessToken(
+      context.ACCOUNT_SID,
+      context.TWILIO_API_KEY,
+      context.TWILIO_API_SECRET,
+      { identity: agent_identity }
+    );
+    token.addGrant(syncGrant);
+    token.addGrant(videoGrant);
+    
+    // Respond to the AGENT frontend with a dual-use token (sync + video)
+    response.setBody({ token: token.toJwt() });
+    
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
@@ -15,7 +15,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const client = context.getTwilioClient();
     
     const documentData = await SyncOperations.fetchDocument({
-      scriptName: context.PATH,
       attempts: 0,
       context,
       documentSid: document_sid,
@@ -46,7 +45,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         })
         .then((new_document_data) =>
           SyncOperations.updateDocumentData({
-            scriptName: context.PATH,
             attempts: 0,
             context,
             documentSid: document_sid,

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
@@ -17,7 +17,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
     
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
-      scriptName: context.PATH,
       attempts: 0,
       context,
       documentSid: code,

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
@@ -1,103 +1,74 @@
+const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const randomstring = require("randomstring");
 const AccessToken = require("twilio").jwt.AccessToken;
 const SyncOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/sync"
 ].path);
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
 const { SyncGrant } = AccessToken;
 
-exports.handler = async function clientGetSyncToken(context, event, callback) {
-  console.log("----- clientGetSyncToken -----");
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "code", purpose: "used for unique name of Sync document" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "code", purpose: "used for unique name of Sync document" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-  response.appendHeader("Content-Type", "application/json");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const client = context.getTwilioClient();
-      const { code } = event;
-
-      // Validate that the unique code is valid, i.e.: that the SYNC document exists
-      const documentData = await SyncOperations.fetchDocument({
-        scriptName,
-        attempts: 0,
-        context,
-        documentSid: code,
-      });
-
-      if (!documentData) {
-        response.setStatusCode(403);
-        response.setBody({ error: `Invalid code.` });
-        return callback(null, response);
-      }
-
-      /*
-        - Generate a random identity for the customer
-        - This could also be a name we ask to provide before joining the room
-      */
-      const client_identity = randomstring.generate();
-      console.log("Client identity for Sync : ", client_identity);
-
-      // Give read-only rights to the SYNC Document to this identity so the UI can subscribe to live updates
-      await client.sync
-        .services(context.TWILIO_FLEX_SYNC_SID)
-        .documents(code)
-        .documentPermissions(client_identity)
-        .update({ read: true, write: false, manage: false })
-        .then((document_permission) => true)
-        .catch((reason) => {
-          console.error(`Error giving permission to ${code}: ${reason}`);
-          return null;
-        });
-
-      // Create an access token which we will sign and return to the client,
-      const token = new AccessToken(
-        context.ACCOUNT_SID,
-        context.TWILIO_API_KEY,
-        context.TWILIO_API_SECRET,
-        { identity: client_identity }
-      );
-
-      // Add grants to the SYNC document and the VIDEO room to that token
-      const syncGrant = new SyncGrant({
-        serviceSid: context.TWILIO_FLEX_SYNC_SID,
-      });
-      token.addGrant(syncGrant);
-
-      /*
-        - Respond to the client with identity and token
-        - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
-      */
-      response.setBody({ token: token.toJwt() });
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const client = context.getTwilioClient();
+    const { code } = event;
+    
+    // Validate that the unique code is valid, i.e.: that the SYNC document exists
+    const documentData = await SyncOperations.fetchDocument({
+      scriptName: context.PATH,
+      attempts: 0,
+      context,
+      documentSid: code,
+    });
+    
+    if (!documentData) {
+      response.setStatusCode(403);
+      response.setBody({ error: `Invalid code.` });
+      return callback(null, response);
     }
+    
+    /*
+      - Generate a random identity for the customer
+      - This could also be a name we ask to provide before joining the room
+    */
+    const client_identity = randomstring.generate();
+    console.log("Client identity for Sync : ", client_identity);
+    
+    // Give read-only rights to the SYNC Document to this identity so the UI can subscribe to live updates
+    await client.sync
+      .services(context.TWILIO_FLEX_SYNC_SID)
+      .documents(code)
+      .documentPermissions(client_identity)
+      .update({ read: true, write: false, manage: false })
+      .then((document_permission) => true)
+      .catch((reason) => {
+        console.error(`Error giving permission to ${code}: ${reason}`);
+        return null;
+      });
+    
+    // Create an access token which we will sign and return to the client,
+    const token = new AccessToken(
+      context.ACCOUNT_SID,
+      context.TWILIO_API_KEY,
+      context.TWILIO_API_SECRET,
+      { identity: client_identity }
+    );
+    
+    // Add grants to the SYNC document and the VIDEO room to that token
+    const syncGrant = new SyncGrant({
+      serviceSid: context.TWILIO_FLEX_SYNC_SID,
+    });
+    token.addGrant(syncGrant);
+    
+    /*
+      - Respond to the client with identity and token
+      - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
+    */
+    response.setBody({ token: token.toJwt() });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
-};
+});

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
@@ -16,7 +16,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
     
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
-      scriptName: context.PATH,
       attempts: 0,
       context,
       documentSid: code,

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
@@ -1,101 +1,72 @@
+const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const randomstring = require("randomstring");
 const AccessToken = require("twilio").jwt.AccessToken;
 const SyncOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/sync"
 ].path);
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
 const { VideoGrant } = AccessToken;
 
-exports.handler = async function clientGetVideoToken(context, event, callback) {
-  console.log("----- clientGetVideoToken -----");
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "code", purpose: "used for connecting to the video room" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "code", purpose: "used for connecting to the video room" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-  response.appendHeader("Content-Type", "application/json");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const { code } = event;
-
-      // Validate that the unique code is valid, i.e.: that the SYNC document exists
-      const documentData = await SyncOperations.fetchDocument({
-        scriptName,
-        attempts: 0,
-        context,
-        documentSid: code,
-      });
-
-      if (!documentData) {
-        response.setStatusCode(403);
-        response.setBody({ error: `Invalid code.` });
-        return callback(null, response);
-      }
-
-      // Check if the video room was created already (i.e.: is the agent connected?)
-      const { document } = documentData;
-      let room_name = document.data.room;
-      if (!room_name) {
-        response.setStatusCode(405);
-        response.setBody({
-          error: `The agent is not yet connected. Please try again later.`,
-        });
-        return callback(null, response);
-      }
-
-      /*
-        - Generate a random identity for the customer
-        - Note: could be replaced with additional data passed to the function
-      */
-      const client_identity = randomstring.generate();
-
-      // Create an access token which we will sign and return to the client,
-      const token = new AccessToken(
-        context.ACCOUNT_SID,
-        context.TWILIO_API_KEY,
-        context.TWILIO_API_SECRET,
-        { identity: client_identity }
-      );
-
-      // Authorize the client Frontend to connect to VIDEO
-      const videoGrant = new VideoGrant({
-        room: room_name,
-      });
-      token.addGrant(videoGrant);
-
-      /*
-        - Respond to the client with identity and token
-        - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
-      */
-      response.setBody({ token: token.toJwt() });
-
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { code } = event;
+    
+    // Validate that the unique code is valid, i.e.: that the SYNC document exists
+    const documentData = await SyncOperations.fetchDocument({
+      scriptName: context.PATH,
+      attempts: 0,
+      context,
+      documentSid: code,
+    });
+    
+    if (!documentData) {
+      response.setStatusCode(403);
+      response.setBody({ error: `Invalid code.` });
+      return callback(null, response);
     }
+    
+    // Check if the video room was created already (i.e.: is the agent connected?)
+    const { document } = documentData;
+    let room_name = document.data.room;
+    if (!room_name) {
+      response.setStatusCode(405);
+      response.setBody({
+        error: `The agent is not yet connected. Please try again later.`,
+      });
+      return callback(null, response);
+    }
+    
+    /*
+      - Generate a random identity for the customer
+      - Note: could be replaced with additional data passed to the function
+    */
+    const client_identity = randomstring.generate();
+    
+    // Create an access token which we will sign and return to the client,
+    const token = new AccessToken(
+      context.ACCOUNT_SID,
+      context.TWILIO_API_KEY,
+      context.TWILIO_API_SECRET,
+      { identity: client_identity }
+    );
+    
+    // Authorize the client Frontend to connect to VIDEO
+    const videoGrant = new VideoGrant({
+      room: room_name,
+    });
+    token.addGrant(videoGrant);
+    
+    /*
+      - Respond to the client with identity and token
+      - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
+    */
+    response.setBody({ token: token.toJwt() });
+    
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
-};
+});

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
@@ -32,7 +32,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       });
     
       document = await SyncOperations.createDocument({
-        scriptName: context.PATH,
         attempts: 0,
         context,
         uniqueName: unique_code,
@@ -49,7 +48,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     };
     
     const result = await TaskOperations.updateTaskAttributes({
-      scriptName: context.PATH,
       context,
       taskSid,
       attributesUpdate: JSON.stringify(attributesUpdate),

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
@@ -1,7 +1,4 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
@@ -10,95 +7,64 @@ const SyncOperations = require(Runtime.getFunctions()[
 ].path);
 const randomstring = require("randomstring");
 
-exports.handler = TokenValidator(async function generateUniqueCode(
-  context,
-  event,
-  callback
-) {
-  console.log("----- generateUniqueCode -----");
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    {
-      key: "taskSid",
-      purpose: "used to update the task attributes and store in Sync document",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  {
+    key: "taskSid",
+    purpose: "used to update the task attributes and store in Sync document",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      /* 
-      - Generate a short unique id for the client-facing url
-      - Create a SYNC document to store the data about this request
-      - The unique code is also the unique name of the document so it's easy to find later on. 
-      */
-      const { taskSid } = event;
-      let unique_code = "";
-      let document = null;
-
-      while (!document) {
-        unique_code = randomstring.generate({
-          length: context.VIDEO_CODE_LENGTH,
-          charset: "alphanumeric",
-        });
-
-        document = await SyncOperations.createDocument({
-          scriptName,
-          attempts: 0,
-          context,
-          uniqueName: unique_code,
-          ttl: context.VIDEO_CODE_TTL,
-          data: {
-            task: taskSid,
-            room: null, // Will be filled-in when the agent connects and opens the Video room
-          },
-        });
-      }
-
-      const attributesUpdate = {
-        syncDocument: document.document.sid,
-      };
-
-      const result = await TaskOperations.updateTaskAttributes({
-        scriptName,
-        context,
-        taskSid,
-        attributesUpdate: JSON.stringify(attributesUpdate),
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    /* 
+    - Generate a short unique id for the client-facing url
+    - Create a SYNC document to store the data about this request
+    - The unique code is also the unique name of the document so it's easy to find later on. 
+    */
+    const { taskSid } = event;
+    let unique_code = "";
+    let document = null;
+    
+    while (!document) {
+      unique_code = randomstring.generate({
+        length: context.VIDEO_CODE_LENGTH,
+        charset: "alphanumeric",
+      });
+    
+      document = await SyncOperations.createDocument({
+        scriptName: context.PATH,
         attempts: 0,
+        context,
+        uniqueName: unique_code,
+        ttl: context.VIDEO_CODE_TTL,
+        data: {
+          task: taskSid,
+          room: null, // Will be filled-in when the agent connects and opens the Video room
+        },
       });
-
-      response.setStatusCode(result.status);
-      response.setBody({
-        unique_code: unique_code,
-        valid_until: document.dateExpires,
-        full_url: `https://${context.DOMAIN_NAME}/features/chat-to-video/index.html?code=${unique_code}`,
-      });
-
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
     }
+    
+    const attributesUpdate = {
+      syncDocument: document.document.sid,
+    };
+    
+    const result = await TaskOperations.updateTaskAttributes({
+      scriptName: context.PATH,
+      context,
+      taskSid,
+      attributesUpdate: JSON.stringify(attributesUpdate),
+      attempts: 0,
+    });
+    
+    response.setStatusCode(result.status);
+    response.setBody({
+      unique_code: unique_code,
+      valid_until: document.dateExpires,
+      full_url: `https://${context.DOMAIN_NAME}/features/chat-to-video/index.html?code=${unique_code}`,
+    });
+    
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-transfer-v2-cbm/flex/chat-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer-v2-cbm/flex/chat-transfer.js
@@ -1,58 +1,49 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const InteractionsOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/interactions"
 ].path);
 
-const getRequiredParameters = (event) => {
-  const requiredParameters = [
-    {
-      key: "taskSid",
-      purpose: "task sid of transferring task",
-    },
-    {
-      key: "conversationId",
-      purpose: "for linking transfer task in insights (CHxxx or WTxxx sid)",
-    },
-    {
-      key: "jsonAttributes",
-      purpose: "string representation of transferring task",
-    },
-    {
-      key: "transferTargetSid",
-      purpose: "worker or queue sid",
-    },
-    {
-      key: "transferQueueName",
-      purpose:
-        "friendly name of taskrouter queue - can be empty string if transferTargetSid is a worker sid",
-    },
-    {
-      key: "ignoreWorkerContactUri",
-      purpose:
-        "contact_uri from workers attributes that transferred the task. we don't want to give them back the transferred task",
-    },
-    {
-      key: "flexInteractionSid",
-      purpose: "KDxxx sid for inteactions API",
-    },
-    {
-      key: "flexInteractionChannelSid",
-      purpose: "UOxxx sid for interactions API",
-    },
-    {
-      key: "flexInteractionParticipantSid",
-      purpose:
-        "UTxxx sid for interactions API for the transferrring agent to remove them from conversation",
-    },
-  ];
-  return requiredParameters;
-};
+const requiredParameters = [
+  {
+    key: "taskSid",
+    purpose: "task sid of transferring task",
+  },
+  {
+    key: "conversationId",
+    purpose: "for linking transfer task in insights (CHxxx or WTxxx sid)",
+  },
+  {
+    key: "jsonAttributes",
+    purpose: "string representation of transferring task",
+  },
+  {
+    key: "transferTargetSid",
+    purpose: "worker or queue sid",
+  },
+  {
+    key: "transferQueueName",
+    purpose:
+      "friendly name of taskrouter queue - can be empty string if transferTargetSid is a worker sid",
+  },
+  {
+    key: "ignoreWorkerContactUri",
+    purpose:
+      "contact_uri from workers attributes that transferred the task. we don't want to give them back the transferred task",
+  },
+  {
+    key: "flexInteractionSid",
+    purpose: "KDxxx sid for inteactions API",
+  },
+  {
+    key: "flexInteractionChannelSid",
+    purpose: "UOxxx sid for interactions API",
+  },
+  {
+    key: "flexInteractionParticipantSid",
+    purpose:
+      "UTxxx sid for interactions API for the transferrring agent to remove them from conversation",
+  },
+];
 
 const getRoutingParams = (
   context,
@@ -87,115 +78,83 @@ const getRoutingParams = (
   return routingParams;
 };
 
-exports.handler = TokenValidator(async function chat_transfer_v2_cbm(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-
-  const requiredParameters = getRequiredParameters(event);
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
-
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (
-    !context.TWILIO_FLEX_WORKSPACE_SID ||
-    !context.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID
-  ) {
-    response.setStatusCode(400);
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    if (
+      !context.TWILIO_FLEX_WORKSPACE_SID ||
+      !context.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID
+    ) {
+      response.setStatusCode(400);
+      response.setBody({
+        data: null,
+        message:
+          "TWILIO_FLEX_WORKSPACE_SID and TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID required enviroment variables",
+      });
+      callback(null, response);
+      return;
+    }
+    
+    const {
+      conversationId,
+      jsonAttributes,
+      transferTargetSid,
+      transferQueueName,
+      ignoreWorkerContactUri,
+      flexInteractionSid,
+      flexInteractionChannelSid,
+      flexInteractionParticipantSid,
+    } = event;
+    
+    const routingParams = getRoutingParams(
+      context,
+      conversationId,
+      jsonAttributes,
+      transferTargetSid,
+      transferQueueName,
+      ignoreWorkerContactUri
+    );
+    
+    const participantCreateInviteParams = {
+      routing: routingParams,
+      interactionSid: flexInteractionSid,
+      channelSid: flexInteractionChannelSid,
+      context,
+      scriptName: context.PATH,
+      attempts: 0,
+    };
+    
+    let {
+      success,
+      status,
+      message = "",
+      participantInvite = null,
+    } = await InteractionsOperations.participantCreateInvite(
+      participantCreateInviteParams
+    );
+    
+    // if this failed bail out so we don't remove the agent from the conversation and no one else joins
+    if (!success) {
+      return sendErrorReply(callback, response, scriptName, status, message);
+    }
+    
+    await InteractionsOperations.participantUpdate({
+      status: "closed",
+      interactionSid: flexInteractionSid,
+      channelSid: flexInteractionChannelSid,
+      participantSid: flexInteractionParticipantSid,
+      scriptName: context.PATH,
+      context,
+      attempts: 0,
+    });
+    
+    response.setStatusCode(201);
     response.setBody({
-      data: null,
-      message:
-        "TWILIO_FLEX_WORKSPACE_SID and TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID required enviroment variables",
+      success: true,
+      message: `Participant invite ${participantInvite.sid}`,
     });
     callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const {
-        conversationId,
-        jsonAttributes,
-        transferTargetSid,
-        transferQueueName,
-        ignoreWorkerContactUri,
-        flexInteractionSid,
-        flexInteractionChannelSid,
-        flexInteractionParticipantSid,
-      } = event;
-
-      const routingParams = getRoutingParams(
-        context,
-        conversationId,
-        jsonAttributes,
-        transferTargetSid,
-        transferQueueName,
-        ignoreWorkerContactUri
-      );
-
-      const participantCreateInviteParams = {
-        routing: routingParams,
-        interactionSid: flexInteractionSid,
-        channelSid: flexInteractionChannelSid,
-        context,
-        scriptName,
-        attempts: 0,
-      };
-
-      let {
-        success,
-        status,
-        message = "",
-        participantInvite = null,
-      } = await InteractionsOperations.participantCreateInvite(
-        participantCreateInviteParams
-      );
-
-      // if this failed bail out so we don't remove the agent from the conversation and no one else joins
-      if (!success) {
-        return sendErrorReply(callback, response, scriptName, status, message);
-      }
-
-      await InteractionsOperations.participantUpdate({
-        status: "closed",
-        interactionSid: flexInteractionSid,
-        channelSid: flexInteractionChannelSid,
-        participantSid: flexInteractionParticipantSid,
-        scriptName,
-        context,
-        attempts: 0,
-      });
-
-      response.setStatusCode(201);
-      response.setBody({
-        success: true,
-        message: `Participant invite ${participantInvite.sid}`,
-      });
-      callback(null, response);
-    } catch (error) {
-      console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error });
-      callback(null, response);
-    }
+  } catch (error) {
+    handleError(error);
   }
 });
 

--- a/serverless-functions/src/functions/features/chat-transfer-v2-cbm/flex/chat-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer-v2-cbm/flex/chat-transfer.js
@@ -119,7 +119,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       interactionSid: flexInteractionSid,
       channelSid: flexInteractionChannelSid,
       context,
-      scriptName: context.PATH,
       attempts: 0,
     };
     
@@ -134,7 +133,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     // if this failed bail out so we don't remove the agent from the conversation and no one else joins
     if (!success) {
-      return sendErrorReply(callback, response, scriptName, status, message);
+      return sendErrorReply(callback, response, context.PATH, status, message);
     }
     
     await InteractionsOperations.participantUpdate({
@@ -142,7 +141,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       interactionSid: flexInteractionSid,
       channelSid: flexInteractionChannelSid,
       participantSid: flexInteractionParticipantSid,
-      scriptName: context.PATH,
       context,
       attempts: 0,
     });

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -9,7 +9,6 @@ const COMPLETED = "completed";
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.channelSid the channel to be updated
@@ -21,10 +20,8 @@ const COMPLETED = "completed";
  *  is called which marks the task as "completed"
  */
 exports.addTaskToChannel = async function (parameters) {
-  const { scriptName, attempts, context, channelSid, taskSid } = parameters;
+  const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))
@@ -68,7 +65,6 @@ exports.addTaskToChannel = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.channelSid the channel to be updated
@@ -79,10 +75,8 @@ exports.addTaskToChannel = async function (parameters) {
  *  channel data and marked as being "complete".
  */
 exports.setTaskToCompleteOnChannel = async function (parameters) {
-  const { scriptName, attempts, context, channelSid, taskSid } = parameters;
+  const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))
@@ -126,7 +120,6 @@ exports.setTaskToCompleteOnChannel = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {object} parameters.taskSid the taskSid to add to the channel attributes
@@ -139,10 +132,8 @@ exports.setTaskToCompleteOnChannel = async function (parameters) {
 exports.removeChannelSidFromTask = async function removeChannelSidFromTask(
   parameters
 ) {
-  const { scriptName, attempts, context, taskSid } = parameters;
+  const { attempts, context, taskSid } = parameters;
 
-  if (!isString(scriptName))
-    throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if (!isNumber(attempts))
     throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if (!isObject(context))

--- a/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
@@ -1,7 +1,4 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
@@ -9,82 +6,52 @@ const ChatOperations = require(Runtime.getFunctions()[
   "features/chat-transfer/common/chat-operations"
 ].path);
 
+const requiredParameters = [
+  { key: "taskSid", purpose: "task sid to remove the chat channel from" },
+  { key: "transferType", purpose: "COLD or WARM transfer" },
+  { key: "channelSid", purpose: "Channel id associated with task" },
+];
+
 /*
  * Remove the original transferred task's reference to the chat channelSid
  * this prevents Twilio's Janitor service from cleaning up the channel when
  * the original task gets completed.
  */
 
-exports.handler = TokenValidator(async function completeTaskForTransfer(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "taskSid", purpose: "task sid to remove the chat channel from" },
-    { key: "transferType", purpose: "COLD or WARM transfer" },
-    { key: "channelSid", purpose: "Channel id associated with task" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
-
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { taskSid, transferType, channelSid } = event;
+    
+    // remove channel sid from task to prevent janitor from closing chat channel
+    const { success: removeSidSuccess, message } =
+      await ChatOperations.removeChannelSidFromTask({
+        scriptName: context.PATH,
+        context,
+        taskSid,
+        attempts: 0,
+      });
+    if (!removeSidSuccess) return { success: removeSidSuccess, message };
+    
+    // update task data in channel to show this task is no longer in flight
     try {
-      const { taskSid, transferType, channelSid } = event;
-
-      // remove channel sid from task to prevent janitor from closing chat channel
-      const { success: removeSidSuccess, message } =
-        await ChatOperations.removeChannelSidFromTask({
-          scriptName,
-          context,
-          taskSid,
-          attempts: 0,
-        });
-      if (!removeSidSuccess) return { success: removeSidSuccess, message };
-
-      // update task data in channel to show this task is no longer in flight
-      try {
-        await ChatOperations.setTaskToCompleteOnChannel({
-          scriptName,
-          context,
-          taskSid,
-          channelSid,
-          attempts: 0,
-        });
-      } catch (error) {
-        console.error("Error updating chat channel with task sid as completed");
-      }
-
-      // move the task to completed
-      const reason = `Task ${transferType} Transfered to new task`;
-      const { success: completeTaskSuccess, message: completeTaskMessage } =
-        await TaskOperations.completeTask({context, taskSid, reason, scriptName, attempts: 0});
-      response.setBody({ success: completeTaskSuccess, message });
-      callback(null, response);
+      await ChatOperations.setTaskToCompleteOnChannel({
+        scriptName: context.PATH,
+        context,
+        taskSid,
+        channelSid,
+        attempts: 0,
+      });
     } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error.message });
-      callback(null, response);
+      console.error("Error updating chat channel with task sid as completed");
     }
+    
+    // move the task to completed
+    const reason = `Task ${transferType} Transfered to new task`;
+    const { success: completeTaskSuccess, message: completeTaskMessage } =
+      await TaskOperations.completeTask({context, taskSid, reason, scriptName, attempts: 0});
+    response.setBody({ success: completeTaskSuccess, message });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
@@ -25,7 +25,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     // remove channel sid from task to prevent janitor from closing chat channel
     const { success: removeSidSuccess, message } =
       await ChatOperations.removeChannelSidFromTask({
-        scriptName: context.PATH,
         context,
         taskSid,
         attempts: 0,
@@ -35,7 +34,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     // update task data in channel to show this task is no longer in flight
     try {
       await ChatOperations.setTaskToCompleteOnChannel({
-        scriptName: context.PATH,
         context,
         taskSid,
         channelSid,
@@ -48,7 +46,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     // move the task to completed
     const reason = `Task ${transferType} Transfered to new task`;
     const { success: completeTaskSuccess, message: completeTaskMessage } =
-      await TaskOperations.completeTask({context, taskSid, reason, scriptName, attempts: 0});
+      await TaskOperations.completeTask({context, taskSid, reason, attempts: 0});
     response.setBody({ success: completeTaskSuccess, message });
     callback(null, response);
   } catch (error) {

--- a/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
@@ -72,7 +72,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       task: newTask,
       status: createTaskStatus,
     } = await TaskOperations.createTask({
-      scriptName: context.PATH,
       context,
       workflowSid,
       taskChannel: "chat",
@@ -88,7 +87,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     try {
       if (createTaskSuccess)
         await ChatOperations.addTaskToChannel({
-          scriptName: context.PATH,
           context,
           taskSid: newTask.sid,
           channelSid: newTask.attributes.channelSid,

--- a/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
@@ -1,7 +1,4 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
@@ -9,135 +6,105 @@ const ChatOperations = require(Runtime.getFunctions()[
   "features/chat-transfer/common/chat-operations"
 ].path);
 
-exports.handler = TokenValidator(async function createTransferTask(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    {
-      key: "conversationId",
-      purpose: "conversation_id to link tasks for reporting",
-    },
-    {
-      key: "jsonAttributes",
-      purpose: "JSON calling tasks attributes to perpetuate onto new task",
-    },
-    {
-      key: "transferTargetSid",
-      purpose: "sid of target worker or target queue",
-    },
-    {
-      key: "transferQueueName",
-      purpose:
-        "name of the queue if transfering to a queue, otherwise empty string",
-    },
-    {
-      key: "ignoreWorkerContactUri",
-      purpose: "woker Contact Uri to ignore when transfering",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  {
+    key: "conversationId",
+    purpose: "conversation_id to link tasks for reporting",
+  },
+  {
+    key: "jsonAttributes",
+    purpose: "JSON calling tasks attributes to perpetuate onto new task",
+  },
+  {
+    key: "transferTargetSid",
+    purpose: "sid of target worker or target queue",
+  },
+  {
+    key: "transferQueueName",
+    purpose:
+      "name of the queue if transfering to a queue, otherwise empty string",
+  },
+  {
+    key: "ignoreWorkerContactUri",
+    purpose: "woker Contact Uri to ignore when transfering",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const {
+      conversationId,
+      jsonAttributes,
+      transferTargetSid,
+      transferQueueName,
+      ignoreWorkerContactUri,
+      workflowSid: overriddenWorkflowSid,
+      timeout: overriddenTimeout,
+      priority: overriddenPriority,
+    } = event;
+    
+    // use assigned values or use defaults
+    const workflowSid =
+      overriddenWorkflowSid ||
+      process.env.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID;
+    const timeout = overriddenTimeout || 86400;
+    const priority = overriddenPriority || 0;
+    
+    // setup the new task attributes based on the old
+    const originalTaskAttributes = JSON.parse(jsonAttributes);
+    const newAttributes = {
+      ...originalTaskAttributes,
+      ignoreWorkerContactUri,
+      transferTargetSid,
+      transferQueueName,
+      transferTargetType: transferTargetSid.startsWith("WK")
+        ? "worker"
+        : "queue",
+      conversations: {
+        ...originalTaskAttributes.conversations,
+        conversation_id: conversationId,
+      },
+    };
+    
+    // create task for transfer
+    const {
+      success: createTaskSuccess,
+      task: newTask,
+      status: createTaskStatus,
+    } = await TaskOperations.createTask({
+      scriptName: context.PATH,
+      context,
+      workflowSid,
+      taskChannel: "chat",
+      attributes: newAttributes,
+      priority,
+      timeout,
+      attempts: 0,
+    });
+    
+    // push task data into chat meta data so that should we end the chat while in queue
+    // the customer front end can trigger cancelling tasks associated to the chat channel
+    // this is not critical to transfer but is ideal
     try {
-      const {
-        conversationId,
-        jsonAttributes,
-        transferTargetSid,
-        transferQueueName,
-        ignoreWorkerContactUri,
-        workflowSid: overriddenWorkflowSid,
-        timeout: overriddenTimeout,
-        priority: overriddenPriority,
-      } = event;
-
-      // use assigned values or use defaults
-      const workflowSid =
-        overriddenWorkflowSid ||
-        process.env.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID;
-      const timeout = overriddenTimeout || 86400;
-      const priority = overriddenPriority || 0;
-
-      // setup the new task attributes based on the old
-      const originalTaskAttributes = JSON.parse(jsonAttributes);
-      const newAttributes = {
-        ...originalTaskAttributes,
-        ignoreWorkerContactUri,
-        transferTargetSid,
-        transferQueueName,
-        transferTargetType: transferTargetSid.startsWith("WK")
-          ? "worker"
-          : "queue",
-        conversations: {
-          ...originalTaskAttributes.conversations,
-          conversation_id: conversationId,
-        },
-      };
-
-      // create task for transfer
-      const {
-        success: createTaskSuccess,
-        task: newTask,
-        status: createTaskStatus,
-      } = await TaskOperations.createTask({
-        scriptName,
-        context,
-        workflowSid,
-        taskChannel: "chat",
-        attributes: newAttributes,
-        priority,
-        timeout,
-        attempts: 0,
-      });
-
-      // push task data into chat meta data so that should we end the chat while in queue
-      // the customer front end can trigger cancelling tasks associated to the chat channel
-      // this is not critical to transfer but is ideal
-      try {
-        if (createTaskSuccess)
-          await ChatOperations.addTaskToChannel({
-            scriptName,
-            context,
-            taskSid: newTask.sid,
-            channelSid: newTask.attributes.channelSid,
-            attempts: 0,
-          });
-      } catch (error) {
-        console.error(
-          "Error updating chat channel with task sid created for it"
-        );
-      }
-
-      response.setStatusCode(createTaskStatus);
-      response.setBody({ success: createTaskSuccess, taskSid: newTask.sid });
-
-      callback(null, response);
+      if (createTaskSuccess)
+        await ChatOperations.addTaskToChannel({
+          scriptName: context.PATH,
+          context,
+          taskSid: newTask.sid,
+          channelSid: newTask.attributes.channelSid,
+          attempts: 0,
+        });
     } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error.message });
-      callback(null, response);
+      console.error(
+        "Error updating chat channel with task sid created for it"
+      );
     }
+    
+    response.setStatusCode(createTaskStatus);
+    response.setBody({ success: createTaskSuccess, taskSid: newTask.sid });
+    
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
+++ b/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
@@ -12,7 +12,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
   try {
     const { taskSid, channelSid } = event;
     const { success } = await ChatOperations.addTaskToChannel({
-      scriptName: context.PATH,
       context,
       taskSid,
       channelSid,

--- a/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
+++ b/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
@@ -1,59 +1,26 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ChatOperations = require(Runtime.getFunctions()[
   "features/chat-transfer/common/chat-operations"
 ].path);
 
-exports.handler = async function addTaskToChatChannelData(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "taskSid", purpose: "taskSid to add to channel attributes" },
-    { key: "channelSid", purpose: "channelSid to add task information to" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "taskSid", purpose: "taskSid to add to channel attributes" },
+  { key: "channelSid", purpose: "channelSid to add task information to" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { taskSid, channelSid } = event;
+    const { success } = await ChatOperations.addTaskToChannel({
+      scriptName: context.PATH,
+      context,
+      taskSid,
+      channelSid,
+      attempts: 0,
+    });
+    response.setBody({ success });
     callback(null, response);
-  } else {
-    try {
-      const { taskSid, channelSid } = event;
-      const { success } = await ChatOperations.addTaskToChannel({
-        scriptName,
-        context,
-        taskSid,
-        channelSid,
-        attempts: 0,
-      });
-      response.setBody({ success });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+  } catch (error) {
+    handleError(error);
   }
-};
+});

--- a/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
+++ b/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
@@ -1,61 +1,32 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function createRecording(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "callSid", purpose: "unique ID of call to record" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "callSid", purpose: "unique ID of call to record" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid } = event;
-
+    
     const result = await VoiceOperations.createRecording({
       context,
-      scriptName,
+      scriptName: context.PATH,
       callSid,
       params: {
         recordingChannels: 'dual'
       },
       attempts: 0,
     });
-
+    
     const { success, recording, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
+++ b/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
@@ -13,7 +13,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.createRecording({
       context,
-      scriptName: context.PATH,
       callSid,
       params: {
         recordingChannels: 'dual'

--- a/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
@@ -3,7 +3,6 @@ const TaskOperations = require(Runtime.getFunctions()["common/twilio-wrappers/ta
 exports.handler = async function callOutboundJoin(context, event, callback) {
   const client = context.getTwilioClient();
   const { FriendlyName: taskSid, ConferenceSid } = event;
-  const scriptName = arguments.callee.name;
 
   if (event.StatusCallbackEvent === "participant-join") {
     console.log(
@@ -17,7 +16,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
 
       const fetchTaskResult = await TaskOperations.fetchTask({
         context,
-        scriptName,
         taskSid,
         attempts: 0,
       });
@@ -39,7 +37,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
         if (to.substring(0, 6) === "client") {
           const createTaskResult = await TaskOperations.createTask({
             context,
-            scriptName,
             attributes: {
               to: to,
               name: fromName,
@@ -64,7 +61,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
         
         await TaskOperations.updateTaskAttributes({
           context,
-          scriptName,
           taskSid,
           attributesUpdate: JSON.stringify(newAttributes),
           attempts: 0,
@@ -77,7 +73,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
     try {
       const fetchTaskResult = await TaskOperations.fetchTask({
         context,
-        scriptName,
         taskSid,
         attempts: 0,
       });
@@ -87,7 +82,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
       if (["assigned", "pending", "reserved"].includes(task.assignmentStatus)) {
         await TaskOperations.updateTask({
           context,
-          scriptName,
           taskSid,
           updateParams: {
             assignmentStatus:
@@ -103,7 +97,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
       if (targetTaskSid) {
         const fetchTargetTaskResult = await TaskOperations.fetchTask({
           context,
-          scriptName,
           taskSid: targetTaskSid,
           attempts: 0,
         });
@@ -113,7 +106,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
         if (["assigned", "pending", "reserved"].includes(targetTask.assignmentStatus)) {
           await TaskOperations.updateTask({
             context,
-            scriptName,
             taskSid: targetTaskSid,
             updateParams: {
               assignmentStatus:

--- a/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
+++ b/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
@@ -1,58 +1,43 @@
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
-exports.handler = TokenValidator(async function cleanupRejectedTask(context, event, callback) {
-    
-    const scriptName = arguments.callee.name;
-    const response = new Twilio.Response();
-    const requiredParameters = [
-        { key: 'taskSid', purpose: 'unique ID of task to clean up' },
-    ];
-    const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
-    
-    response.appendHeader('Access-Control-Allow-Origin', '*');
-    response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-    response.appendHeader('Content-Type', 'application/json');
-    response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-    
-    if (parameterError) {
-        console.error(`${scriptName} invalid parameters passed`);
-        response.setStatusCode(400);
-        response.setBody({ data: null, message: parameterError });
-        callback(null, response);
-        return;
-    }
-	
+const requiredParameters = [
+  { key: 'taskSid', purpose: 'unique ID of task to clean up' },
+];
+
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
     const { taskSid } = event;
     
     const conferencesResponse = await ConferenceOperations.fetchByTask(
-      {
-        context,
-        scriptName,
-        taskSid,
-        status: 'in-progress',
-        limit: 20,
-        attempts: 0
-      });
-
+    {
+      context,
+      scriptName: context.PATH,
+      taskSid,
+      status: 'in-progress',
+      limit: 20,
+      attempts: 0
+    });
+    
     if (!conferencesResponse.success) {
-        callback(null, assets.response("json", {}));
-        return;
+      callback(null, assets.response("json", {}));
+      return;
     }
       
     await Promise.all(conferencesResponse.conferences.map(conference => {
-        return ConferenceOperations.updateConference(
-          {
-            context,
-            scriptName,
-            conference: conference.sid,
-            updateParams: {status: 'completed'},
-            attempts: 0
-          });
+      return ConferenceOperations.updateConference(
+        {
+          context,
+          scriptName: context.PATH,
+          conference: conference.sid,
+          updateParams: {status: 'completed'},
+          attempts: 0
+        });
     }))
     
     response.setBody({});
     callback(null, response);
-
+  } catch (error) {
+    handleError(error);
+  }
 });

--- a/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
+++ b/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
@@ -12,7 +12,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const conferencesResponse = await ConferenceOperations.fetchByTask(
     {
       context,
-      scriptName: context.PATH,
       taskSid,
       status: 'in-progress',
       limit: 20,
@@ -28,7 +27,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       return ConferenceOperations.updateConference(
         {
           context,
-          scriptName: context.PATH,
           conference: conference.sid,
           updateParams: {status: 'completed'},
           attempts: 0

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
@@ -1,42 +1,19 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function pauseCallRecording(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "callSid", purpose: "unique ID of call to pause recording" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "callSid", purpose: "unique ID of call to pause recording" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, pauseBehavior, recordingSid } = event;
-
+    
     const result = await VoiceOperations.updateCallRecording({
       context,
-      scriptName,
+      scriptName: context.PATH,
       callSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {
@@ -45,19 +22,13 @@ exports.handler = TokenValidator(async function pauseCallRecording(context, even
       },
       attempts: 0,
     });
-
+    
     const { success, recording, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
@@ -13,7 +13,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.updateCallRecording({
       context,
-      scriptName: context.PATH,
       callSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
@@ -1,42 +1,19 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function pauseConferenceRecording(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conferenceSid", purpose: "unique ID of conference to pause recording" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conferenceSid", purpose: "unique ID of conference to pause recording" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conferenceSid, pauseBehavior, recordingSid } = event;
-
+    
     const result = await VoiceOperations.updateConferenceRecording({
       context,
-      scriptName,
+      scriptName: context.PATH,
       conferenceSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {
@@ -45,19 +22,13 @@ exports.handler = TokenValidator(async function pauseConferenceRecording(context
       },
       attempts: 0,
     });
-
+    
     const { success, recording, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
@@ -13,7 +13,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.updateConferenceRecording({
       context,
-      scriptName: context.PATH,
       conferenceSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
@@ -14,7 +14,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.updateCallRecording({
       context,
-      scriptName: context.PATH,
       callSid,
       recordingSid,
       params: {

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
@@ -1,43 +1,20 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function resumeCallRecording(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "callSid", purpose: "unique ID of call to resume recording" },
-    { key: "recordingSid", purpose: "unique ID of recording to resume" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "callSid", purpose: "unique ID of call to resume recording" },
+  { key: "recordingSid", purpose: "unique ID of recording to resume" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, recordingSid } = event;
-
+    
     const result = await VoiceOperations.updateCallRecording({
       context,
-      scriptName,
+      scriptName: context.PATH,
       callSid,
       recordingSid,
       params: {
@@ -45,19 +22,13 @@ exports.handler = TokenValidator(async function resumeCallRecording(context, eve
       },
       attempts: 0,
     });
-
+    
     const { success, recording, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
@@ -14,7 +14,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     
     const result = await VoiceOperations.updateConferenceRecording({
       context,
-      scriptName: context.PATH,
       conferenceSid,
       recordingSid,
       params: {

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
@@ -1,43 +1,20 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const VoiceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/programmable-voice"
 ].path);
 
-exports.handler = TokenValidator(async function resumeConferenceRecording(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conferenceSid", purpose: "unique ID of conference to resume recording" },
-    { key: "recordingSid", purpose: "unique ID of recording to resume" },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conferenceSid", purpose: "unique ID of conference to resume recording" },
+  { key: "recordingSid", purpose: "unique ID of recording to resume" },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (parameterError) {
-    console.error(`${scriptName} invalid parameters passed`);
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conferenceSid, recordingSid } = event;
-
+    
     const result = await VoiceOperations.updateConferenceRecording({
       context,
-      scriptName,
+      scriptName: context.PATH,
       conferenceSid,
       recordingSid,
       params: {
@@ -45,19 +22,13 @@ exports.handler = TokenValidator(async function resumeConferenceRecording(contex
       },
       attempts: 0,
     });
-
+    
     const { success, recording, status } = result;
-
+    
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({
-      success: false,
-      message: error,
-    });
-    callback(null, response);
+    handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -36,7 +36,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         agentSid,
         muted,
         coaching,
-        scriptName: context.PATH,
         attempts: 0,
       });
       response.setStatusCode(result.status);
@@ -52,7 +51,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         conferenceSid,
         participantSid,
         muted,
-        scriptName: context.PATH,
         attempts: 0,
       });
       response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -1,100 +1,68 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ConferenceOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/conference-participant"
 ].path);
 
-exports.handler = TokenValidator(async function participantMuteCoach(
-  context,
-  event,
-  callback
-) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  const requiredParameters = [
-    { key: "conferenceSid", purpose: "conference sid to target for changes" },
-    {
-      key: "participantSid",
-      purpose: "participant sid to target for conference changes",
-    },
-    { key: "agentSid", purpose: "sid of target worker" },
-    {
-      key: "muted",
-      purpose:
-        "boolean to determine the muted status of the participant in the conference",
-    },
-    {
-      key: "coaching",
-      purpose:
-        "boolean to determine the coaching status of the participant in the conference",
-    },
-  ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+const requiredParameters = [
+  { key: "conferenceSid", purpose: "conference sid to target for changes" },
+  {
+    key: "participantSid",
+    purpose: "participant sid to target for conference changes",
+  },
+  { key: "agentSid", purpose: "sid of target worker" },
+  {
+    key: "muted",
+    purpose:
+      "boolean to determine the muted status of the participant in the conference",
+  },
+  {
+    key: "coaching",
+    purpose:
+      "boolean to determine the coaching status of the participant in the conference",
+  },
+];
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const { conferenceSid, participantSid, agentSid, muted, coaching } =
-        event;
-
-      // If agentSid isn't null/blank, we know we are updating the conference coaching status
-      if (agentSid != "") {
-        const result = await ConferenceOperations.coachToggle({
-          context,
-          conferenceSid,
-          participantSid,
-          agentSid,
-          muted,
-          coaching,
-          scriptName,
-          attempts: 0,
-        });
-        response.setStatusCode(result.status);
-        response.setBody({
-          success: result.success,
-          conference: result.conferenceSid,
-        });
-      }
-      // If the agentSid is null/blank, we know we are updating the conference muted status
-      if (agentSid === "") {
-        const result = await ConferenceOperations.bargeToggle({
-          context,
-          conferenceSid,
-          participantSid,
-          muted,
-          scriptName,
-          attempts: 0,
-        });
-        response.setStatusCode(result.status);
-        response.setBody({
-          success: result.success,
-          conference: result.conferenceSid,
-        });
-      }
-      callback(null, response);
-    } catch (error) {
-      response.setStatusCode(500);
-      response.setBody({ success: false, message: error.message });
-      callback(null, response);
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const { conferenceSid, participantSid, agentSid, muted, coaching } =
+      event;
+    
+    // If agentSid isn't null/blank, we know we are updating the conference coaching status
+    if (agentSid != "") {
+      const result = await ConferenceOperations.coachToggle({
+        context,
+        conferenceSid,
+        participantSid,
+        agentSid,
+        muted,
+        coaching,
+        scriptName: context.PATH,
+        attempts: 0,
+      });
+      response.setStatusCode(result.status);
+      response.setBody({
+        success: result.success,
+        conference: result.conferenceSid,
+      });
     }
+    // If the agentSid is null/blank, we know we are updating the conference muted status
+    if (agentSid === "") {
+      const result = await ConferenceOperations.bargeToggle({
+        context,
+        conferenceSid,
+        participantSid,
+        muted,
+        scriptName: context.PATH,
+        attempts: 0,
+      });
+      response.setStatusCode(result.status);
+      response.setBody({
+        success: result.success,
+        conference: result.conferenceSid,
+      });
+    }
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/admin/publish.js
+++ b/serverless-schedule-manager/functions/admin/publish.js
@@ -1,26 +1,11 @@
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
-exports.handler = TokenValidator(async function publish(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  response.appendHeader('Access-Control-Allow-Origin', '*');
-  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-  response.appendHeader('Content-Type', 'application/json');
-  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-  
-  const requiredParameters = [
-    { key: 'buildSid', purpose: 'build SID to deploy' }
-  ];
-  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
-  
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ parameterError });
-    callback(null, response);
-    return;
-  }
+const requiredParameters = [
+  { key: 'buildSid', purpose: 'build SID to deploy' }
+];
+
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   
   const { buildSid, TokenResult } = event;
   
@@ -33,16 +18,12 @@ exports.handler = TokenValidator(async function publish(context, event, callback
   
   try {
     // create deployment for this build
-    const result = await ServerlessOperations.deployBuild({ scriptName, context, buildSid, attempts: 0 });
+    const result = await ServerlessOperations.deployBuild({ context, buildSid, attempts: 0 });
     
     response.setStatusCode(result.status);
-    response.setBody(result)
+    response.setBody(result);
+    callback(null, response);
   } catch (error) {
-    console.log(error);
-    
-    response.setStatusCode(500);
-    response.setBody({ message: error.message });
+    handleError(error);
   }
-  
-  callback(null, response);
 });

--- a/serverless-schedule-manager/functions/admin/update-status.js
+++ b/serverless-schedule-manager/functions/admin/update-status.js
@@ -1,26 +1,11 @@
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
-exports.handler = TokenValidator(async function updateStatus(context, event, callback) {
-  const scriptName = arguments.callee.name;
-  const response = new Twilio.Response();
-  response.appendHeader('Access-Control-Allow-Origin', '*');
-  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-  response.appendHeader('Content-Type', 'application/json');
-  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-  
-  const requiredParameters = [
-    { key: 'buildSid', purpose: 'build sid to check status of' }
-  ];
-  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
-  
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ parameterError });
-    callback(null, response);
-    return;
-  }
+const requiredParameters = [
+  { key: 'buildSid', purpose: 'build sid to check status of' }
+];
+
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   
   const { buildSid, TokenResult } = event;
   
@@ -33,13 +18,12 @@ exports.handler = TokenValidator(async function updateStatus(context, event, cal
   
   try {
     // get status of the given build sid
-    const buildStatusResult = await ServerlessOperations.fetchBuildStatus({ scriptName, context, attempts: 0, buildSid });
+    const buildStatusResult = await ServerlessOperations.fetchBuildStatus({ context, attempts: 0, buildSid });
     
     response.setStatusCode(buildStatusResult.status);
     response.setBody(buildStatusResult);
     callback(null, response);
   } catch (error) {
-    console.log('Error executing function', error);
-    callback(error);
+    handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/check-schedule.js
+++ b/serverless-schedule-manager/functions/check-schedule.js
@@ -1,29 +1,13 @@
-const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
 const ScheduleUtils = require(Runtime.getFunctions()['common/helpers/schedule-utils'].path);
 
-exports.handler = async function checkSchedule(context, event, callback) {
-  const response = new Twilio.Response();
-  response.appendHeader('Access-Control-Allow-Origin', '*');
-  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST GET');
-  response.appendHeader('Content-Type', 'application/json');
-  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-  
-  const requiredParameters = [
-    { key: 'name', purpose: 'name of the schedule to check' }
-  ];
-  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
-  
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ parameterError });
-    callback(null, response);
-    return;
-  }
-  
-  const { name, simulate } = event;
-  
+const requiredParameters = [
+  { key: 'name', purpose: 'name of the schedule to check' }
+];
+
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-    
+    const { name, simulate } = event;
     const returnData = ScheduleUtils.evaluateSchedule(name, simulate);
     
     if (returnData.error) {
@@ -41,9 +25,6 @@ exports.handler = async function checkSchedule(context, event, callback) {
     response.setBody(returnData);
     callback(null, response);
   } catch (error) {
-    console.log('Error executing function', error);
-    response.setStatusCode(500);
-    response.setBody({ error });
-    callback(null, response);
+    handleError(error);
   }
-};
+});

--- a/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
@@ -1,0 +1,61 @@
+const TokenValidator = require("twilio-flex-token-validator").functionValidator;
+const ParameterValidator = require(Runtime.getFunctions()[
+  "common/helpers/parameter-validator"
+].path);
+
+const prepareFunction = (context, event, callback, requiredParameters, handlerFn) => {
+  const response = new Twilio.Response();
+  const parameterError = ParameterValidator.validate(
+    context.PATH,
+    event,
+    requiredParameters
+  );
+  
+  response.appendHeader("Access-Control-Allow-Origin", "*");
+  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST GET");
+  response.appendHeader("Content-Type", "application/json");
+  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+  
+  if (parameterError) {
+    console.error(`(${context.PATH}) invalid parameters passed`);
+    response.setStatusCode(400);
+    response.setBody({ data: null, message: parameterError });
+    callback(null, response);
+    return;
+  }
+  
+  const handleError = (error) => {
+    console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
+    response.setStatusCode(500);
+    response.setBody({
+      success: false,
+      message: error,
+    });
+    callback(null, response);
+  }
+  
+  return handlerFn(context, event, callback, response, handleError);
+};
+
+/**
+ * Prepares the function for execution. Validates the token and other required parameters, then prepares
+ * the response object with the appropriate headers, as well as an error handling function.
+ *
+ * @param requiredParameters    array of parameters required and their description
+ * @param handlerFn             the Twilio Runtime handler function to execute
+ */
+exports.prepareFlexFunction = (requiredParameters, handlerFn) => {
+  return TokenValidator((context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn));
+};
+
+/**
+ * Prepares the function for execution. Validates required parameters, then prepares
+ * the response object with the appropriate headers, as well as an error handling function.
+ * Note: This is only intended for protected functions, and does not validate a token.
+ *
+ * @param requiredParameters    array of parameters required and their description
+ * @param handlerFn             the Twilio Runtime handler function to execute
+ */
+exports.prepareStudioFunction = (requiredParameters, handlerFn) => {
+  return (context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn);
+};

--- a/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
+++ b/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
@@ -5,7 +5,6 @@ const retryHandler = (require(Runtime.getFunctions()['common/twilio-wrappers/ret
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.buildSid the build to be deployed
@@ -14,10 +13,8 @@ const retryHandler = (require(Runtime.getFunctions()['common/twilio-wrappers/ret
  */
 exports.deployBuild = async function (parameters) {
 
-  const { scriptName, attempts, context, buildSid } = parameters;
+  const { attempts, context, buildSid } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))
@@ -46,7 +43,6 @@ exports.deployBuild = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.buildSid the build SID to check status for 
@@ -55,10 +51,8 @@ exports.deployBuild = async function (parameters) {
  */
 exports.fetchBuildStatus = async function (parameters) {
 
-  const { scriptName, attempts, context, buildSid } = parameters;
+  const { attempts, context, buildSid } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))
@@ -91,7 +85,6 @@ exports.fetchBuildStatus = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @returns {object} An object containing the deployment sid
@@ -99,10 +92,8 @@ exports.fetchBuildStatus = async function (parameters) {
  */
 exports.fetchLatestBuild = async function (parameters) {
 
-  const { scriptName, attempts, context } = parameters;
+  const { attempts, context } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))
@@ -133,7 +124,6 @@ exports.fetchLatestBuild = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @returns {object} The latest deployment
@@ -141,10 +131,8 @@ exports.fetchLatestBuild = async function (parameters) {
  */
 exports.fetchLatestDeployment = async function (parameters) {
 
-  const { scriptName, attempts, context } = parameters;
+  const { attempts, context } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))
@@ -176,7 +164,6 @@ exports.fetchLatestDeployment = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {array} parameters.assetVersions the asset versions to include in this build
@@ -187,10 +174,8 @@ exports.fetchLatestDeployment = async function (parameters) {
  */
 exports.createBuild = async function (parameters) {
 
-  const { scriptName, attempts, context, assetVersions, dependencies, functionVersions } = parameters;
+  const { attempts, context, assetVersions, dependencies, functionVersions } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))
@@ -223,7 +208,6 @@ exports.createBuild = async function (parameters) {
 
 /**
  * @param {object} parameters the parameters for the function
- * @param {string} parameters.scriptName the name of the top level lambda function 
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
  * @param {string} parameters.assetSid the asset versions to include in this build
@@ -234,10 +218,8 @@ exports.createBuild = async function (parameters) {
  */
 exports.uploadAsset = async function (parameters) {
 
-  const { scriptName, attempts, context, assetSid, assetPath, assetData } = parameters;
+  const { attempts, context, assetSid, assetPath, assetData } = parameters;
 
-  if(!isString(scriptName))
-      throw "Invalid parameters object passed. Parameters must contain scriptName of calling function";
   if(!isNumber(attempts))
       throw "Invalid parameters object passed. Parameters must contain the number of attempts";
   if(!isObject(context))


### PR DESCRIPTION
### Summary

Previously each serverless function was mostly boilerplate, making them more difficult to work with and read. This also increased the friction for a developer adding new functions to the project.

Added two wrapper functions that take all of the boilerplate and move it to a single spot:

- `prepareStudioFunction` - validates that required parameters are provided, sets up the response object with the appropriate headers, and provides an error handling function
- `prepareFlexFunction` - the same as above, plus the Flex `TokenValidator`

These wrapper functions are used in the exact same way we typically used `TokenValidator`, wrapping the entire handler function. Now, functions behave exactly the same but are significantly easier to read and write. Here is an example, `get-call-properties`:

```
const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
const VoiceOperations = require(Runtime.getFunctions()[
  "common/twilio-wrappers/programmable-voice"
].path);

const requiredParameters = [
  { key: "callSid", purpose: "unique ID of call to fetch" },
];

exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
  try {
    const { callSid } = event;
    
    const result = await VoiceOperations.fetchProperties({
      context,
      callSid,
      attempts: 0,
    });
    
    const { success, callProperties, status } = result;
    
    response.setStatusCode(status);
    response.setBody({ success, callProperties });
    callback(null, response);
  } catch (error) {
    handleError(error);
  }
});
```

As part of the change, I decided to axe the `scriptName` parameter we were passing around in favor of `context.PATH`. This provides a few benefits:
- `context.PATH` provides the function name and its path in the project structure
- Fewer parameters to pass around to every Twilio wrapper function; we were already passing `context` around
- Developers don't need to remember to name their handler function, which was easy to overlook

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
