### PR TITLE
Windows updates 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ or (for Flex UI v2.x)
 ```bash
 npm run start:local:v2
 ```
-or if you have renamed your plugin (v2 only)
+or if you have renamed your plugin (v2 only, this does not currently work for windows)
 ```bash
 npm run start:local
 ```

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "remove-features": "node scripts/remove-features.js",
     "rename-template": "node scripts/rename-template.js",
     "start:serverless": "cd serverless-functions && twilio serverless:start --inspect=localhost --port=3001 --env .env",
-    "start:plugin:v1": "node scripts/start-local.js v1",
-    "start:plugin:v2": "node scripts/start-local.js v2",
+    "start:plugin:v1": "cd plugin-flex-ts-template-v1 && twilio flex:plugins:start --port=3000",
+    "start:plugin:v2": "cd plugin-flex-ts-template-v2 && twilio flex:plugins:start --port=3000",
     "start:plugin": "node scripts/start-local.js",
-    "start:local:v1": "concurrently --kill-others \"npm run start:serverless\" \"npm run start:plugin:v1\"",
-    "start:local:v2": "concurrently --kill-others \"npm run start:serverless\" \"npm run start:plugin:v2\"",
-    "start:local": "concurrently --kill-others \"npm run start:serverless\" \"npm run start:plugin\""
+    "start:local:v1": "npm-run-all --parallel start:serverless start:plugin:v1",
+    "start:local:v2": "npm-run-all --parallel start:serverless start:plugin:v2",
+    "start:local": "concurrently --kill-others --timings true \"npm:start:serverless\" \"npm:start:plugin\""
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "concurrently": "^7.5.0",
     "prompt": "^1.3.0",
     "shelljs": "^0.8.5",
-    "twilio-cli": "5.2.1"
+    "twilio-cli": "5.2.1",
+    "npm-run-all": "4.1.5"
   }
 }

--- a/scripts/start-local.js
+++ b/scripts/start-local.js
@@ -1,5 +1,5 @@
 const shell = require("shelljs");
-var { setPluginName, getPaths } = require("./select-plugin");
+var { getPaths } = require("./select-plugin");
 
 const plugin = process.argv[2]
 


### PR DESCRIPTION
### Summary

Switching from `concurrently` to `npm-run-all` to support `npm run start:local:v1` and `npm run start:local:v2` commands in windows.  

Concurrently is doing something in the windows cmd shell that breaks the plugin start.  Shell.js also has the same issue, this is why the `npm run start:local` command still doesn't work as it uses shell.js to launch the process after it dynamically identifies the plugin folder.  As a reminder, this script is used after the template has been renamed.
