### PR TITLE
Fix activity handler with callbacks (#153)

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/CompleteTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/actions/CompleteTask.ts
@@ -1,4 +1,5 @@
 import * as Flex from "@twilio/flex-ui";
+import FlexHelper from "../../helpers/flexHelper";
 import WorkerState from "../../helpers/workerActivityHelper";
 import { getPendingActivity } from "../../helpers/pendingActivity";
 import { isFeatureEnabled } from '../..';
@@ -10,6 +11,11 @@ export function beforeCompleteWorkerTask(
   if (!isFeatureEnabled()) return;
 
   flex.Actions.addListener("beforeCompleteTask", async () => {
+    
+    if (FlexHelper.activeTaskCount > 1) {
+      return;
+    }
+    
     const pendingActivity = getPendingActivity();
 
     if (pendingActivity) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskEnded.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskEnded.ts
@@ -18,7 +18,7 @@ const taskEndedHandler = (task: Flex.ITask, flexEvent: FlexEvent) => {
 
   if (
     flexEvent === FlexEvent.taskTimeout ||
-    FlexHelper.hasActiveCallTask ||
+    FlexHelper.hasActiveTask ||
     FlexHelper.hasWrappingTask ||
     WorkerActivity.activitySid === pendingActivity?.sid
   ) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskWrapup.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/taskWrapup.ts
@@ -15,7 +15,7 @@ const taskEndedHandler = (task: Flex.ITask, flexEvent: FlexEvent) => {
   console.log(`activity-handler: handle ${flexEvent} for ${task.sid}`);
 
   if (
-    FlexHelper.hasLiveCallTask ||
+    FlexHelper.hasActiveTask ||
     FlexHelper.hasPendingTask ||
     WorkerActivity.activityName === SystemActivityNames.wrapup
   ) {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helpers/flexHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helpers/flexHelper.ts
@@ -28,6 +28,15 @@ class FlexHelper {
   get workerTasks(): Map<string, ITask> {
     return this.flexState.worker.tasks;
   }
+  
+  get activeTaskCount(): number {
+    if (!this.workerTasks) return 0;
+  
+    return [...this.workerTasks.values()].filter(
+      (task) =>
+        TaskHelper.isTaskAccepted(task)
+    ).length;
+  }
 
   get hasLiveCallTask(): boolean {
     if (!this.workerTasks) return false;


### PR DESCRIPTION
### Summary

Previously the activity-reservation-handler feature worked with the assumption that only calls would be handled, and only one at a time. This change removes the assumption and adds fixes to handle multiple tasks. Fixes #153 

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
