### PR TITLE
Fix video breakage from beta 3 type changes

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.24",
+  "version": "9.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plugin-flex-ts-template-v2",
-      "version": "9.0.24",
+      "version": "9.0.25",
       "dependencies": {
         "@twilio-paste/core": "^15.3.0",
         "@twilio-paste/icons": "^9.2.0",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.24",
+  "version": "9.0.25",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
@@ -9,7 +9,7 @@ import { UIAttributes } from "types/manager/ServiceConfiguration";
 interface SwitchToVideoProps {
   task: ITask;
   context?: any;
-  conversation?: ConversationState;
+  conversation?: ConversationState.ConversationState;
 }
 
 const { custom_data } = Manager.getInstance().configuration as UIAttributes;


### PR DESCRIPTION
### Summary

I changed this file in #82 because it was broken by beta 2, but the types changed again with beta 3 which re-broke it.

### Checklist
- [x] Tested changes end to end
- [x] Updated build number in package.json when modifying a flex plugin
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
