### PR TITLE
Pin @twilio-paste/icons to 9.4.0 to fix error

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.40",
+  "version": "9.0.41",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@twilio-paste/core": "^17.0.1",
-    "@twilio-paste/icons": "^9.2.0",
+    "@twilio-paste/icons": "9.4.0",
     "@twilio/flex-dev-utils": "^5.1.3",
     "@twilio/flex-plugin-scripts": "6.0.3",
     "@types/jest": "^26.0.20",


### PR DESCRIPTION
### Summary

Because of `^9.2.0`, we were pulling 9.4.1, which has an issue. Pinning to 9.4.0 fixes the error from #120.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
