### PR TITLE
Fix dual channel recording not starting after transfer

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.27",
+  "version": "9.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plugin-flex-ts-template-v2",
-      "version": "9.0.27",
+      "version": "9.0.28",
       "dependencies": {
         "@twilio-paste/core": "^15.3.0",
         "@twilio-paste/icons": "^9.2.0",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.27",
+  "version": "9.0.28",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
@@ -123,7 +123,7 @@ export const waitForConferenceParticipants = (task: ITask): Promise<ConferencePa
         return;
       }
       const worker = participants.find(
-        (p) => p.participantType === 'worker'
+        (p) => p.participantType === 'worker' && p.isCurrentWorker
       );
       const customer = participants.find(
         (p) => p.participantType === 'customer'


### PR DESCRIPTION
### Summary

There was a mismatch of condition when waiting for participants to join vs getting which participant to record, so recordings weren't starting after a transfer when the recording channel is `worker`.

Since there are a few things waiting merge right now, I will update the build number after approval but before merging.

### Checklist
- [x] Tested changes end to end
- [ ] Updated build number in package.json when modifying a flex plugin
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
