### PR TITLE
ParameterValidator empty string check

### DIFF
--- a/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
+++ b/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
@@ -15,12 +15,12 @@ exports.validate = function(callingFunctionPath, parameterObject, requiredKeysAr
   requiredKeysArray.forEach(data => {
     if (module.exports.isString(data)) {
       // Support "lazy" requiredKeysArray of just ['propertyName']
-      if (parameterObject[data] === undefined || parameterObject[data] === null) {
+      if (parameterObject[data] === undefined || parameterObject[data] === null || parameterObject[data].length < 1) {
         errorMessage += `(${callingFunctionPath}) Missing ${data}`;
       }
     } else if (module.exports.isObject(data) && data.key && data.purpose) {
       // Support "useful" requiredKeysArray of [{ key: 'propertyName', purpose: 'I need it' }]
-      if (parameterObject[data.key] === undefined || parameterObject[data.key] === null) {
+      if (parameterObject[data.key] === undefined || parameterObject[data.key] === null || parameterObject[data.key].length < 1) {
         errorMessage += `(${callingFunctionPath}) Missing ${data.key}: ${data.purpose}`;
       }
     } else {

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -28,11 +28,6 @@ const getRequiredParameters = (event) => {
       purpose: "worker or queue sid",
     },
     {
-      key: "transferQueueName",
-      purpose:
-        "friendly name of taskrouter queue - can be empty string if transferTargetSid is a worker sid",
-    },
-    {
       key: "workersToIgnore",
       purpose:
         "json object with key indicating task attribute to set as an array of workers to ignore. eg {'workersToIgnore':['Alice','Bob']}. This gets copied to task attributes.",
@@ -44,11 +39,6 @@ const getRequiredParameters = (event) => {
     {
       key: "flexInteractionChannelSid",
       purpose: "UOxxx sid for interactions API",
-    },
-    {
-      key: "removeFlexInteractionParticipantSid",
-      purpose:
-        "UTxxx sid for interactions API for the transferrring agent to remove them from conversation. Can be empty string if we are adding additional participant and don't want to remove transferring",
     },
   ];
   return requiredParameters;

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -9,7 +9,6 @@ const requiredParameters = [
     key: "participantSid",
     purpose: "participant sid to target for conference changes",
   },
-  { key: "agentSid", purpose: "sid of target worker" },
   {
     key: "muted",
     purpose:


### PR DESCRIPTION
### Summary
Currently, ParameterValidator checks if parameters are provided, but doesn't check if they are empty or not. The thought behind this change is that if a parameter can be provided but empty, it probably shouldn't be included in the requiredParameters array anyway. Otherwise, each function will need to add duplicate checks for if each value is empty or not.

Leaving in 'question' status for now to collect feedback and double-check that other functions do not rely on the current behavior.

#135 exposed this issue.

### Checklist
- [ ] Tested changes end to end
- [ ] Added PR Label "ready-for-review"
- [ ] Requested one or more reviewers for the PR
