### PR TITLE
Fix #166

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/components/TaskCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/flex-hooks/components/TaskCanvasTabs.tsx
@@ -6,7 +6,7 @@ import { FlexComponent } from '../../../../types/feature-loader';
 export const componentName = FlexComponent.TaskCanvasTabs;
 export const componentHook = function addVideoRoomTabToTaskCanvasTabs(flex: typeof Flex) {
   flex.TaskCanvasTabs.Content.add(
-    <Flex.Tab label="Video Room" key="VideoRoom">
+    <Flex.Tab label="Video Room" key="VideoRoom" uniqueName="VideoRoom">
       <VideoRoom />
     </Flex.Tab>,
     {

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/TaskCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/TaskCanvasTabs.tsx
@@ -15,7 +15,7 @@ export const componentHook = function addTaskCanvasTabCustomization(flex: typeof
   if (!isMultiParticipantEnabled()) return;
 
   flex.TaskCanvasTabs.Content.add(
-    <Tab label={ParticipantTabLabel()} key="participant-tab">
+    <Tab label={ParticipantTabLabel()} key="participant-tab" uniqueName="ConversationTransferParticipants">
       <ParticipantsTab />
     </Tab>,
     { if: ({ task }: Props) => TaskHelper.isCBMTask(task) && task.status === 'accepted' },


### PR DESCRIPTION
### Summary

Add `uniqueName` to every `Flex.Tab` added to `TaskCanvasTabs` to fix #166.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
