### PR TITLE
Commit version bump pre merge instead of after

### DIFF
--- a/.github/workflows/bump_version_plugin_v1.yaml
+++ b/.github/workflows/bump_version_plugin_v1.yaml
@@ -3,7 +3,7 @@ name: bump_version_plugin_v1
 on:
   pull_request:
     types:
-      - closed
+      - opened
     branches:
       - main
     paths:
@@ -13,7 +13,6 @@ on:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,5 +29,4 @@ jobs:
           PACKAGEJSON_DIR:  'plugin-flex-ts-template-v1'
         with:
           skip-tag: 'true'
-          target-branch: ${{ github.event.pull_request.base.ref && github.event.pull_request.base.ref || github.ref_name }}
           version-type: 'patch'

--- a/.github/workflows/bump_version_plugin_v2.yaml
+++ b/.github/workflows/bump_version_plugin_v2.yaml
@@ -3,7 +3,7 @@ name: bump_version_plugin_v2
 on:
   pull_request:
     types:
-      - closed
+      - opened
     branches:
       - main
     paths:
@@ -13,7 +13,6 @@ on:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,5 +29,4 @@ jobs:
           PACKAGEJSON_DIR:  'plugin-flex-ts-template-v2'
         with:
           skip-tag: 'true'
-          target-branch: ${{ github.event.pull_request.base.ref && github.event.pull_request.base.ref || github.ref_name }}
           version-type: 'patch'


### PR DESCRIPTION
### Summary

main is protected, so we can't push to it within an action. New strategy does everything before PR merge.

### Checklist
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
