### PR TITLE
Don’t load teams view filters for non-supervisors

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.28",
+  "version": "9.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "plugin-flex-ts-template-v2",
-      "version": "9.0.28",
+      "version": "9.0.29",
       "dependencies": {
         "@twilio-paste/core": "^15.3.0",
         "@twilio-paste/icons": "^9.2.0",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.28",
+  "version": "9.0.29",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/flex-hooks/teams-filters/index.ts
+++ b/plugin-flex-ts-template-v2/src/flex-hooks/teams-filters/index.ts
@@ -3,6 +3,11 @@ import CustomFilters from "./filters";
 
 export default async (flex: typeof Flex, manager: Flex.Manager) => {
   
+  const { roles } = manager.user;
+  const loadFilters = roles.indexOf("supervisor") >= 0 || roles.indexOf("admin") >= 0;
+  
+  if (!loadFilters) return;
+  
   const customFilters = await CustomFilters();
   Flex.TeamsView.defaultProps.filters = [
     Flex.TeamsView.activitiesFilter,


### PR DESCRIPTION
### Summary

Because filters have to provide their options up front, this means that filters which execute API requests do this unconditionally when Flex loads. This means that even agents without access to the teams view will execute the API request(s). This change fixes that issue, so an agent loading Flex doesn't cause unnecessary API requests.

### Checklist
- [x] Tested changes end to end
- [ ] Updated build number in package.json when modifying a flex plugin
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
