### PR TITLE
Auto version bump

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,5 @@ _Provide a summary of the change..._
   - [ ] Flex User Experience with animations - _animations with descriptions if necessary of the user experience in Flex_
   - [ ] Setup and dependencies - _description of any setup steps required for this feature_
   - [ ] How does it work? - _description of plumbing supporting feature_
-- [ ] Updated build number in package.json when modifying a flex plugin
 - [ ] Added PR Label "ready-for-review"
 - [ ] Requested one or more reviewers for the PR

--- a/.github/template_files/flex_deploy_dev.yaml
+++ b/.github/template_files/flex_deploy_dev.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_DEV }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_DEV }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_DEV }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_DEV }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_DEV }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_DEV }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/template_files/flex_deploy_prod.yaml
+++ b/.github/template_files/flex_deploy_prod.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_PROD }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_PROD }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_PROD }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_PROD }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_PROD }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_PROD }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/template_files/flex_deploy_qa.yaml
+++ b/.github/template_files/flex_deploy_qa.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_QA }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_QA }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_QA }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_QA }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_QA }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_QA }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/template_files/flex_deploy_test.yaml
+++ b/.github/template_files/flex_deploy_test.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_TEST }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_TEST }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_TEST }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_TEST }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_TEST }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_TEST }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/workflows/bump_version_plugin_v1.yaml
+++ b/.github/workflows/bump_version_plugin_v1.yaml
@@ -15,6 +15,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v3
+      - name: setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - name: 'Bump version'
         uses: 'phips28/gh-action-bump-version@master'
         env:

--- a/.github/workflows/bump_version_plugin_v1.yaml
+++ b/.github/workflows/bump_version_plugin_v1.yaml
@@ -1,7 +1,9 @@
 name: bump_version_plugin_v1
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
     paths:
@@ -11,6 +13,7 @@ on:
 
 jobs:
   bump-version:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,4 +30,4 @@ jobs:
           PACKAGEJSON_DIR:  'plugin-flex-ts-template-v1'
         with:
           skip-tag: 'true'
-          version-type: 'minor'
+          version-type: 'patch'

--- a/.github/workflows/bump_version_plugin_v1.yaml
+++ b/.github/workflows/bump_version_plugin_v1.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'plugin-flex-ts-template-v1/**'
+  # Enable running this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   bump-version:

--- a/.github/workflows/bump_version_plugin_v1.yaml
+++ b/.github/workflows/bump_version_plugin_v1.yaml
@@ -1,0 +1,23 @@
+name: bump_version_plugin_v1
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugin-flex-ts-template-v1/**'
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 'Bump version'
+        uses: 'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGEJSON_DIR:  'plugin-flex-ts-template-v1'
+        with:
+          skip-tag: 'true'
+          version-type: 'minor'

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -16,6 +16,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v3
+      - name: setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - name: 'Bump version'
         uses: 'phips28/gh-action-bump-version@master'
         env:

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'plugin-flex-ts-template-v2/**'
+  # Enable running this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   bump-version:

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'auto-version-bump'
     paths:
       - 'plugin-flex-ts-template-v2/**'
   # Enable running this workflow manually from the Actions tab

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -1,0 +1,23 @@
+name: bump_version_plugin_v2
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugin-flex-ts-template-v2/**'
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 'Bump version'
+        uses: 'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGEJSON_DIR:  'plugin-flex-ts-template-v2'
+        with:
+          skip-tag: 'true'
+          version-type: 'minor'

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -1,10 +1,11 @@
 name: bump_version_plugin_v2
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
-      - 'auto-version-bump'
     paths:
       - 'plugin-flex-ts-template-v2/**'
   # Enable running this workflow manually from the Actions tab
@@ -12,6 +13,7 @@ on:
 
 jobs:
   bump-version:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,4 +30,4 @@ jobs:
           PACKAGEJSON_DIR:  'plugin-flex-ts-template-v2'
         with:
           skip-tag: 'true'
-          version-type: 'minor'
+          version-type: 'patch'

--- a/.github/workflows/flex_deploy_dev.yaml
+++ b/.github/workflows/flex_deploy_dev.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_DEV }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_DEV }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_DEV }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -63,7 +63,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_DEV }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_DEV }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_DEV }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/workflows/flex_deploy_prod.yaml
+++ b/.github/workflows/flex_deploy_prod.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_PROD }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_PROD }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_PROD }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -63,7 +63,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_PROD }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_PROD }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_PROD }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/workflows/flex_deploy_qa.yaml
+++ b/.github/workflows/flex_deploy_qa.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_QA }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_QA }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_QA }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -63,7 +63,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_QA }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_QA }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_QA }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/.github/workflows/flex_deploy_test.yaml
+++ b/.github/workflows/flex_deploy_test.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16'
      
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_TEST }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_TEST }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_TEST }} npm run populate-missing-placeholders $ENVIRONMENT
@@ -63,7 +63,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: install npm and apply missing envirnoment variables
+      - name: install npm and apply missing environment variables
         run: |
           npm install
           TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID_TEST }} TWILIO_API_KEY=${{ secrets.TWILIO_API_KEY_TEST }} TWILIO_API_SECRET=${{ secrets.TWILIO_API_SECRET_TEST }} npm run populate-missing-placeholders $ENVIRONMENT

--- a/plugin-flex-ts-template-v2/README.md
+++ b/plugin-flex-ts-template-v2/README.md
@@ -27,7 +27,7 @@ This plugin defines a package structure to make distributed development easier w
 
 The following guide assumes the reader has some familiarity with _Twilio Flex Plugins_, the _Flex Action Framework_ and _Flex React Component Model_ if not you can pop over [here](https://www.twilio.com/docs/flex/developer/ui-and-plugins) and read up on it.
 
-Even though the Flex plugin model allows a lot of extensibility and customization it doesnt offer any opinions on how to structure the code so that its readable and maintainable. The package structure outlined here aims to do that.
+Even though the Flex plugin model allows a lof of extensibility and customization it doesnt offer any opinions on how to structure the code so that its readable and maintainable. The package structure outlined here aims to do that.
 
 ---
 

--- a/plugin-flex-ts-template-v2/README.md
+++ b/plugin-flex-ts-template-v2/README.md
@@ -27,7 +27,7 @@ This plugin defines a package structure to make distributed development easier w
 
 The following guide assumes the reader has some familiarity with _Twilio Flex Plugins_, the _Flex Action Framework_ and _Flex React Component Model_ if not you can pop over [here](https://www.twilio.com/docs/flex/developer/ui-and-plugins) and read up on it.
 
-Even though the Flex plugin model allows a lof of extensibility and customization it doesnt offer any opinions on how to structure the code so that its readable and maintainable. The package structure outlined here aims to do that.
+Even though the Flex plugin model allows a lot of extensibility and customization it doesnt offer any opinions on how to structure the code so that its readable and maintainable. The package structure outlined here aims to do that.
 
 ---
 

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.37",
+  "version": "9.1.0",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.1.0",
+  "version": "9.0.37",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",


### PR DESCRIPTION
### Summary

Whenever a PR is merged, bump the patch number in the corresponding package.json file and push a new commit.

I wasn't able to test end-to-end, because ultimately this should only run upon merge. However, you can see in this PR's commit history evidence of it working :tada:

Note that our deploy workflows are currently only manually triggered. If that was not the case, these would race. In the future, if we want to automate deploys, we have a couple options:
- Use the version bump commit as the deploy trigger
- Use the API to dispatch the deploy workflow from the version bump workflow

### Checklist
- [ ] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR