### PR TITLE
Voicemail Improvements to Cater to Transcription Callback Invocations

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "9.0.49",
+  "version": "9.0.50",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/README.md
@@ -1,6 +1,6 @@
 # callbacks and voicemail
 
-This feature enables the use of callbacks and voicemails as a custom task type.  It is a generic version intended to accelerate the customization of such a feature for any particular project, providing the main parts of a callback feature in easy to understand and customizable way.  It is inspired by the work in the [twilio solution library](https://www.twilio.com/docs/flex/solutions-library/queued-callback-and-voicemail) however it has a few key aspects that make it a little easier to use
+This feature enables the use of callbacks and voicemails as a custom task type. It is a generic version intended to accelerate the customization of such a feature for any particular project, providing the main parts of a callback feature in easy to understand and customizable way. It is inspired by the work in the [twilio solution library](https://www.twilio.com/docs/flex/solutions-library/queued-callback-and-voicemail) however it has a few key aspects that make it a little easier to use
 
 - the callbacks are placed on the voice channel by default, as its typical projects want callbacks to be threaded in single file with voice calls.
 - there is an API for creating the callback so you just have to create your customer experience then decide when to create the callback instead of peeling apart the sample solution.
@@ -21,36 +21,43 @@ voicemails will look like this
 
 # setup and dependencies
 
-Creating a callback involves creating a task with at a minimum a number to callback and a number to call from.  A sample setup of that is shown here in a studio flow where a number has been wired up to immediately create a callback and hang up.
+Creating a callback involves creating a task with at a minimum a number to callback and a number to call from. A sample setup of that is shown here in a studio flow where a number has been wired up to immediately create a callback and hang up.
 
 ![alt text](screenshots/sample-triggering-callback.png)
 
 here you can see three parameters which are populated from the studio flow
 
-- numberToCall: {{trigger.call.From}} - the number the customer dialed from
-- numberToCallFrom: {{trigger.call.To}} - the number the customer tried to dial
-- flexFlowSid: {{flow.flow_sid}} - to capture the entry point of this callback, it is stored on the task
+- `numberToCall: {{trigger.call.From}}` - the number the customer dialed from
+- `numberToCallFrom: {{trigger.call.To}}` - the number the customer tried to dial
+- `flexFlowSid: {{flow.flow_sid}}` - to capture the entry point of this callback, it is stored on the task and is useful for debugging and tracking. (Optional)  
 
 This serverless function can be used from anywhere, not just the studio flow, to create a callback task.
 
-The creation of a task requires a workflow.  You may create a custom workflow, that uses some collected data to organize the tasks into different queues or maybe something more complex.  You may also just want to use the default "Assign To Anyone" workflow that is spawned on a vanilla flex instance.
+The creation of a task requires a workflow. You may create a custom workflow, that uses some collected data to organize the tasks into different queues or maybe something more complex. You may also just want to use the default "Assign To Anyone" workflow that is spawned on a vanilla flex instance.
 
-Once you have decided which workflow you are using, you simply reference it in the environment file for your serverless-functions and make sure it is deployed as well as ensuring the flag is set for the feature in flex-config and that, that is also deployed.  You now have a functioning callback feature!
+Once you have decided which workflow you are using, you simply reference it in the environment file for your serverless-functions and make sure it is deployed as well as ensuring the flag is set for the feature in flex-config and that, that is also deployed. You now have a functioning callback feature!
 
 the variable that you need to make sure is set is
->TWILIO_FLEX_CALLBACK_WORKFLOW_SID=WW....
+
+> TWILIO_FLEX_CALLBACK_WORKFLOW_SID=WW....
 
 Creating a voicemail involves the same setup as above, however the following additional parameters must be passed to the create-callback function from a Record Voicemail widget:
 
 - recordingSid: {{widgets.record_voicemail_1.RecordingSid}} - the recording SID from the Record Voicemail widget
 - recordingUrl: {{widgets.record_voicemail_1.RecordingUrl}} - the recording URL from the Record Voicemail widget
 
+Alternatively, if you wish to enable transcriptions and show the transcription text on the voicemail task, you can invoke the create-callback functon from the Transcription Callback URL on the Record Voicemail widget. Just be sure to include the required params in the URL. e.g.
+
+`https://custom-flex-extensions-serverless-XXXX-dev.twil.io/features/callbacks/studio/create-callback?numberToCall={{trigger.call.From}}&numberToCallFrom={{trigger.call.To}}&flexFlowSid={{flow.sid}}`
+
+(The recordingSid and recordingUrl are already part of the transcription callback event)
+
 # how does it work?
 
-The feature works be registering custom flex channels for callbacks and voicemails.  These channels are a presentation only layer, on top of the taskrouter channel, which remains voice.
+The feature works be registering custom flex channels for callbacks and voicemails. These channels are a presentation only layer, on top of the taskrouter channel, which remains voice.
 
 when the channel is registered, it renders custom components based on the task attribute; _taskType: callback_ or _taskType: voicemail_
 
 there are two associated serverless functions called _create-callback_
 
-the only difference between these functions is one is intended to be called from flex, the other from anywhere else but typically studio.  The difference is the security model for each function but both do the same thing, taking in task attributes and generating a new callback task.  The flex interface is used for the re-queueing feature.
+the only difference between these functions is one is intended to be called from flex, the other from anywhere else but typically studio. The difference is the security model for each function but both do the same thing, taking in task attributes and generating a new callback task. The flex interface is used for the re-queueing feature.

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/README.md
@@ -29,7 +29,7 @@ here you can see three parameters which are populated from the studio flow
 
 - `numberToCall: {{trigger.call.From}}` - the number the customer dialed from
 - `numberToCallFrom: {{trigger.call.To}}` - the number the customer tried to dial
-- `flexFlowSid: {{flow.flow_sid}}` - to capture the entry point of this callback, it is stored on the task and is useful for debugging and tracking. (Optional)  
+- `flexFlowSid: {{flow.flow_sid}}` - to capture the entry point of this callback, it is stored on the task and is useful for debugging and tracking. (Optional)
 
 This serverless function can be used from anywhere, not just the studio flow, to create a callback task.
 
@@ -43,8 +43,8 @@ the variable that you need to make sure is set is
 
 Creating a voicemail involves the same setup as above, however the following additional parameters must be passed to the create-callback function from a Record Voicemail widget:
 
-- recordingSid: {{widgets.record_voicemail_1.RecordingSid}} - the recording SID from the Record Voicemail widget
-- recordingUrl: {{widgets.record_voicemail_1.RecordingUrl}} - the recording URL from the Record Voicemail widget
+- `recordingSid: {{widgets.record_voicemail_1.RecordingSid}}` - the recording SID from the Record Voicemail widget
+- `recordingUrl: {{widgets.record_voicemail_1.RecordingUrl}}` - the recording URL from the Record Voicemail widget
 
 Alternatively, if you wish to enable transcriptions and show the transcription text on the voicemail task, you can invoke the create-callback functon from the Transcription Callback URL on the Record Voicemail widget. Just be sure to include the required params in the URL. e.g.
 

--- a/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callbacks/flex/create-callback.js
@@ -1,4 +1,6 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()[
+  "common/helpers/prepare-function"
+].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
@@ -9,78 +11,77 @@ const requiredParameters = [
     key: "numberToCallFrom",
     purpose: "the number to call the customer from",
   },
-  {
-    key: "flexFlowSid",
-    purpose: "the SID of the Flex Flow that triggered this function",
-  },
 ];
 
-exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  try {
-    const {
-      numberToCall,
-      numberToCallFrom,
-      flexFlowSid,
-      workflowSid: overriddenWorkflowSid,
-      timeout: overriddenTimeout,
-      priority: overriddenPriority,
-      attempts: retryAttempt,
-      conversation_id,
-      message,
-      utcDateTimeReceived,
-      recordingSid,
-      recordingUrl,
-      transcriptSid,
-      transcriptText,
-      isDeleted,
-      taskChannel: overriddenTaskChannel,
-    } = event;
-    
-    // use assigned values or use defaults
-    const workflowSid =
-      overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
-    const timeout = overriddenTimeout || 86400;
-    const priority = overriddenPriority || 0;
-    const attempts = retryAttempt || 0;
-    const taskChannel = overriddenTaskChannel || "voice";
-    
-    // setup required task attributes for task
-    const attributes = {
-      taskType: recordingSid ? "voicemail" : "callback",
-      name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
-      flow_execution_sid: flexFlowSid,
-      message: message || null,
-      callBackData: {
+exports.handler = prepareFlexFunction(
+  requiredParameters,
+  async (context, event, callback, response, handleError) => {
+    try {
+      const {
         numberToCall,
         numberToCallFrom,
-        attempts,
-        mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        utcDateTimeReceived: utcDateTimeReceived || new Date(),
+        flexFlowSid,
+        workflowSid: overriddenWorkflowSid,
+        timeout: overriddenTimeout,
+        priority: overriddenPriority,
+        attempts: retryAttempt,
+        conversation_id,
+        message,
+        utcDateTimeReceived,
         recordingSid,
         recordingUrl,
         transcriptSid,
         transcriptText,
-        isDeleted: isDeleted || false,
-      },
-      direction: "inbound",
-      conversations: {
-        conversation_id,
-      },
-    };
-    
-    const result = await TaskOperations.createTask({
-      context,
-      workflowSid,
-      taskChannel,
-      attributes,
-      priority,
-      timeout,
-      attempts: 0,
-    });
-    response.setStatusCode(result.status);
-    response.setBody({ success: result.success, taskSid: result.taskSid });
-    callback(null, response);
-  } catch (error) {
-    handleError(error);
+        isDeleted,
+        taskChannel: overriddenTaskChannel,
+      } = event;
+
+      // use assigned values or use defaults
+      const workflowSid =
+        overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
+      const timeout = overriddenTimeout || 86400;
+      const priority = overriddenPriority || 0;
+      const attempts = retryAttempt || 0;
+      const taskChannel = overriddenTaskChannel || "voice";
+
+      // setup required task attributes for task
+      const attributes = {
+        taskType: recordingSid ? "voicemail" : "callback",
+        name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
+        flow_execution_sid: flexFlowSid,
+        message: message || null,
+        callBackData: {
+          numberToCall,
+          numberToCallFrom,
+          attempts,
+          mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          utcDateTimeReceived: utcDateTimeReceived || new Date(),
+          recordingSid,
+          recordingUrl,
+          transcriptSid,
+          transcriptText,
+          isDeleted: isDeleted || false,
+        },
+        direction: "inbound",
+        conversations: {
+          conversation_id,
+        },
+      };
+
+      const result = await TaskOperations.createTask({
+        context,
+        workflowSid,
+        taskChannel,
+        attributes,
+        priority,
+        timeout,
+        attempts: 0,
+      });
+      response.setStatusCode(result.status);
+      response.setBody({ success: result.success, taskSid: result.taskSid });
+      callback(null, response);
+    } catch (error) {
+      handleError(error);
+    }
   }
-});
+);

