### PR TITLE
Better handle Sync errors in serverless

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.38",
+  "version": "9.0.39",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/SwitchToVideo/SwitchToVideo.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { Actions, ITask, Manager, ConversationState } from "@twilio/flex-ui";
+import { Actions, ITask, Manager, ConversationState, Notifications } from "@twilio/flex-ui";
 import { Flex, Button } from "@twilio-paste/core";
 import { VideoOnIcon } from "@twilio-paste/icons/esm/VideoOnIcon";
 
 import { updateTaskAttributesForVideo } from "../../helpers/taskAttributes";
 import { UIAttributes } from "types/manager/ServiceConfiguration";
+import { ChatToVideoNotification } from '../../flex-hooks/notifications/ChatToVideo';
 
 interface SwitchToVideoProps {
   task: ITask;
@@ -64,6 +65,12 @@ const SwitchToVideo: React.FunctionComponent<SwitchToVideoProps> = ({
       .then((response) => response.json())
       .then((response) => {
         console.log("SwitchToVideo: unique link created:", response);
+        
+        if (!response.full_url) {
+          Notifications.showNotification(ChatToVideoNotification.FailedVideoLinkNotification);
+          return;
+        }
+        
         return Actions.invokeAction("SendMessage", {
           body: `Please join me using this unique video link: ${response.full_url}`,
           conversation,

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/notifications/ChatToVideo.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/notifications/ChatToVideo.ts
@@ -1,0 +1,19 @@
+import * as Flex from '@twilio/flex-ui';
+import { StringTemplates } from '../strings/ChatToVideo';
+
+// Export the notification IDs an enum for better maintainability when accessing them elsewhere
+export enum ChatToVideoNotification {
+  FailedVideoLinkNotification = 'PS_FailedVideoLink'
+};
+
+export default (flex: typeof Flex, manager: Flex.Manager) => {
+  failedVideoLinkNotification(flex, manager);
+}
+
+function failedVideoLinkNotification(flex: typeof Flex, manager: Flex.Manager) {
+  flex.Notifications.registerNotification({
+    id: ChatToVideoNotification.FailedVideoLinkNotification,
+    type: Flex.NotificationType.error,
+    content: StringTemplates.FailedVideoLinkNotification
+  });
+}

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/strings/ChatToVideo.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/strings/ChatToVideo.ts
@@ -1,0 +1,8 @@
+// Export the template names as an enum for better maintainability when accessing them elsewhere
+export enum StringTemplates {
+  FailedVideoLinkNotification = 'PS_FailedVideoLink'
+}
+
+export default {
+  [StringTemplates.FailedVideoLinkNotification]: 'Unable to create the video room. Please try again.'
+}

--- a/plugin-flex-ts-template-v2/src/flex-hooks/notifications/notifications.ts
+++ b/plugin-flex-ts-template-v2/src/flex-hooks/notifications/notifications.ts
@@ -10,10 +10,11 @@ import ScheduleManager from "../../feature-library/schedule-manager/flex-hooks/n
 import MultiCall from "../../feature-library/multi-call/flex-hooks/notifications/MultiCall";
 import InternalCall from "../../feature-library/internal-call/flex-hooks/notifications/InternalCall";
 import Callback from "../../feature-library/callback-and-voicemail/flex-hooks/notifications/Callback";
+import ChatToVideo from "../../feature-library/chat-to-video-escalation/flex-hooks/notifications/ChatToVideo";
 
 const notificationsToRegister: ((
   flex: typeof Flex,
   manager: Flex.Manager
-) => void)[] = [ActivityReservationHandler, ActivitySkillFilter, Conference, ChatTransfer, DualChannelRecording, PauseRecording, TeamsViewFilters, ScheduleManager, MultiCall, InternalCall, Callback];
+) => void)[] = [ActivityReservationHandler, ActivitySkillFilter, Conference, ChatTransfer, DualChannelRecording, PauseRecording, TeamsViewFilters, ScheduleManager, MultiCall, InternalCall, Callback, ChatToVideo];
 
 export default notificationsToRegister;

--- a/plugin-flex-ts-template-v2/src/flex-hooks/strings/strings.ts
+++ b/plugin-flex-ts-template-v2/src/flex-hooks/strings/strings.ts
@@ -8,7 +8,8 @@ import TeamsViewFilters from "../../feature-library/teams-view-filters/flex-hook
 import ScheduleManager from "../../feature-library/schedule-manager/flex-hooks/strings/ScheduleManager";
 import MultiCall from "../../feature-library/multi-call/flex-hooks/strings/MultiCall";
 import Callback from "../../feature-library/callback-and-voicemail/flex-hooks/strings/Callback";
+import ChatToVideo from "../../feature-library/chat-to-video-escalation/flex-hooks/strings/ChatToVideo";
 
-const customStrings = { ...ActivityReservationHandler, ...ActivitySkillFilter, ...Conference, ...ChatTransfer, ...DualChannelRecording, ...PauseRecording, ...TeamsViewFilters, ...ScheduleManager, ...MultiCall , ...Callback};
+const customStrings = { ...ActivityReservationHandler, ...ActivitySkillFilter, ...Conference, ...ChatTransfer, ...DualChannelRecording, ...PauseRecording, ...TeamsViewFilters, ...ScheduleManager, ...MultiCall , ...Callback, ...ChatToVideo};
 
 export default customStrings;

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -38,14 +38,7 @@ exports.createDocument = async function (parameters) {
 
     const document = await client.sync
       .services(context.TWILIO_FLEX_SYNC_SID)
-      .documents.create(documentParameters)
-      .catch((reason) => false);
-
-    if (!document)
-      return {
-        success: false,
-        message: `Failed to create Sync document ${reason}`,
-      };
+      .documents.create(documentParameters);
 
     return { success: true, status: 200, document: document };
   } catch (error) {
@@ -77,14 +70,7 @@ exports.fetchDocument = async function (parameters) {
     const document = await client.sync
       .services(context.TWILIO_FLEX_SYNC_SID)
       .documents(documentSid)
-      .fetch()
-      .catch((reason) => false);
-
-    if (!document)
-      return {
-        success: false,
-        message: `Failed to fetch Sync document ${reason}`,
-      };
+      .fetch();
 
     return { success: true, status: 200, document: document };
   } catch (error) {
@@ -119,14 +105,7 @@ exports.updateDocumentData = async function (parameters) {
     const documentUpdate = await client.sync
       .services(context.TWILIO_FLEX_SYNC_SID)
       .documents(documentSid)
-      .update({ data: updateData })
-      .catch((reason) => false);
-
-    if (!documentUpdate)
-      return {
-        success: false,
-        message: `Failed to update Sync document data ${reason}`,
-      };
+      .update({ data: updateData });
 
     return { success: true, status: 200, document: documentUpdate };
   } catch (error) {


### PR DESCRIPTION
### Summary

Fixes #111 by not catching errors prematurely. I noticed the plugin component that was using the function also wasn't handling the error so I added a basic error notification to handle it.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
