### PR TITLE
Fix errors caused by missing config

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.45",
+  "version": "9.0.46",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/ScheduleManagerService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/ScheduleManagerService.ts
@@ -2,7 +2,7 @@ import * as Flex from '@twilio/flex-ui';
 import { ScheduleManagerConfig, UpdateConfigResponse, UpdateConfigStatusResponse, PublishConfigRequest, PublishConfigResponse } from '../types/schedule-manager';
 import { EncodedParams } from '../../../types/serverless';
 import ApiService from '../../../utils/serverless/ApiService';
-import { getServerlessDomain } from '..';
+import { isFeatureEnabled, getServerlessDomain } from '..';
 
 class ScheduleManagerService extends ApiService {
   readonly scheduleManagerServerlessDomain: string;
@@ -12,7 +12,7 @@ class ScheduleManagerService extends ApiService {
     
     this.scheduleManagerServerlessDomain = getServerlessDomain();
     
-    if (!this.scheduleManagerServerlessDomain) {
+    if (isFeatureEnabled() && !this.scheduleManagerServerlessDomain) {
       console.error(
         "schedule_manager serverless_domain is not set in flex config"
       );

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/index.ts
@@ -13,7 +13,7 @@ const {
   queue_worker_data = false,
   team = false,
   agent_skills = false
-  } = getFeatureFlags().features?.teams_view_filters.applied_filters || {};
+  } = getFeatureFlags().features?.teams_view_filters?.applied_filters || {};
 
 export const isFeatureEnabled = () => {
   return enabled;


### PR DESCRIPTION
### Summary

Fixed some incorrect assumptions about the config so that the plugin does not crash when the config is missing.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