--- a/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
+++ b/serverless-functions/src/functions/features/callbacks/studio/create-callback.protected.js
@@ -1,4 +1,6 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()[
+  "common/helpers/prepare-function"
+].path);
 const TaskOperations = require(Runtime.getFunctions()[
   "common/twilio-wrappers/taskrouter"
 ].path);
@@ -9,78 +11,90 @@ const requiredParameters = [
     key: "numberToCallFrom",
     purpose: "the number to call the customer from",
   },
-  {
-    key: "flexFlowSid",
-    purpose: "the SID of the Flex Flow that triggered this function",
-  },
 ];
 
-exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  try {
-    const {
-      numberToCall,
-      numberToCallFrom,
-      flexFlowSid,
-      workflowSid: overriddenWorkflowSid,
-      timeout: overriddenTimeout,
-      priority: overriddenPriority,
-      attempts: retryAttempt,
-      conversation_id,
-      message,
-      utcDateTimeReceived,
-      recordingSid,
-      recordingUrl,
-      transcriptSid,
-      transcriptText,
-      isDeleted,
-      taskChannel: overriddenTaskChannel,
-    } = event;
-    
-    // use assigned values or use defaults
-    const workflowSid =
-      overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
-    const timeout = overriddenTimeout || 86400;
-    const priority = overriddenPriority || 0;
-    const attempts = retryAttempt || 0;
-    const taskChannel = overriddenTaskChannel || "voice";
-    
-    // setup required task attributes for task
-    const attributes = {
-      taskType: recordingSid ? "voicemail" : "callback",
-      name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
-      flow_execution_sid: flexFlowSid,
-      message: message || null,
-      callBackData: {
+exports.handler = prepareStudioFunction(
+  requiredParameters,
+  async (context, event, callback, response, handleError) => {
+    try {
+      const {
         numberToCall,
         numberToCallFrom,
-        attempts,
-        mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        utcDateTimeReceived: utcDateTimeReceived || new Date(),
-        recordingSid,
-        recordingUrl,
-        transcriptSid,
-        transcriptText,
-        isDeleted: isDeleted || false,
-      },
-      direction: "inbound",
-      conversations: {
+        flexFlowSid,
+        workflowSid: overriddenWorkflowSid,
+        timeout: overriddenTimeout,
+        priority: overriddenPriority,
+        attempts: retryAttempt,
         conversation_id,
-      },
-    };
-    
-    const result = await TaskOperations.createTask({
-      context,
-      workflowSid,
-      taskChannel,
-      attributes,
-      priority,
-      timeout,
-      attempts: 0,
-    });
-    response.setStatusCode(result.status);
-    response.setBody({ success: result.success, taskSid: result.taskSid });
-    callback(null, response);
-  } catch (error) {
-    handleError(error);
+        message,
+        utcDateTimeReceived,
+        recordingSid,
+        RecordingSid,
+        recordingUrl,
+        RecordingUrl,
+        transcriptSid,
+        TranscriptionSid,
+        transcriptText,
+        TranscriptionText,
+        isDeleted,
+        taskChannel: overriddenTaskChannel,
+      } = event;
+
+      // use assigned values or use defaults
+      const workflowSid =
+        overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
+      const timeout = overriddenTimeout || 86400;
+      const priority = overriddenPriority || 0;
+      const attempts = retryAttempt || 0;
+      const taskChannel = overriddenTaskChannel || "voice";
+
+      // use explicitly passed in values or use values from the transcription callback event (if applicable)
+      const definitiveRecordingSid = recordingSid || RecordingSid;
+      const definitiveRecordingUrl = recordingUrl || RecordingUrl;
+      const definitiveTranscriptionSid = transcriptSid || TranscriptionSid;
+      const definitiveTranscriptionText =
+        transcriptText || TranscriptionText;
+
+      // setup required task attributes for task
+      const attributes = {
+        taskType: definitiveRecordingSid ? "voicemail" : "callback",
+        name:
+          (definitiveRecordingSid ? "Voicemail" : "Callback") +
+          ` (${numberToCall})`,
+        flow_execution_sid: flexFlowSid,
+        message: message || null,
+        callBackData: {
+          numberToCall,
+          numberToCallFrom,
+          attempts,
+          mainTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          utcDateTimeReceived: utcDateTimeReceived || new Date(),
+          recordingSid: definitiveRecordingSid,
+          recordingUrl: definitiveRecordingUrl,
+          transcriptSid: definitiveTranscriptionSid,
+          transcriptText: definitiveTranscriptionText,
+          isDeleted: isDeleted || false,
+        },
+        direction: "inbound",
+        conversations: {
+          conversation_id,
+        },
+      };
+
+      const result = await TaskOperations.createTask({
+        context,
+        workflowSid,
+        taskChannel,
+        attributes,
+        priority,
+        timeout,
+        attempts: 0,
+      });
+      response.setStatusCode(result.status);
+      response.setBody({ success: result.success, taskSid: result.taskSid });
+      callback(null, response);
+    } catch (error) {
+      handleError(error);
+    }
   }
-});
+);


### PR DESCRIPTION

### Summary

Catering to Transcription Callback events being the invokers of `create-callback` function (i.e. slightly different parameter naming convention). Updated README to mention this alternative approach for initiating the function call via Transcription Callback URL on the Record Voicemail widget.

Removing `flexFlowSid` as a required param from both (Studio an Flex) `create-callback` functions - as this API could be called from a TwiML app instead of a Studio Flow. 

Updated README to reflect optional `flexFlowSid`, and give description as to how it's used.

### Checklist
- [x] Tested changes end to end
- [x] README updates
- [x] Added PR Label "ready-for-review"
- [ ] Requested one or more reviewers for the PR
