### PR TITLE
Fix undefined codecPreferences in multi-call

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.41",
+  "version": "9.0.42",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -18,6 +18,7 @@ const createNewDevice = (manager: Manager) => {
   };
   
   if (!deviceOptions.codecPreferences) {
+    // The voice SDK throws an error when codecPreferences is set to undefined
     delete deviceOptions.codecPreferences;
   }
   

--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -17,6 +17,10 @@ const createNewDevice = (manager: Manager) => {
     appVersion: FlexVersion
   };
   
+  if (!deviceOptions.codecPreferences) {
+    delete deviceOptions.codecPreferences;
+  }
+  
   let device = new Device(manager.voiceClient.token ?? "", deviceOptions);
   
   if (audioConstraints) {


### PR DESCRIPTION
### Summary

The voice SDK doesn't seem to properly handle when `codecPreferences` is set to `undefined`; removing it from the object avoids the issue. I didn't catch this at first because I had previously set `codecPreferences` in my Flex config!

Fixes #121

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
