### PR TITLE
Add eslint to serverless-functions

### DIFF
--- a/.github/workflows/check_serverless.yaml
+++ b/.github/workflows/check_serverless.yaml
@@ -1,0 +1,64 @@
+name: check_serverless
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+    paths:
+      - 'serverless-functions/**'
+  # Enable running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install packages
+        working-directory: ./serverless-functions
+        run: npm install
+      - name: Run eslint
+        working-directory: ./serverless-functions
+        run: npm run lint:report
+        continue-on-error: true
+      - name: Annotate Code Linting Results
+        id: annotate
+        uses: ataylorme/eslint-annotate-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "serverless-functions/eslint_report.json"
+      - name: Comment on error
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount > 0
+        with:
+          message: |
+            Linter results for serverless-functions:
+            ${{steps.annotate.outputs.summary}}
+            :rotating_light: Errors must be resolved before merging, and have been annotated in the "Files changed" tab. Run `npm run lint` from the serverless-functions directory if you would like to see results locally.
+      - name: Comment on warning
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount < 1 && steps.annotate.outputs.warningCount > 0
+        with:
+          message: |
+            Linter results for serverless-functions:
+            ${{steps.annotate.outputs.summary}}
+            :warning: Merging is still possible with these warnings, but please fix them if possible! Annotations are available in the "Files changed" tab. Run `npm run lint` from the serverless-functions directory if you would like to see results locally.
+      - name: Comment on no issues
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount < 1 && steps.annotate.outputs.warningCount < 1
+        with:
+          message: |
+            Linter results for serverless-functions:
+            ${{steps.annotate.outputs.summary}}
+            :white_check_mark: No issues found!

--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ Lastly, this package manages the github action workflows - with one example bein
 
 (the following is only applicable when using the flex v2 plugin)
 
-ESLint is configured for the v2 plugin, using [Twilio Style](https://github.com/twilio-labs/twilio-style) as a base with some relaxations. When opening a pull request, the included GitHub workflows will run the linter, preventing merge if errors are present. Therefore, it is convenient to run the linter locally to identify any errors that you may need to fix ahead of time.
+ESLint is configured for the v2 plugin and the serverless-functions package, using [Twilio Style](https://github.com/twilio-labs/twilio-style) as a base with some relaxations. When opening a pull request, the included GitHub workflows will run the linter, preventing merge if errors are present. Therefore, it is convenient to run the linter locally to identify any errors that you may need to fix ahead of time.
 
-Before pushing changes, run the following command from the `plugin-flex-ts-template-v2` dir to see the linter results.
+Before pushing changes, run the following command from the `plugin-flex-ts-template-v2` dir and/or the `serverless-functions` dir to see the linter results.
 
 ```bash
 npm run lint

--- a/serverless-functions/.prettierrc.js
+++ b/serverless-functions/.prettierrc.js
@@ -1,0 +1,5 @@
+const baseConfig = require('./node_modules/eslint-config-twilio/rules/prettier');
+
+module.exports = {
+  ...baseConfig,
+};

--- a/serverless-functions/package.json
+++ b/serverless-functions/package.json
@@ -52,6 +52,7 @@
       "multiline-comment-style": "off",
       "no-alert": "off",
       "no-console": "off",
+      "no-multi-str": "off",
       "no-use-before-define": "off",
       "prefer-destructuring": "off",
       "prefer-named-capture-group": "off",

--- a/serverless-functions/package.json
+++ b/serverless-functions/package.json
@@ -12,7 +12,9 @@
     "deploy:qa": "TWILIO_PROFILE=qa npm run deploy",
     "deploy:prod": "TWILIO_PROFILE=prod npm run deploy",
     "x-old-predeploy": "[[ -z \"${TWILIO_PROFILE}\" ]] && (echo \"TWILIO_PROFILE must be set\"; exit 1) || exit 0",
-    "x-old-deploy": "twilio serverless:deploy --override-existing-project -p \"$TWILIO_PROFILE\" --env \".env.$TWILIO_PROFILE\" --no-assets"
+    "x-old-deploy": "twilio serverless:deploy --override-existing-project -p \"$TWILIO_PROFILE\" --env \".env.$TWILIO_PROFILE\" --no-assets",
+    "lint": "eslint --ext js ./src/functions",
+    "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
     "@twilio-labs/serverless-runtime-types": "^1.1",
@@ -25,11 +27,38 @@
     "@types/lodash": "4.14.182",
     "axios": "0.27.2",
     "copyfiles": "2.4.1",
+    "eslint": "^8.37.0",
+    "eslint-config-twilio": "^2.0.0",
     "twilio-cli": "5.2.1",
     "twilio-run": "3.4.2",
     "typescript": "^3.9.4"
   },
   "engines": {
     "node": "14"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "twilio"
+    ],
+    "rules": {
+      "camelcase": "off",
+      "complexity": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": "off",
+      "import/no-mutable-exports": "off",
+      "import/no-unresolved": "off",
+      "import/no-unused-modules": "off",
+      "multiline-comment-style": "off",
+      "no-alert": "off",
+      "no-console": "off",
+      "no-use-before-define": "off",
+      "prefer-destructuring": "off",
+      "prefer-named-capture-group": "off",
+      "prefer-promise-reject-errors": "off",
+      "sonarjs/cognitive-complexity": "off",
+      "sonarjs/no-identical-functions": "off",
+      "sonarjs/no-duplicate-string": "off"
+    }
   }
 }

--- a/serverless-functions/package.json
+++ b/serverless-functions/package.json
@@ -14,7 +14,8 @@
     "x-old-predeploy": "[[ -z \"${TWILIO_PROFILE}\" ]] && (echo \"TWILIO_PROFILE must be set\"; exit 1) || exit 0",
     "x-old-deploy": "twilio serverless:deploy --override-existing-project -p \"$TWILIO_PROFILE\" --env \".env.$TWILIO_PROFILE\" --no-assets",
     "lint": "eslint --ext js ./src/functions",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "lint:report": "npm run lint -- --output-file eslint_report.json --format json"
   },
   "dependencies": {
     "@twilio-labs/serverless-runtime-types": "^1.1",

--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -20,8 +20,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, phoneNumbers });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -1,7 +1,5 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const PhoneNumberOpertions = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/phone-numbers"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const PhoneNumberOpertions = require(Runtime.getFunctions()['common/twilio-wrappers/phone-numbers'].path);
 
 const requiredParameters = [];
 
@@ -11,7 +9,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       attempts: 0,
     });
-    
+
     const { success, phoneNumbers: fullPhoneNumberList, status } = result;
     const phoneNumbers = fullPhoneNumberList
       ? fullPhoneNumberList.map((number) => {
@@ -19,7 +17,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           return { friendlyName, phoneNumber };
         })
       : null;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, phoneNumbers });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
+++ b/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
@@ -1,11 +1,9 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ChatOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-chat"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ChatOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-chat'].path);
 
 const requiredParameters = [
-  { key: "channelSid", purpose: "channel to be updated" },
-  { key: "attributes", purpose: "new attributes" },
+  { key: 'channelSid', purpose: 'channel to be updated' },
+  { key: 'attributes', purpose: 'new attributes' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
@@ -18,7 +16,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       attributes,
       attempts: 0,
     });
-    
+
     response.setStatusCode(result.status);
     response.setBody({ success: result.success });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
+++ b/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
@@ -19,8 +19,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(result.status);
     response.setBody({ success: result.success });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
@@ -23,8 +23,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
@@ -1,18 +1,16 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ConferenceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/conference-participant"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
-  { key: "taskSid", purpose: "unique ID of task to update" },
-  { key: "to", purpose: "number to add to the conference" },
-  { key: "from", purpose: "caller ID to use when adding to the conference" },
+  { key: 'taskSid', purpose: 'unique ID of task to update' },
+  { key: 'to', purpose: 'number to add to the conference' },
+  { key: 'from', purpose: 'caller ID to use when adding to the conference' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { taskSid, to, from } = event;
-    
+
     const result = await ConferenceOperations.addParticipant({
       context,
       taskSid,
@@ -20,9 +18,9 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       from,
       attempts: 0,
     });
-    
+
     const { success, participantsResponse, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
@@ -1,26 +1,24 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
 const requiredParameters = [
-  { key: "callSid", purpose: "unique ID of call to update" },
-  { key: "to", purpose: "phone number to transfer to" },
+  { key: 'callSid', purpose: 'unique ID of call to update' },
+  { key: 'to', purpose: 'phone number to transfer to' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, to } = event;
-    
+
     const result = await VoiceOperations.coldTransfer({
       context,
       callSid,
       to,
       attempts: 0,
     });
-    
+
     const { success, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
@@ -21,8 +21,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -17,8 +17,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, callProperties });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -1,24 +1,20 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
-const requiredParameters = [
-  { key: "callSid", purpose: "unique ID of call to fetch" },
-];
+const requiredParameters = [{ key: 'callSid', purpose: 'unique ID of call to fetch' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid } = event;
-    
+
     const result = await VoiceOperations.fetchProperties({
       context,
       callSid,
       attempts: 0,
     });
-    
+
     const { success, callProperties, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, callProperties });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
@@ -23,8 +23,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
@@ -1,28 +1,26 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ConferenceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/conference-participant"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
-  { key: "conference", purpose: "unique ID of conference to update" },
-  { key: "participant", purpose: "unique ID of participant to update" },
-  { key: "hold", purpose: "whether to hold or unhold the participant" },
+  { key: 'conference', purpose: 'unique ID of conference to update' },
+  { key: 'participant', purpose: 'unique ID of participant to update' },
+  { key: 'hold', purpose: 'whether to hold or unhold the participant' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant, hold } = event;
-    
+
     const result = await ConferenceOperations.holdParticipant({
       context,
       conference,
       participant,
-      hold: hold === "true",
+      hold: hold === 'true',
       attempts: 0,
     });
-    
+
     const { success, participantsResponse, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
@@ -1,26 +1,24 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ConferenceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/conference-participant"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
-  { key: "conference", purpose: "unique ID of conference to update" },
-  { key: "participant", purpose: "unique ID of participant to update" },
+  { key: 'conference', purpose: 'unique ID of conference to update' },
+  { key: 'participant', purpose: 'unique ID of participant to update' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant } = event;
-    
+
     const result = await ConferenceOperations.removeParticipant({
       context,
       conference,
       participant,
       attempts: 0,
     });
-    
+
     const { success, participantsResponse, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
@@ -21,8 +21,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
@@ -1,31 +1,29 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ConferenceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/conference-participant"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
-  { key: "conference", purpose: "unique ID of conference to update" },
-  { key: "participant", purpose: "unique ID of participant to update" },
+  { key: 'conference', purpose: 'unique ID of conference to update' },
+  { key: 'participant', purpose: 'unique ID of participant to update' },
   {
-    key: "endConferenceOnExit",
-    purpose: "whether to end conference when the participant leaves",
+    key: 'endConferenceOnExit',
+    purpose: 'whether to end conference when the participant leaves',
   },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conference, participant, endConferenceOnExit } = event;
-    
+
     const result = await ConferenceOperations.updateParticipant({
       context,
       conference,
       participant,
-      endConferenceOnExit: endConferenceOnExit === "true",
+      endConferenceOnExit: endConferenceOnExit === 'true',
       attempts: 0,
     });
-    
+
     const { success, participantsResponse, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
@@ -26,8 +26,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
@@ -18,8 +18,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       : null;
     response.setStatusCode(status);
     response.setBody({ success, queues, message });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
@@ -1,7 +1,5 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskRouterOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskRouterOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 const requiredParameters = [];
 

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
@@ -15,8 +15,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, workerChannels });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
@@ -1,11 +1,7 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskRouterOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskRouterOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
-const requiredParameters = [
-  { key: "workerSid", purpose: "unique ID of the worker" },
-];
+const requiredParameters = [{ key: 'workerSid', purpose: 'unique ID of the worker' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
@@ -16,7 +12,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       workerSid,
     });
     const { success, status, workerChannels } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, workerChannels });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
@@ -29,25 +29,25 @@ exports.handler = TokenValidator(async function updateTaskAttributes(context, ev
     console.error('update-assignment status invalid parameters passed');
     response.setStatusCode(400);
     response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-  } else {
-    try {
-      const { taskSid, assignmentStatus } = event;
-      const result = await TaskOperations.updateTask({
-        scriptName,
-        context,
-        taskSid,
-        updateParams: { assignmentStatus },
-        attempts: 0,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success });
-      callback(null, response);
-    } catch (error) {
-      console.log(error);
-      response.setStatusCode(500);
-      response.setBody({ data: null, message: error.message });
-      callback(null, response);
-    }
+    return callback(null, response);
+  }
+
+  try {
+    const { taskSid, assignmentStatus } = event;
+    const result = await TaskOperations.updateTask({
+      scriptName,
+      context,
+      taskSid,
+      updateParams: { assignmentStatus },
+      attempts: 0,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success });
+    return callback(null, response);
+  } catch (error) {
+    console.log(error);
+    response.setStatusCode(500);
+    response.setBody({ data: null, message: error.message });
+    return callback(null, response);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
@@ -4,7 +4,6 @@ const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parame
 const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 exports.handler = TokenValidator(async function updateTaskAttributes(context, event, callback) {
-  const scriptName = arguments.callee.name;
   const response = new Twilio.Response();
   const requiredParameters = [
     { key: 'taskSid', purpose: 'unique ID of task to update' },
@@ -35,7 +34,6 @@ exports.handler = TokenValidator(async function updateTaskAttributes(context, ev
   try {
     const { taskSid, assignmentStatus } = event;
     const result = await TaskOperations.updateTask({
-      scriptName,
       context,
       taskSid,
       updateParams: { assignmentStatus },

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
@@ -1,44 +1,32 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
-exports.handler = TokenValidator(async function updateTaskAttributes(
-  context,
-  event,
-  callback
-) {
+const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+
+exports.handler = TokenValidator(async function updateTaskAttributes(context, event, callback) {
   const scriptName = arguments.callee.name;
   const response = new Twilio.Response();
   const requiredParameters = [
-    { key: "taskSid", purpose: "unique ID of task to update" },
+    { key: 'taskSid', purpose: 'unique ID of task to update' },
     {
-      key: "assignmentStatus",
-      purpose:
-        "Set task to assignemnt status of: pending, reserved, assigned, canceled, wrapping, or completed",
+      key: 'assignmentStatus',
+      purpose: 'Set task to assignemnt status of: pending, reserved, assigned, canceled, wrapping, or completed',
     },
   ];
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+  response.appendHeader('Access-Control-Allow-Origin', '*');
+  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
+  response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
   if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
+    console.log('Empty event object, likely an OPTIONS request');
     return callback(null, response);
   }
 
   if (parameterError) {
-    console.error("update-assignment status invalid parameters passed");
+    console.error('update-assignment status invalid parameters passed');
     response.setStatusCode(400);
     response.setBody({ data: null, message: parameterError });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
@@ -20,8 +20,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     });
     response.setStatusCode(result.status);
     response.setBody({ success: result.success });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
@@ -1,13 +1,11 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskRouterOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskRouterOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 const requiredParameters = [
-  { key: "taskSid", purpose: "unique ID of task to update" },
+  { key: 'taskSid', purpose: 'unique ID of task to update' },
   {
-    key: "attributesUpdate",
-    purpose: "object to overwrite on existing task attributes",
+    key: 'attributesUpdate',
+    purpose: 'object to overwrite on existing task attributes',
   },
 ];
 

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
@@ -1,27 +1,25 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskRouterOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskRouterOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 const requiredParameters = [
-  { key: "workerSid", purpose: "unique ID of the worker" },
+  { key: 'workerSid', purpose: 'unique ID of the worker' },
   {
-    key: "workerChannelSid",
-    purpose: "unique ID of the workerChannelSid to update",
+    key: 'workerChannelSid',
+    purpose: 'unique ID of the workerChannelSid to update',
   },
-  { key: "capacity", purpose: "the new capacity" },
-  { key: "available", purpose: "whether the channel is enabled or not" },
+  { key: 'capacity', purpose: 'the new capacity' },
+  { key: 'available', purpose: 'whether the channel is enabled or not' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     // Make sure that this user is allowed to perform this action
     if (!(event.TokenResult.roles.includes('supervisor') || event.TokenResult.roles.includes('admin'))) {
-      response.setStatusCode(403)
-      response.setBody({success: false, error: "User does not have the permissions to perform this action."});
+      response.setStatusCode(403);
+      response.setBody({ success: false, error: 'User does not have the permissions to perform this action.' });
       return callback(null, response);
     }
-    
+
     const { workerSid, workerChannelSid, capacity, available } = event;
     const result = await TaskRouterOperations.updateWorkerChannel({
       context,
@@ -29,10 +27,10 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       workerSid,
       workerChannelSid,
       capacity: Number(capacity),
-      available: available === "true",
+      available: available === 'true',
     });
     const { success, message, status, workerChannelCapacity } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, message, workerChannelCapacity });
     callback(null, response);

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
@@ -33,8 +33,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, message, workerChannelCapacity });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
+++ b/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
@@ -4,15 +4,15 @@
  * @param {Array} requiredKeysArray
  * @returns {string}
  * @description Convenience method to validate properties exist on an object
- * requiredKeysArray should be an array of strings or objects, 
+ * requiredKeysArray should be an array of strings or objects,
  *   { key: 'propertyName', purpose: 'describe need' }
- * error handling will fallback to less useful messages 
+ * error handling will fallback to less useful messages
  * if an array of strings is provided instead of the key and purpose objects
  */
 
-exports.validate = function(callingFunctionPath, parameterObject, requiredKeysArray) {
+exports.validate = function (callingFunctionPath, parameterObject, requiredKeysArray) {
   let errorMessage = '';
-  requiredKeysArray.forEach(data => {
+  requiredKeysArray.forEach((data) => {
     if (module.exports.isString(data)) {
       // Support "lazy" requiredKeysArray of just ['propertyName']
       if (parameterObject[data] === undefined || parameterObject[data] === null || parameterObject[data].length < 1) {
@@ -20,7 +20,11 @@ exports.validate = function(callingFunctionPath, parameterObject, requiredKeysAr
       }
     } else if (module.exports.isObject(data) && data.key && data.purpose) {
       // Support "useful" requiredKeysArray of [{ key: 'propertyName', purpose: 'I need it' }]
-      if (parameterObject[data.key] === undefined || parameterObject[data.key] === null || parameterObject[data.key].length < 1) {
+      if (
+        parameterObject[data.key] === undefined ||
+        parameterObject[data.key] === null ||
+        parameterObject[data.key].length < 1
+      ) {
         errorMessage += `(${callingFunctionPath}) Missing ${data.key}: ${data.purpose}`;
       }
     } else {
@@ -29,20 +33,24 @@ exports.validate = function(callingFunctionPath, parameterObject, requiredKeysAr
     }
   });
   return errorMessage;
-}
+};
 
-exports.isBoolean = function(data) {
+exports.isBoolean = function (data) {
   let valueToCheck = data;
   if (module.exports.isString(valueToCheck)) {
     valueToCheck = Boolean(data);
   }
-  return valueToCheck === true || valueToCheck === false || Object.prototype.toString.call(valueToCheck) === '[object Boolean]';
-}
+  return (
+    valueToCheck === true ||
+    valueToCheck === false ||
+    Object.prototype.toString.call(valueToCheck) === '[object Boolean]'
+  );
+};
 
-exports.isString = function(data) {
+exports.isString = function (data) {
   return typeof data === 'string' || data instanceof String;
-}
+};
 
-exports.isObject = function(data) {
+exports.isObject = function (data) {
   return Object.prototype.toString.call(data) === '[object Object]';
-}
+};

--- a/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
+++ b/serverless-functions/src/functions/common/helpers/parameter-validator.private.js
@@ -10,7 +10,7 @@
  * if an array of strings is provided instead of the key and purpose objects
  */
 
-exports.validate = function (callingFunctionPath, parameterObject, requiredKeysArray) {
+exports.validate = (callingFunctionPath, parameterObject, requiredKeysArray) => {
   let errorMessage = '';
   requiredKeysArray.forEach((data) => {
     if (module.exports.isString(data)) {
@@ -35,7 +35,7 @@ exports.validate = function (callingFunctionPath, parameterObject, requiredKeysA
   return errorMessage;
 };
 
-exports.isBoolean = function (data) {
+exports.isBoolean = (data) => {
   let valueToCheck = data;
   if (module.exports.isString(valueToCheck)) {
     valueToCheck = Boolean(data);
@@ -47,10 +47,10 @@ exports.isBoolean = function (data) {
   );
 };
 
-exports.isString = function (data) {
+exports.isString = (data) => {
   return typeof data === 'string' || data instanceof String;
 };
 
-exports.isObject = function (data) {
+exports.isObject = (data) => {
   return Object.prototype.toString.call(data) === '[object Object]';
 };

--- a/serverless-functions/src/functions/common/helpers/prepare-function.private.js
+++ b/serverless-functions/src/functions/common/helpers/prepare-function.private.js
@@ -15,8 +15,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
     console.error(`(${context.PATH}) invalid parameters passed`);
     response.setStatusCode(400);
     response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
+    return callback(null, response);
   }
 
   const handleError = (error) => {
@@ -26,7 +25,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
       success: false,
       message: error,
     });
-    callback(null, response);
+    return callback(null, response);
   };
 
   return handlerFn(context, event, callback, response, handleError);

--- a/serverless-functions/src/functions/common/helpers/prepare-function.private.js
+++ b/serverless-functions/src/functions/common/helpers/prepare-function.private.js
@@ -1,21 +1,16 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
 
 const prepareFunction = (context, event, callback, requiredParameters, handlerFn) => {
   const response = new Twilio.Response();
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
-  
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST GET");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-  
+  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
+
+  response.appendHeader('Access-Control-Allow-Origin', '*');
+  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST GET');
+  response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   if (parameterError) {
     console.error(`(${context.PATH}) invalid parameters passed`);
     response.setStatusCode(400);
@@ -23,7 +18,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
     callback(null, response);
     return;
   }
-  
+
   const handleError = (error) => {
     console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
     response.setStatusCode(500);
@@ -32,8 +27,8 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
       message: error,
     });
     callback(null, response);
-  }
-  
+  };
+
   return handlerFn(context, event, callback, response, handleError);
 };
 
@@ -45,7 +40,9 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
  * @param handlerFn             the Twilio Runtime handler function to execute
  */
 exports.prepareFlexFunction = (requiredParameters, handlerFn) => {
-  return TokenValidator((context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn));
+  return TokenValidator((context, event, callback) =>
+    prepareFunction(context, event, callback, requiredParameters, handlerFn),
+  );
 };
 
 /**

--- a/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
@@ -36,7 +36,7 @@ exports.coachToggle = async function coachToggle(parameters) {
     });
     return { success: true, updatedConference, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.coachToggle);
   }
 };
 
@@ -68,7 +68,7 @@ exports.bargeToggle = async function bargeToggle(parameters) {
     });
     return { success: true, updatedConference, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.bargeToggle);
   }
 };
 
@@ -102,7 +102,7 @@ exports.addParticipant = async (parameters) => {
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.addParticipant);
   }
 };
 
@@ -133,7 +133,7 @@ exports.holdParticipant = async (parameters) => {
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.holdParticipant);
   }
 };
 
@@ -160,7 +160,7 @@ exports.removeParticipant = async (parameters) => {
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.removeParticipant);
   }
 };
 
@@ -187,7 +187,7 @@ exports.fetchParticipant = async (parameters) => {
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchParticipant);
   }
 };
 
@@ -219,7 +219,7 @@ exports.updateParticipant = async (parameters) => {
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateParticipant);
   }
 };
 
@@ -252,7 +252,7 @@ exports.fetchByTask = async (parameters) => {
 
     return { success: true, conferences, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchByTask);
   }
 };
 
@@ -279,6 +279,6 @@ exports.updateConference = async (parameters) => {
 
     return { success: true, conferencesResponse, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateConference);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
@@ -18,14 +18,18 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.coachToggle = async function coachToggle(parameters) {
   const { context, conferenceSid, participantSid, agentSid, muted, coaching, attempts } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conferenceSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain conferenceSid string');
   if (!isString(participantSid))
-    throw 'Invalid parameters object passed. Parameters must contain participantSid string';
-  if (!isString(agentSid)) throw 'Invalid parameters object passed. Parameters must contain agentSid string';
-  if (!isString(muted)) throw 'Invalid parameters object passed. Parameters must contain muted boolean';
-  if (!isString(coaching)) throw 'Invalid parameters object passed. Parameters must contain coaching boolean';
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+    throw new Error('Invalid parameters object passed. Parameters must contain participantSid string');
+  if (!isString(agentSid)) throw new Error('Invalid parameters object passed. Parameters must contain agentSid string');
+  if (!isString(muted)) throw new Error('Invalid parameters object passed. Parameters must contain muted boolean');
+  if (!isString(coaching))
+    throw new Error('Invalid parameters object passed. Parameters must contain coaching boolean');
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   try {
     const client = context.getTwilioClient();
 
@@ -54,12 +58,15 @@ exports.coachToggle = async function coachToggle(parameters) {
 exports.bargeToggle = async function bargeToggle(parameters) {
   const { context, conferenceSid, participantSid, muted, attempts } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conferenceSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain conferenceSid string');
   if (!isString(participantSid))
-    throw 'Invalid parameters object passed. Parameters must contain participantSid string';
-  if (!isString(muted)) throw 'Invalid parameters object passed. Parameters must contain muted boolean';
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+    throw new Error('Invalid parameters object passed. Parameters must contain participantSid string');
+  if (!isString(muted)) throw new Error('Invalid parameters object passed. Parameters must contain muted boolean');
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   try {
     const client = context.getTwilioClient();
 
@@ -85,10 +92,11 @@ exports.bargeToggle = async function bargeToggle(parameters) {
 exports.addParticipant = async (parameters) => {
   const { context, taskSid, to, from } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
-  if (!isString(to)) throw 'Invalid parameters object passed. Parameters must contain to string';
-  if (!isString(from)) throw 'Invalid parameters object passed. Parameters must contain from string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
+  if (!isString(to)) throw new Error('Invalid parameters object passed. Parameters must contain to string');
+  if (!isString(from)) throw new Error('Invalid parameters object passed. Parameters must contain from string');
 
   try {
     const client = context.getTwilioClient();
@@ -119,10 +127,13 @@ exports.addParticipant = async (parameters) => {
 exports.holdParticipant = async (parameters) => {
   const { context, conference, participant, hold } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
-  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
-  if (!isBoolean(hold)) throw 'Invalid parameters object passed. Parameters must contain hold boolean';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conference))
+    throw new Error('Invalid parameters object passed. Parameters must contain conference string');
+  if (!isString(participant))
+    throw new Error('Invalid parameters object passed. Parameters must contain participant string');
+  if (!isBoolean(hold)) throw new Error('Invalid parameters object passed. Parameters must contain hold boolean');
 
   try {
     const client = context.getTwilioClient();
@@ -149,9 +160,12 @@ exports.holdParticipant = async (parameters) => {
 exports.removeParticipant = async (parameters) => {
   const { context, conference, participant } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
-  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conference))
+    throw new Error('Invalid parameters object passed. Parameters must contain conference string');
+  if (!isString(participant))
+    throw new Error('Invalid parameters object passed. Parameters must contain participant string');
 
   try {
     const client = context.getTwilioClient();
@@ -176,9 +190,12 @@ exports.removeParticipant = async (parameters) => {
 exports.fetchParticipant = async (parameters) => {
   const { context, conference, participant } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
-  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conference))
+    throw new Error('Invalid parameters object passed. Parameters must contain conference string');
+  if (!isString(participant))
+    throw new Error('Invalid parameters object passed. Parameters must contain participant string');
 
   try {
     const client = context.getTwilioClient();
@@ -204,11 +221,14 @@ exports.fetchParticipant = async (parameters) => {
 exports.updateParticipant = async (parameters) => {
   const { context, conference, participant, endConferenceOnExit } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
-  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conference))
+    throw new Error('Invalid parameters object passed. Parameters must contain conference string');
+  if (!isString(participant))
+    throw new Error('Invalid parameters object passed. Parameters must contain participant string');
   if (!isBoolean(endConferenceOnExit))
-    throw 'Invalid parameters object passed. Parameters must contain endConferenceOnExit boolean';
+    throw new Error('Invalid parameters object passed. Parameters must contain endConferenceOnExit boolean');
 
   try {
     const client = context.getTwilioClient();
@@ -236,10 +256,11 @@ exports.updateParticipant = async (parameters) => {
 exports.fetchByTask = async (parameters) => {
   const { context, taskSid, status, limit } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
-  if (!isString(status)) throw 'Invalid parameters object passed. Parameters must contain status string';
-  if (!isNumber(limit)) throw 'Invalid parameters object passed. Parameters must contain limit number';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
+  if (!isString(status)) throw new Error('Invalid parameters object passed. Parameters must contain status string');
+  if (!isNumber(limit)) throw new Error('Invalid parameters object passed. Parameters must contain limit number');
 
   try {
     const client = context.getTwilioClient();
@@ -268,9 +289,12 @@ exports.fetchByTask = async (parameters) => {
 exports.updateConference = async (parameters) => {
   const { context, conference, updateParams } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
-  if (!isObject(updateParams)) throw 'Invalid parameters object passed. Parameters must contain updateParams object';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conference))
+    throw new Error('Invalid parameters object passed. Parameters must contain conference string');
+  if (!isObject(updateParams))
+    throw new Error('Invalid parameters object passed. Parameters must contain updateParams object');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
@@ -1,8 +1,6 @@
-const { isString, isObject, isNumber, isBoolean } = require("lodash");
+const { isString, isObject, isNumber, isBoolean } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -18,41 +16,24 @@ const retryHandler = require(Runtime.getFunctions()[
  *      within the defined conference
  */
 exports.coachToggle = async function coachToggle(parameters) {
-  const {
-    context,
-    conferenceSid,
-    participantSid,
-    agentSid,
-    muted,
-    coaching,
-    attempts,
-  } = parameters;
+  const { context, conferenceSid, participantSid, agentSid, muted, coaching, attempts } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conferenceSid))
-    throw "Invalid parameters object passed. Parameters must contain conferenceSid string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
   if (!isString(participantSid))
-    throw "Invalid parameters object passed. Parameters must contain participantSid string";
-  if (!isString(agentSid))
-    throw "Invalid parameters object passed. Parameters must contain agentSid string";
-  if (!isString(muted))
-    throw "Invalid parameters object passed. Parameters must contain muted boolean";
-  if (!isString(coaching))
-    throw "Invalid parameters object passed. Parameters must contain coaching boolean";
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
+    throw 'Invalid parameters object passed. Parameters must contain participantSid string';
+  if (!isString(agentSid)) throw 'Invalid parameters object passed. Parameters must contain agentSid string';
+  if (!isString(muted)) throw 'Invalid parameters object passed. Parameters must contain muted boolean';
+  if (!isString(coaching)) throw 'Invalid parameters object passed. Parameters must contain coaching boolean';
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
   try {
     const client = context.getTwilioClient();
 
-    const updatedConference = await client
-      .conferences(conferenceSid)
-      .participants(participantSid)
-      .update({
-        coaching: coaching,
-        callSidToCoach: agentSid,
-        muted: muted,
-      });
+    const updatedConference = await client.conferences(conferenceSid).participants(participantSid).update({
+      coaching,
+      callSidToCoach: agentSid,
+      muted,
+    });
     return { success: true, updatedConference, status: 200 };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
@@ -71,33 +52,20 @@ exports.coachToggle = async function coachToggle(parameters) {
  *      within the defined conference
  */
 exports.bargeToggle = async function bargeToggle(parameters) {
-  const {
-    context,
-    conferenceSid,
-    participantSid,
-    muted,
-    attempts,
-  } = parameters;
+  const { context, conferenceSid, participantSid, muted, attempts } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conferenceSid))
-    throw "Invalid parameters object passed. Parameters must contain conferenceSid string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
   if (!isString(participantSid))
-    throw "Invalid parameters object passed. Parameters must contain participantSid string";
-  if (!isString(muted))
-    throw "Invalid parameters object passed. Parameters must contain muted boolean";
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
+    throw 'Invalid parameters object passed. Parameters must contain participantSid string';
+  if (!isString(muted)) throw 'Invalid parameters object passed. Parameters must contain muted boolean';
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
   try {
     const client = context.getTwilioClient();
 
-    const updatedConference = await client
-      .conferences(conferenceSid)
-      .participants(participantSid)
-      .update({
-        muted: muted,
-      });
+    const updatedConference = await client.conferences(conferenceSid).participants(participantSid).update({
+      muted,
+    });
     return { success: true, updatedConference, status: 200 };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
@@ -117,26 +85,20 @@ exports.bargeToggle = async function bargeToggle(parameters) {
 exports.addParticipant = async (parameters) => {
   const { context, taskSid, to, from } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain taskSid string";
-  if (!isString(to))
-    throw "Invalid parameters object passed. Parameters must contain to string";
-  if (!isString(from))
-    throw "Invalid parameters object passed. Parameters must contain from string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
+  if (!isString(to)) throw 'Invalid parameters object passed. Parameters must contain to string';
+  if (!isString(from)) throw 'Invalid parameters object passed. Parameters must contain from string';
 
   try {
     const client = context.getTwilioClient();
 
-    const participantsResponse = await client
-      .conferences(taskSid)
-      .participants.create({
-        to,
-        from,
-        earlyMedia: true,
-        endConferenceOnExit: false,
-      });
+    const participantsResponse = await client.conferences(taskSid).participants.create({
+      to,
+      from,
+      earlyMedia: true,
+      endConferenceOnExit: false,
+    });
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
@@ -157,24 +119,17 @@ exports.addParticipant = async (parameters) => {
 exports.holdParticipant = async (parameters) => {
   const { context, conference, participant, hold } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conference))
-    throw "Invalid parameters object passed. Parameters must contain conference string";
-  if (!isString(participant))
-    throw "Invalid parameters object passed. Parameters must contain participant string";
-  if (!isBoolean(hold))
-    throw "Invalid parameters object passed. Parameters must contain hold boolean";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
+  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
+  if (!isBoolean(hold)) throw 'Invalid parameters object passed. Parameters must contain hold boolean';
 
   try {
     const client = context.getTwilioClient();
 
-    const participantsResponse = await client
-      .conferences(conference)
-      .participants(participant)
-      .update({
-        hold,
-      });
+    const participantsResponse = await client.conferences(conference).participants(participant).update({
+      hold,
+    });
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
@@ -194,20 +149,14 @@ exports.holdParticipant = async (parameters) => {
 exports.removeParticipant = async (parameters) => {
   const { context, conference, participant } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conference))
-    throw "Invalid parameters object passed. Parameters must contain conference string";
-  if (!isString(participant))
-    throw "Invalid parameters object passed. Parameters must contain participant string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
+  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
 
   try {
     const client = context.getTwilioClient();
 
-    const participantsResponse = await client
-      .conferences(conference)
-      .participants(participant)
-      .remove();
+    const participantsResponse = await client.conferences(conference).participants(participant).remove();
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
@@ -225,34 +174,22 @@ exports.removeParticipant = async (parameters) => {
  * @description fetch the given conference participant
  */
 exports.fetchParticipant = async (parameters) => {
-    
-    const { context, conference, participant } = parameters;
+  const { context, conference, participant } = parameters;
 
-    if(!isObject(context))
-        throw "Invalid parameters object passed. Parameters must contain reason context object";
-    if(!isString(conference))
-        throw "Invalid parameters object passed. Parameters must contain conference string";
-    if(!isString(participant))
-        throw "Invalid parameters object passed. Parameters must contain participant string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
+  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
 
-    try {
-        const client = context.getTwilioClient();
-        
-        const participantsResponse = await client
-            .conferences(conference)
-            .participants(participant)
-            .fetch();
+  try {
+    const client = context.getTwilioClient();
 
-        return { success: true, participantsResponse, status: 200 };
-    }
-    catch (error) {
-        return retryHandler(
-            error, 
-            parameters,
-            arguments.callee
-        )
-    }
-}
+    const participantsResponse = await client.conferences(conference).participants(participant).fetch();
+
+    return { success: true, participantsResponse, status: 200 };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
+  }
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -267,24 +204,18 @@ exports.fetchParticipant = async (parameters) => {
 exports.updateParticipant = async (parameters) => {
   const { context, conference, participant, endConferenceOnExit } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conference))
-    throw "Invalid parameters object passed. Parameters must contain conference string";
-  if (!isString(participant))
-    throw "Invalid parameters object passed. Parameters must contain participant string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
+  if (!isString(participant)) throw 'Invalid parameters object passed. Parameters must contain participant string';
   if (!isBoolean(endConferenceOnExit))
-    throw "Invalid parameters object passed. Parameters must contain endConferenceOnExit boolean";
+    throw 'Invalid parameters object passed. Parameters must contain endConferenceOnExit boolean';
 
   try {
     const client = context.getTwilioClient();
 
-    const participantsResponse = await client
-      .conferences(conference)
-      .participants(participant)
-      .update({
-        endConferenceOnExit,
-      });
+    const participantsResponse = await client.conferences(conference).participants(participant).update({
+      endConferenceOnExit,
+    });
 
     return { success: true, participantsResponse, status: 200 };
   } catch (error) {
@@ -305,36 +236,25 @@ exports.updateParticipant = async (parameters) => {
 exports.fetchByTask = async (parameters) => {
   const { context, taskSid, status, limit } = parameters;
 
-  if(!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if(!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain taskSid string";
-  if(!isString(status))
-    throw "Invalid parameters object passed. Parameters must contain status string";
-  if(!isNumber(limit))
-    throw "Invalid parameters object passed. Parameters must contain limit number";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
+  if (!isString(status)) throw 'Invalid parameters object passed. Parameters must contain status string';
+  if (!isNumber(limit)) throw 'Invalid parameters object passed. Parameters must contain limit number';
 
   try {
     const client = context.getTwilioClient();
-    
-    const conferences = await client
-      .conferences
-      .list({
-        friendlyName: taskSid, 
-        status,
-        limit
-      });
+
+    const conferences = await client.conferences.list({
+      friendlyName: taskSid,
+      status,
+      limit,
+    });
 
     return { success: true, conferences, status: 200 };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-      error, 
-      parameters,
-      arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -348,27 +268,17 @@ exports.fetchByTask = async (parameters) => {
 exports.updateConference = async (parameters) => {
   const { context, conference, updateParams } = parameters;
 
-  if(!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if(!isString(conference))
-    throw "Invalid parameters object passed. Parameters must contain conference string";
-  if(!isObject(updateParams))
-    throw "Invalid parameters object passed. Parameters must contain updateParams object";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conference)) throw 'Invalid parameters object passed. Parameters must contain conference string';
+  if (!isObject(updateParams)) throw 'Invalid parameters object passed. Parameters must contain updateParams object';
 
   try {
     const client = context.getTwilioClient();
-    
-    const conferencesResponse = await client
-      .conferences(conference)
-      .update(updateParams);
+
+    const conferencesResponse = await client.conferences(conference).update(updateParams);
 
     return { success: true, conferencesResponse, status: 200 };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-      error, 
-      parameters,
-      arguments.callee
-    )
-  }
-}
+};

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -1,8 +1,6 @@
-const { isString, isObject, isNumber } = require("lodash");
+const { isString, isObject, isNumber } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -15,29 +13,21 @@ const retryHandler = require(Runtime.getFunctions()[
  * @description the following method is used to create an Interaction Channel Invite
  */
 exports.participantCreateInvite = async function (parameters) {
-  const { attempts, context, interactionSid, channelSid, routing } =
-    parameters;
+  const { attempts, context, interactionSid, channelSid, routing } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
   if (!isString(interactionSid))
-    throw "Invalid parameters object passed. Parameters must contain interactionSid string value";
-  if (!isString(channelSid))
-    throw "Invalid parameters object passed. Parameters must contain channelSid string value";
-  if (!isObject(routing))
-    throw "Invalid parameters object passed. Parameters must contain routing object";
+    throw 'Invalid parameters object passed. Parameters must contain interactionSid string value';
+  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string value';
+  if (!isObject(routing)) throw 'Invalid parameters object passed. Parameters must contain routing object';
 
   try {
     const client = context.getTwilioClient();
 
-    const participantInvite = await client.flexApi.v1
-      .interaction(interactionSid)
-      .channels(channelSid)
-      .invites.create({
-        routing: routing,
-      });
+    const participantInvite = await client.flexApi.v1.interaction(interactionSid).channels(channelSid).invites.create({
+      routing,
+    });
 
     return { success: true, status: 200, participantInvite };
   } catch (error) {
@@ -57,27 +47,16 @@ exports.participantCreateInvite = async function (parameters) {
  * @description the following method is used to update/modify a channel participant
  */
 exports.participantUpdate = async function (parameters) {
-  const {
-    attempts,
-    context,
-    interactionSid,
-    channelSid,
-    participantSid,
-    status,
-  } = parameters;
+  const { attempts, context, interactionSid, channelSid, participantSid, status } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
   if (!isString(interactionSid))
-    throw "Invalid parameters object passed. Parameters must contain interactionSid string value";
-  if (!isString(channelSid))
-    throw "Invalid parameters object passed. Parameters must contain channelSid string value";
+    throw 'Invalid parameters object passed. Parameters must contain interactionSid string value';
+  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string value';
   if (!isString(participantSid))
-    throw "Invalid parameters object passed. Parameters must contain participantSid string value";
-  if (!isString(status))
-    throw "Invalid parameters object passed. Parameters must contain status string value";
+    throw 'Invalid parameters object passed. Parameters must contain participantSid string value';
+  if (!isString(status)) throw 'Invalid parameters object passed. Parameters must contain status string value';
 
   try {
     const client = context.getTwilioClient();
@@ -85,7 +64,7 @@ exports.participantUpdate = async function (parameters) {
       .interaction(interactionSid)
       .channels(channelSid)
       .participants(participantSid)
-      .update({ status: status });
+      .update({ status });
 
     return { success: true, status: 200, updatedParticipant };
   } catch (error) {

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -12,7 +12,7 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
  * @returns {object} An object containing details about the interaction channel invite
  * @description the following method is used to create an Interaction Channel Invite
  */
-exports.participantCreateInvite = async function (parameters) {
+exports.participantCreateInvite = async (parameters) => {
   const { attempts, context, interactionSid, channelSid, routing } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -46,7 +46,7 @@ exports.participantCreateInvite = async function (parameters) {
  * @returns {object} An object containing an array of queues for the account
  * @description the following method is used to update/modify a channel participant
  */
-exports.participantUpdate = async function (parameters) {
+exports.participantUpdate = async (parameters) => {
   const { attempts, context, interactionSid, channelSid, participantSid, status } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -15,12 +15,14 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.participantCreateInvite = async (parameters) => {
   const { attempts, context, interactionSid, channelSid, routing } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(interactionSid))
-    throw 'Invalid parameters object passed. Parameters must contain interactionSid string value';
-  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string value';
-  if (!isObject(routing)) throw 'Invalid parameters object passed. Parameters must contain routing object';
+    throw new Error('Invalid parameters object passed. Parameters must contain interactionSid string value');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string value');
+  if (!isObject(routing)) throw new Error('Invalid parameters object passed. Parameters must contain routing object');
 
   try {
     const client = context.getTwilioClient();
@@ -49,14 +51,17 @@ exports.participantCreateInvite = async (parameters) => {
 exports.participantUpdate = async (parameters) => {
   const { attempts, context, interactionSid, channelSid, participantSid, status } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(interactionSid))
-    throw 'Invalid parameters object passed. Parameters must contain interactionSid string value';
-  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain interactionSid string value');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string value');
   if (!isString(participantSid))
-    throw 'Invalid parameters object passed. Parameters must contain participantSid string value';
-  if (!isString(status)) throw 'Invalid parameters object passed. Parameters must contain status string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain participantSid string value');
+  if (!isString(status))
+    throw new Error('Invalid parameters object passed. Parameters must contain status string value');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -31,7 +31,7 @@ exports.participantCreateInvite = async (parameters) => {
 
     return { success: true, status: 200, participantInvite };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.participantCreateInvite);
   }
 };
 
@@ -68,6 +68,6 @@ exports.participantUpdate = async (parameters) => {
 
     return { success: true, status: 200, updatedParticipant };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.participantUpdate);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
@@ -21,6 +21,6 @@ exports.listPhoneNumbers = async function listPhoneNumbers(parameters) {
 
     return { success: true, phoneNumbers, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.listPhoneNumbers);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
@@ -1,7 +1,6 @@
-const { isObject } = require("lodash");
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const { isObject } = require('lodash');
+
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -12,8 +11,7 @@ const retryHandler = require(Runtime.getFunctions()[
  *   the phone numbers for the account
  */
 exports.listPhoneNumbers = async function listPhoneNumbers(parameters) {
-  if (!isObject(parameters.context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isObject(parameters.context)) throw 'Invalid parameters object passed. Parameters must contain context object';
 
   try {
     const client = parameters.context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/phone-numbers.private.js
@@ -11,7 +11,8 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
  *   the phone numbers for the account
  */
 exports.listPhoneNumbers = async function listPhoneNumbers(parameters) {
-  if (!isObject(parameters.context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isObject(parameters.context))
+    throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = parameters.context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -12,7 +12,7 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
  * @description the following method is used to apply attributes
  *    to the channel object
  */
-exports.updateChannelAttributes = async function (parameters) {
+exports.updateChannelAttributes = async (parameters) => {
   const { attempts, context, channelSid, attributes } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -1,8 +1,6 @@
-const { isString, isObject, isNumber } = require("lodash");
+const { isString, isObject, isNumber } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -17,28 +15,21 @@ const retryHandler = require(Runtime.getFunctions()[
 exports.updateChannelAttributes = async function (parameters) {
   const { attempts, context, channelSid, attributes } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(channelSid))
-    throw "Invalid parameters object passed. Parameters must contain channelSid string";
-  if (!isString(attributes))
-    throw "Invalid parameters object passed. Parameters must contain attributes string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
+  if (!isString(attributes)) throw 'Invalid parameters object passed. Parameters must contain attributes string';
 
   try {
     const client = context.getTwilioClient();
-    const channel = await client.chat
-      .services(context.TWILIO_FLEX_CHAT_SERVICE_SID)
-      .channels(channelSid)
-      .fetch();
+    const channel = await client.chat.services(context.TWILIO_FLEX_CHAT_SERVICE_SID).channels(channelSid).fetch();
 
-    if (!channel) return { success: false, message: "channel not found" };
+    if (!channel) return { success: false, message: 'channel not found' };
 
     const updatedChannel = await client.chat
       .services(context.TWILIO_FLEX_CHAT_SERVICE_SID)
       .channels(channelSid)
-      .update({ attributes: attributes });
+      .update({ attributes });
 
     return { success: true, status: 200, channel: updatedChannel };
   } catch (error) {

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -15,10 +15,13 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.updateChannelAttributes = async (parameters) => {
   const { attempts, context, channelSid, attributes } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
-  if (!isString(attributes)) throw 'Invalid parameters object passed. Parameters must contain attributes string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');
+  if (!isString(attributes))
+    throw new Error('Invalid parameters object passed. Parameters must contain attributes string');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -33,6 +33,6 @@ exports.updateChannelAttributes = async (parameters) => {
 
     return { success: true, status: 200, channel: updatedChannel };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateChannelAttributes);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -23,7 +23,7 @@ exports.fetchProperties = async (parameters) => {
 
     return { success: true, callProperties, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchProperties);
   }
 };
 
@@ -52,7 +52,7 @@ exports.coldTransfer = async (parameters) => {
 
     return { success: true, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.coldTransfer);
   }
 };
 
@@ -78,7 +78,7 @@ exports.createRecording = async (parameters) => {
 
     return { success: true, recording, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.createRecording);
   }
 };
 
@@ -107,7 +107,7 @@ exports.updateCallRecording = async (parameters) => {
 
     return { success: true, recording, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateCallRecording);
   }
 };
 
@@ -136,7 +136,7 @@ exports.updateConferenceRecording = async (parameters) => {
 
     return { success: true, recording, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateConferenceRecording);
   }
 };
 
@@ -163,6 +163,6 @@ exports.updateCall = async (parameters) => {
 
     return { success: true, call, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateCall);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -13,8 +13,9 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.fetchProperties = async (parameters) => {
   const { context, callSid } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(callSid)) throw new Error('Invalid parameters object passed. Parameters must contain callSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -39,9 +40,10 @@ exports.fetchProperties = async (parameters) => {
 exports.coldTransfer = async (parameters) => {
   const { context, callSid, to } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
-  if (!isString(to)) throw 'Invalid parameters object passed. Parameters must contain to string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(callSid)) throw new Error('Invalid parameters object passed. Parameters must contain callSid string');
+  if (!isString(to)) throw new Error('Invalid parameters object passed. Parameters must contain to string');
 
   try {
     const client = context.getTwilioClient();
@@ -68,8 +70,9 @@ exports.coldTransfer = async (parameters) => {
 exports.createRecording = async (parameters) => {
   const { context, callSid, params } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(callSid)) throw new Error('Invalid parameters object passed. Parameters must contain callSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -95,10 +98,12 @@ exports.createRecording = async (parameters) => {
 exports.updateCallRecording = async (parameters) => {
   const { context, callSid, recordingSid, params } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
-  if (!isString(recordingSid)) throw 'Invalid parameters object passed. Parameters must contain recordingSid string';
-  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(callSid)) throw new Error('Invalid parameters object passed. Parameters must contain callSid string');
+  if (!isString(recordingSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain recordingSid string');
+  if (!isObject(params)) throw new Error('Invalid parameters object passed. Parameters must contain params object');
 
   try {
     const client = context.getTwilioClient();
@@ -124,10 +129,13 @@ exports.updateCallRecording = async (parameters) => {
 exports.updateConferenceRecording = async (parameters) => {
   const { context, conferenceSid, recordingSid, params } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
-  if (!isString(recordingSid)) throw 'Invalid parameters object passed. Parameters must contain recordingSid string';
-  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(conferenceSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain conferenceSid string');
+  if (!isString(recordingSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain recordingSid string');
+  if (!isObject(params)) throw new Error('Invalid parameters object passed. Parameters must contain params object');
 
   try {
     const client = context.getTwilioClient();
@@ -152,9 +160,10 @@ exports.updateConferenceRecording = async (parameters) => {
 exports.updateCall = async (parameters) => {
   const { context, callSid, params } = parameters;
 
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
-  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
+  if (!isString(callSid)) throw new Error('Invalid parameters object passed. Parameters must contain callSid string');
+  if (!isObject(params)) throw new Error('Invalid parameters object passed. Parameters must contain params object');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -1,8 +1,6 @@
-const { isString, isObject } = require("lodash");
+const { isString, isObject } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -15,10 +13,8 @@ const retryHandler = require(Runtime.getFunctions()[
 exports.fetchProperties = async (parameters) => {
   const { context, callSid } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(callSid))
-    throw "Invalid parameters object passed. Parameters must contain callSid string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
 
   try {
     const client = context.getTwilioClient();
@@ -43,12 +39,9 @@ exports.fetchProperties = async (parameters) => {
 exports.coldTransfer = async (parameters) => {
   const { context, callSid, to } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(callSid))
-    throw "Invalid parameters object passed. Parameters must contain callSid string";
-  if (!isString(to))
-    throw "Invalid parameters object passed. Parameters must contain to string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
+  if (!isString(to)) throw 'Invalid parameters object passed. Parameters must contain to string';
 
   try {
     const client = context.getTwilioClient();
@@ -75,10 +68,8 @@ exports.coldTransfer = async (parameters) => {
 exports.createRecording = async (parameters) => {
   const { context, callSid, params } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(callSid))
-    throw "Invalid parameters object passed. Parameters must contain callSid string";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
 
   try {
     const client = context.getTwilioClient();
@@ -104,14 +95,10 @@ exports.createRecording = async (parameters) => {
 exports.updateCallRecording = async (parameters) => {
   const { context, callSid, recordingSid, params } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(callSid))
-    throw "Invalid parameters object passed. Parameters must contain callSid string";
-  if (!isString(recordingSid))
-    throw "Invalid parameters object passed. Parameters must contain recordingSid string";
-  if (!isObject(params))
-    throw "Invalid parameters object passed. Parameters must contain params object";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
+  if (!isString(recordingSid)) throw 'Invalid parameters object passed. Parameters must contain recordingSid string';
+  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
 
   try {
     const client = context.getTwilioClient();
@@ -137,14 +124,10 @@ exports.updateCallRecording = async (parameters) => {
 exports.updateConferenceRecording = async (parameters) => {
   const { context, conferenceSid, recordingSid, params } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(conferenceSid))
-    throw "Invalid parameters object passed. Parameters must contain conferenceSid string";
-  if (!isString(recordingSid))
-    throw "Invalid parameters object passed. Parameters must contain recordingSid string";
-  if (!isObject(params))
-    throw "Invalid parameters object passed. Parameters must contain params object";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(conferenceSid)) throw 'Invalid parameters object passed. Parameters must contain conferenceSid string';
+  if (!isString(recordingSid)) throw 'Invalid parameters object passed. Parameters must contain recordingSid string';
+  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
 
   try {
     const client = context.getTwilioClient();
@@ -169,12 +152,9 @@ exports.updateConferenceRecording = async (parameters) => {
 exports.updateCall = async (parameters) => {
   const { context, callSid, params } = parameters;
 
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(callSid))
-    throw "Invalid parameters object passed. Parameters must contain callSid string";
-  if (!isObject(params))
-    throw "Invalid parameters object passed. Parameters must contain params object";
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(callSid)) throw 'Invalid parameters object passed. Parameters must contain callSid string';
+  if (!isObject(params)) throw 'Invalid parameters object passed. Parameters must contain params object';
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
@@ -31,11 +31,11 @@ exports.retryHandler = async (error, parameters, callback) => {
   const { attempts, context } = parameters;
   const { response, message: errorMessage } = error;
   const status = response ? response.status : 500;
-  const logWarning = attempts == 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
+  const logWarning = attempts === 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
   const message = errorMessage ? errorMessage : error;
 
   if (
-    (status == 412 || status == 429 || status == 503) &&
+    (status === 412 || status === 429 || status === 503) &&
     isNumber(attempts) &&
     attempts < TWILIO_SERVICE_RETRY_LIMIT
   ) {

--- a/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
@@ -1,6 +1,6 @@
-const { random, isNumber, isString } = require("lodash");
+const { random, isNumber, isString } = require('lodash');
 
-snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
+snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * @param {object} error the error from the calling function
@@ -8,55 +8,46 @@ snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {function} callback the callback function to retry
  * @returns {any}
- * @description the following method is used as a generic retry handler for method 
+ * @description the following method is used as a generic retry handler for method
  *   calls to the twilio client where the response code is 412, 429 or 503.
  *   Although there is a maximum runtime for twilio functions
  *   it is beneficial to retry from within the twilio function as the overhead
- *   of the retry is much lower from within the twilio function 
+ *   of the retry is much lower from within the twilio function
  *   (as its in the same data center) than to go all
- *   the way back to the calling client and retry from there. 
- * 
- *   this is particularly useful if doing a multi transactional 
+ *   the way back to the calling client and retry from there.
+ *
+ *   this is particularly useful if doing a multi transactional
  *   operation from a single twilio function call as it helps minimize
  *   failures here from the occasional 412 or 429 in particular
- *  
+ *
  *   NOTE: Status codes should still be passed back and
  *   retry handler in the browser are still encouraged.
  */
 exports.retryHandler = async (error, parameters, callback) => {
+  if (!isNumber(parameters.attempts))
+    throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
 
-  if(!isNumber(parameters.attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-
-  const { 
-    TWILIO_SERVICE_MAX_BACKOFF, 
-    TWILIO_SERVICE_MIN_BACKOFF, 
-    TWILIO_SERVICE_RETRY_LIMIT } = process.env;
+  const { TWILIO_SERVICE_MAX_BACKOFF, TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_RETRY_LIMIT } = process.env;
   const { attempts, context } = parameters;
   const { response, message: errorMessage } = error;
-  const status = response? response.status : 500;
+  const status = response ? response.status : 500;
   const logWarning = attempts == 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
-  const message = errorMessage? errorMessage : error;
+  const message = errorMessage ? errorMessage : error;
 
   if (
-    (status == 412 || status == 429 || status == 503) 
-    && isNumber(attempts)
-    && attempts < TWILIO_SERVICE_RETRY_LIMIT) 
-    {
-      console.warn(`retrying ${context.PATH}.${callback.name}() after ${logWarning}, status code: ${status}`);
-      if(status === 429 || status === 503)
-        await snooze(
-          random(
-            TWILIO_SERVICE_MIN_BACKOFF,
-            TWILIO_SERVICE_MAX_BACKOFF
-            )
-          );
-      
-      const updatedAttempts = attempts+1
-      const updatedParameters = {...parameters, attempts: updatedAttempts};
-      return callback(updatedParameters);
-  } else {
-    console.error(`retrying ${context.PATH}.${callback.name}() failed after ${logWarning}, status code: ${status}, message: ${message}`);
-    return { success: false, message, status };
+    (status == 412 || status == 429 || status == 503) &&
+    isNumber(attempts) &&
+    attempts < TWILIO_SERVICE_RETRY_LIMIT
+  ) {
+    console.warn(`retrying ${context.PATH}.${callback.name}() after ${logWarning}, status code: ${status}`);
+    if (status === 429 || status === 503) await snooze(random(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF));
+
+    const updatedAttempts = attempts + 1;
+    const updatedParameters = { ...parameters, attempts: updatedAttempts };
+    return callback(updatedParameters);
   }
-}
+  console.error(
+    `retrying ${context.PATH}.${callback.name}() failed after ${logWarning}, status code: ${status}, message: ${message}`,
+  );
+  return { success: false, message, status };
+};

--- a/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/retry-handler.private.js
@@ -25,7 +25,7 @@ snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  */
 exports.retryHandler = async (error, parameters, callback) => {
   if (!isNumber(parameters.attempts))
-    throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
 
   const { TWILIO_SERVICE_MAX_BACKOFF, TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_RETRY_LIMIT } = process.env;
   const { attempts, context } = parameters;

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -28,7 +28,7 @@ exports.deleteMapItem = async (parameters) => {
 
     return { success: true, status: 200 };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.deleteMapItem);
   }
 };
 
@@ -58,7 +58,7 @@ exports.fetchMapItem = async (parameters) => {
 
     return { success: true, status: 200, mapItem };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchMapItem);
   }
 };
 
@@ -101,7 +101,7 @@ exports.createMapItem = async (parameters) => {
 
     return { success: true, status: 200, mapItem };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.createMapItem);
   }
 };
 
@@ -138,7 +138,7 @@ exports.createDocument = async (parameters) => {
 
     return { success: true, status: 200, document };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.createDocument);
   }
 };
 
@@ -165,7 +165,7 @@ exports.fetchDocument = async (parameters) => {
 
     return { success: true, status: 200, document };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchDocument);
   }
 };
 
@@ -197,6 +197,6 @@ exports.updateDocumentData = async (parameters) => {
 
     return { success: true, status: 200, document: documentUpdate };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateDocumentData);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -11,7 +11,7 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
  * @returns {object} success
  * @description the following method is used to remove a Sync Map Item
  */
-exports.deleteMapItem = async function (parameters) {
+exports.deleteMapItem = async (parameters) => {
   const { attempts, context, mapSid, key } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -24,11 +24,7 @@ exports.deleteMapItem = async function (parameters) {
   try {
     const client = context.getTwilioClient();
 
-    const mapItem = await client.sync
-      .services(context.TWILIO_FLEX_SYNC_SID)
-      .syncMaps(mapSid)
-      .syncMapItems(key)
-      .remove();
+    await client.sync.services(context.TWILIO_FLEX_SYNC_SID).syncMaps(mapSid).syncMapItems(key).remove();
 
     return { success: true, status: 200 };
   } catch (error) {
@@ -45,7 +41,7 @@ exports.deleteMapItem = async function (parameters) {
  * @returns {object} An existing Sync Map Item
  * @description the following method is used to fetch a Sync Map Item
  */
-exports.fetchMapItem = async function (parameters) {
+exports.fetchMapItem = async (parameters) => {
   const { attempts, context, mapSid, key } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -77,7 +73,7 @@ exports.fetchMapItem = async function (parameters) {
  * @returns {object} A new Sync Map Item
  * @description the following method is used to create a Sync Map Item
  */
-exports.createMapItem = async function (parameters) {
+exports.createMapItem = async (parameters) => {
   const { attempts, context, mapSid, key, ttl, data } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -119,7 +115,7 @@ exports.createMapItem = async function (parameters) {
  * @returns {object} A new Sync document
  * @description the following method is used to create a sync document
  */
-exports.createDocument = async function (parameters) {
+exports.createDocument = async (parameters) => {
   const { attempts, context, uniqueName, ttl, data } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -154,7 +150,7 @@ exports.createDocument = async function (parameters) {
  * @returns {object} A Sync document
  * @description the following method is used to fetch a sync document
  */
-exports.fetchDocument = async function (parameters) {
+exports.fetchDocument = async (parameters) => {
   const { attempts, context, documentSid } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -182,7 +178,7 @@ exports.fetchDocument = async function (parameters) {
  * @returns {object} A Sync document
  * @description the following method is used to fetch a sync document
  */
-exports.updateDocumentData = async function (parameters) {
+exports.updateDocumentData = async (parameters) => {
   const { attempts, context, documentSid, updateData } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -1,8 +1,6 @@
-const { isString, isObject, isNumber } = require("lodash");
+const { isString, isObject, isNumber } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -13,17 +11,15 @@ const retryHandler = require(Runtime.getFunctions()[
  * @returns {object} success
  * @description the following method is used to remove a Sync Map Item
  */
- exports.deleteMapItem = async function (parameters) {
+exports.deleteMapItem = async function (parameters) {
   const { attempts, context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!mapSid && !isString(mapSid))
-    throw "Invalid parameters object passed. Parameters must contain mapSid string value";
-  if (!!key && !isString(key))
-    throw "Invalid parameters object passed. Parameters must contain key string value";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(mapSid) && !isString(mapSid))
+    throw 'Invalid parameters object passed. Parameters must contain mapSid string value';
+  if (Boolean(key) && !isString(key))
+    throw 'Invalid parameters object passed. Parameters must contain key string value';
 
   try {
     const client = context.getTwilioClient();
@@ -31,14 +27,14 @@ const retryHandler = require(Runtime.getFunctions()[
     const mapItem = await client.sync
       .services(context.TWILIO_FLEX_SYNC_SID)
       .syncMaps(mapSid)
-      .syncMapItems(key).remove();
+      .syncMapItems(key)
+      .remove();
 
     return { success: true, status: 200 };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
   }
 };
-
 
 /**
  * @param {object} parameters the parameters for the function
@@ -52,24 +48,19 @@ const retryHandler = require(Runtime.getFunctions()[
 exports.fetchMapItem = async function (parameters) {
   const { attempts, context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!mapSid && !isString(mapSid))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!key && !isString(key))
-    throw "Invalid parameters object passed. Parameters must contain uniqueName string value";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(mapSid) && !isString(mapSid))
+    throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(key) && !isString(key))
+    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
 
   try {
     const client = context.getTwilioClient();
 
-    const mapItem = await client.sync
-      .services(context.TWILIO_FLEX_SYNC_SID)
-      .syncMaps(mapSid)
-      .syncMapItems(key).fetch();
+    const mapItem = await client.sync.services(context.TWILIO_FLEX_SYNC_SID).syncMaps(mapSid).syncMapItems(key).fetch();
 
-    return { success: true, status: 200, mapItem: mapItem };
+    return { success: true, status: 200, mapItem };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
   }
@@ -89,25 +80,22 @@ exports.fetchMapItem = async function (parameters) {
 exports.createMapItem = async function (parameters) {
   const { attempts, context, mapSid, key, ttl, data } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!mapSid && !isString(mapSid))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!key && !isString(key))
-    throw "Invalid parameters object passed. Parameters must contain uniqueName string value";
-  if (!!ttl && !isString(ttl))
-    throw "Invalid parameters object passed. Parameters must contain ttl integer value";
-  if (!!data && !isObject(data))
-    throw "Invalid parameters object passed. Parameters must contain data object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(mapSid) && !isString(mapSid))
+    throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(key) && !isString(key))
+    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
+  if (Boolean(ttl) && !isString(ttl))
+    throw 'Invalid parameters object passed. Parameters must contain ttl integer value';
+  if (Boolean(data) && !isObject(data)) throw 'Invalid parameters object passed. Parameters must contain data object';
 
   try {
     const client = context.getTwilioClient();
     const mapItemParameters = {
-      key: key,
-      ttl: ttl,
-      data: data,
+      key,
+      ttl,
+      data,
     };
 
     const mapItem = await client.sync
@@ -115,7 +103,7 @@ exports.createMapItem = async function (parameters) {
       .syncMaps(mapSid)
       .syncMapItems.create(mapItemParameters);
 
-      return { success: true, status: 200, mapItem: mapItem };
+    return { success: true, status: 200, mapItem };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
   }
@@ -134,30 +122,25 @@ exports.createMapItem = async function (parameters) {
 exports.createDocument = async function (parameters) {
   const { attempts, context, uniqueName, ttl, data } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!!uniqueName && !isString(uniqueName))
-    throw "Invalid parameters object passed. Parameters must contain uniqueName string value";
-  if (!!ttl && !isString(ttl))
-    throw "Invalid parameters object passed. Parameters must contain ttl integer value";
-  if (!!data && !isObject(data))
-    throw "Invalid parameters object passed. Parameters must contain data object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (Boolean(uniqueName) && !isString(uniqueName))
+    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
+  if (Boolean(ttl) && !isString(ttl))
+    throw 'Invalid parameters object passed. Parameters must contain ttl integer value';
+  if (Boolean(data) && !isObject(data)) throw 'Invalid parameters object passed. Parameters must contain data object';
 
   try {
     const client = context.getTwilioClient();
     const documentParameters = {
-      uniqueName: uniqueName,
-      ttl: ttl,
-      data: data,
+      uniqueName,
+      ttl,
+      data,
     };
 
-    const document = await client.sync
-      .services(context.TWILIO_FLEX_SYNC_SID)
-      .documents.create(documentParameters);
+    const document = await client.sync.services(context.TWILIO_FLEX_SYNC_SID).documents.create(documentParameters);
 
-    return { success: true, status: 200, document: document };
+    return { success: true, status: 200, document };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
   }
@@ -174,22 +157,17 @@ exports.createDocument = async function (parameters) {
 exports.fetchDocument = async function (parameters) {
   const { attempts, context, documentSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
   if (!isString(documentSid))
-    throw "Invalid parameters object passed. Parameters must contain documentSid string value";
+    throw 'Invalid parameters object passed. Parameters must contain documentSid string value';
 
   try {
     const client = context.getTwilioClient();
 
-    const document = await client.sync
-      .services(context.TWILIO_FLEX_SYNC_SID)
-      .documents(documentSid)
-      .fetch();
+    const document = await client.sync.services(context.TWILIO_FLEX_SYNC_SID).documents(documentSid).fetch();
 
-    return { success: true, status: 200, document: document };
+    return { success: true, status: 200, document };
   } catch (error) {
     return retryHandler(error, parameters, arguments.callee);
   }
@@ -207,14 +185,11 @@ exports.fetchDocument = async function (parameters) {
 exports.updateDocumentData = async function (parameters) {
   const { attempts, context, documentSid, updateData } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
   if (!isString(documentSid))
-    throw "Invalid parameters object passed. Parameters must contain documentSid string value";
-  if (!isObject(updateData))
-    throw "Invalid parameters object passed. Parameters must contain updateData object";
+    throw 'Invalid parameters object passed. Parameters must contain documentSid string value';
+  if (!isObject(updateData)) throw 'Invalid parameters object passed. Parameters must contain updateData object';
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -14,12 +14,13 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.deleteMapItem = async (parameters) => {
   const { attempts, context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
-    throw 'Invalid parameters object passed. Parameters must contain mapSid string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain mapSid string value');
   if (Boolean(key) && !isString(key))
-    throw 'Invalid parameters object passed. Parameters must contain key string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain key string value');
 
   try {
     const client = context.getTwilioClient();
@@ -44,12 +45,13 @@ exports.deleteMapItem = async (parameters) => {
 exports.fetchMapItem = async (parameters) => {
   const { attempts, context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
-    throw 'Invalid parameters object passed. Parameters must contain context object';
+    throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(key) && !isString(key))
-    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain uniqueName string value');
 
   try {
     const client = context.getTwilioClient();
@@ -76,15 +78,17 @@ exports.fetchMapItem = async (parameters) => {
 exports.createMapItem = async (parameters) => {
   const { attempts, context, mapSid, key, ttl, data } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
-    throw 'Invalid parameters object passed. Parameters must contain context object';
+    throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(key) && !isString(key))
-    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain uniqueName string value');
   if (Boolean(ttl) && !isString(ttl))
-    throw 'Invalid parameters object passed. Parameters must contain ttl integer value';
-  if (Boolean(data) && !isObject(data)) throw 'Invalid parameters object passed. Parameters must contain data object';
+    throw new Error('Invalid parameters object passed. Parameters must contain ttl integer value');
+  if (Boolean(data) && !isObject(data))
+    throw new Error('Invalid parameters object passed. Parameters must contain data object');
 
   try {
     const client = context.getTwilioClient();
@@ -118,13 +122,15 @@ exports.createMapItem = async (parameters) => {
 exports.createDocument = async (parameters) => {
   const { attempts, context, uniqueName, ttl, data } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(uniqueName) && !isString(uniqueName))
-    throw 'Invalid parameters object passed. Parameters must contain uniqueName string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain uniqueName string value');
   if (Boolean(ttl) && !isString(ttl))
-    throw 'Invalid parameters object passed. Parameters must contain ttl integer value';
-  if (Boolean(data) && !isObject(data)) throw 'Invalid parameters object passed. Parameters must contain data object';
+    throw new Error('Invalid parameters object passed. Parameters must contain ttl integer value');
+  if (Boolean(data) && !isObject(data))
+    throw new Error('Invalid parameters object passed. Parameters must contain data object');
 
   try {
     const client = context.getTwilioClient();
@@ -153,10 +159,11 @@ exports.createDocument = async (parameters) => {
 exports.fetchDocument = async (parameters) => {
   const { attempts, context, documentSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(documentSid))
-    throw 'Invalid parameters object passed. Parameters must contain documentSid string value';
+    throw new Error('Invalid parameters object passed. Parameters must contain documentSid string value');
 
   try {
     const client = context.getTwilioClient();
@@ -181,11 +188,13 @@ exports.fetchDocument = async (parameters) => {
 exports.updateDocumentData = async (parameters) => {
   const { attempts, context, documentSid, updateData } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(documentSid))
-    throw 'Invalid parameters object passed. Parameters must contain documentSid string value';
-  if (!isObject(updateData)) throw 'Invalid parameters object passed. Parameters must contain updateData object';
+    throw new Error('Invalid parameters object passed. Parameters must contain documentSid string value');
+  if (!isObject(updateData))
+    throw new Error('Invalid parameters object passed. Parameters must contain updateData object');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -1,8 +1,6 @@
-const { merge, isString, isObject, isNumber, isBoolean, omitBy, isNil } = require("lodash");
+const { merge, isString, isObject, isNumber, isBoolean, omitBy, isNil } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -18,18 +16,16 @@ const retryHandler = require(Runtime.getFunctions()[
 exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
   const { attempts, taskSid, attributesUpdate } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain the taskSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
   if (!isString(attributesUpdate))
-    throw "Invalid parameters object passed. Parameters must contain attributesUpdate JSON string";
+    throw 'Invalid parameters object passed. Parameters must contain attributesUpdate JSON string';
 
   try {
-    const axios = require("axios");
+    const axios = require('axios');
 
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;
-    let config = {
+    const config = {
       auth: {
         username: process.env.ACCOUNT_SID,
         password: process.env.AUTH_TOKEN,
@@ -44,17 +40,13 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
     task.revision = JSON.parse(getResponse.headers.etag);
 
     // merge the objects
-    let updatedTaskAttributes = omitBy(merge(
-      {},
-      task.attributes,
-      JSON.parse(attributesUpdate)
-    ), isNil);
+    const updatedTaskAttributes = omitBy(merge({}, task.attributes, JSON.parse(attributesUpdate)), isNil);
 
     // if-match the revision number to ensure
     // no update collisions
     config.headers = {
-      "If-Match": task.revision,
-      "content-type": "application/x-www-form-urlencoded",
+      'If-Match': task.revision,
+      'content-type': 'application/x-www-form-urlencoded',
     };
 
     data = new URLSearchParams({
@@ -88,14 +80,10 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
 exports.completeTask = async function completeTask(parameters) {
   const { attempts, taskSid, reason, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain the taskSid string";
-  if (!isString(reason))
-    throw "Invalid parameters object passed. Parameters must contain reason string";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
+  if (!isString(reason)) throw 'Invalid parameters object passed. Parameters must contain reason string';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
 
   try {
     const client = context.getTwilioClient();
@@ -103,7 +91,7 @@ exports.completeTask = async function completeTask(parameters) {
     const task = await client.taskrouter
       .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
       .tasks(taskSid)
-      .update({ assignmentStatus: "completed", reason });
+      .update({ assignmentStatus: 'completed', reason });
 
     return {
       success: true,
@@ -121,9 +109,7 @@ exports.completeTask = async function completeTask(parameters) {
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
       const { context } = parameters;
-      console.warn(
-        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
-      );
+      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
         status: 200,
@@ -147,16 +133,13 @@ exports.completeTask = async function completeTask(parameters) {
 exports.updateReservation = async function updateReservation(parameters) {
   const { attempts, context, taskSid, reservationSid, status } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain the taskSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
   if (!isString(reservationSid))
-    throw "Invalid parameters object passed. Parameters must contain reservationSid string";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
-  if (!isString(status) || (status != "completed" && status != "wrapping"))
-    throw "Invalid parameters object passed. Parameters must contain status to update the reservation to and it must be one of \"completed\" or \"wrapping\""
+    throw 'Invalid parameters object passed. Parameters must contain reservationSid string';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isString(status) || (status != 'completed' && status != 'wrapping'))
+    throw 'Invalid parameters object passed. Parameters must contain status to update the reservation to and it must be one of "completed" or "wrapping"';
 
   try {
     const client = context.getTwilioClient();
@@ -183,9 +166,7 @@ exports.updateReservation = async function updateReservation(parameters) {
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
       const { context } = parameters;
-      console.warn(
-        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
-      );
+      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
         status: 200,
@@ -219,31 +200,26 @@ exports.createTask = async function createTask(parameters) {
     attempts,
   } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
   if (!isString(workflowSid) || workflowSid.length == 0)
-    throw "Invalid parameters object passed. Parameters must contain workflowSid string";
+    throw 'Invalid parameters object passed. Parameters must contain workflowSid string';
   if (!isString(taskChannel) || taskChannel.length == 0)
-    throw "Invalid parameters object passed. Parameters must contain taskChannel string";
-  if (!isObject(attributes))
-    throw "Invalid parameters object passed. Parameters must contain attributes object";
+    throw 'Invalid parameters object passed. Parameters must contain taskChannel string';
+  if (!isObject(attributes)) throw 'Invalid parameters object passed. Parameters must contain attributes object';
 
   const timeout = overriddenTimeout || 86400;
   const priority = overriddenPriority || 0;
 
   try {
     const client = context.getTwilioClient();
-    const task = await client.taskrouter
-      .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
-      .tasks.create({
-        attributes: JSON.stringify(attributes),
-        workflowSid,
-        taskChannel,
-        priority,
-        timeout,
-      });
+    const task = await client.taskrouter.workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID).tasks.create({
+      attributes: JSON.stringify(attributes),
+      workflowSid,
+      taskChannel,
+      priority,
+      timeout,
+    });
 
     return {
       success: true,
@@ -270,10 +246,8 @@ exports.createTask = async function createTask(parameters) {
 exports.getQueues = async function getQueues(parameters) {
   const { context, attempts } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
 
   try {
     const client = context.getTwilioClient();
@@ -301,26 +275,18 @@ exports.getQueues = async function getQueues(parameters) {
  *   worker channel
  */
 exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
-  const {
-    context,
-    attempts,
-    workerSid,
-  } = parameters;
+  const { context, attempts, workerSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(workerSid))
-    throw "Invalid parameters object passed. Parameters must contain workerSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(workerSid)) throw 'Invalid parameters object passed. Parameters must contain workerSid string';
 
   try {
     const client = context.getTwilioClient();
     const workerChannels = await client.taskrouter
       .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
       .workers(workerSid)
-      .workerChannels
-      .list();
+      .workerChannels.list();
 
     return {
       success: true,
@@ -341,27 +307,15 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
  *   worker channel capacity
  */
 exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
-  const {
-    context,
-    attempts,
-    workerSid,
-    workerChannelSid,
-    capacity,
-    available,
-  } = parameters;
+  const { context, attempts, workerSid, workerChannelSid, capacity, available } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(workerSid))
-    throw "Invalid parameters object passed. Parameters must contain workerSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(workerSid)) throw 'Invalid parameters object passed. Parameters must contain workerSid string';
   if (!isString(workerChannelSid))
-    throw "Invalid parameters object passed. Parameters must contain workerChannelSid string";
-  if (!isNumber(capacity))
-    throw "Invalid parameters object passed. Parameters must contain capacity number";
-  if (!isBoolean(available))
-    throw "Invalid parameters object passed. Parameters must contain available boolean";
+    throw 'Invalid parameters object passed. Parameters must contain workerChannelSid string';
+  if (!isNumber(capacity)) throw 'Invalid parameters object passed. Parameters must contain capacity number';
+  if (!isBoolean(available)) throw 'Invalid parameters object passed. Parameters must contain available boolean';
 
   try {
     const client = context.getTwilioClient();
@@ -393,14 +347,10 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
 exports.updateTask = async function updateTask(parameters) {
   const { attempts, taskSid, updateParams, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain the taskSid string";
-  if (!isObject(updateParams))
-    throw "Invalid parameters object passed. Parameters must contain updateParams object";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
+  if (!isObject(updateParams)) throw 'Invalid parameters object passed. Parameters must contain updateParams object';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
 
   try {
     const client = context.getTwilioClient();
@@ -416,7 +366,7 @@ exports.updateTask = async function updateTask(parameters) {
       task: {
         ...task,
         attributes: JSON.parse(task.attributes),
-      }
+      },
     };
   } catch (error) {
     // 20001 error code is returned when the task is not in an assigned state
@@ -429,9 +379,7 @@ exports.updateTask = async function updateTask(parameters) {
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
       const { context } = parameters;
-      console.warn(
-        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
-      );
+      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
         status: 200,
@@ -453,20 +401,14 @@ exports.updateTask = async function updateTask(parameters) {
 exports.fetchTask = async function fetchTask(parameters) {
   const { attempts, taskSid, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain the taskSid string";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain reason context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
 
   try {
     const client = context.getTwilioClient();
 
-    const task = await client.taskrouter
-      .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
-      .tasks(taskSid)
-      .fetch();
+    const task = await client.taskrouter.workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID).tasks(taskSid).fetch();
 
     return {
       success: true,
@@ -474,7 +416,7 @@ exports.fetchTask = async function fetchTask(parameters) {
       task: {
         ...task,
         attributes: JSON.parse(task.attributes),
-      }
+      },
     };
   } catch (error) {
     // 20001 error code is returned when the task is not in an assigned state
@@ -487,9 +429,7 @@ exports.fetchTask = async function fetchTask(parameters) {
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
       const { context } = parameters;
-      console.warn(
-        `${context.PATH}.${arguments.callee.name}(): ${error.message}`
-      );
+      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
         status: 200,
@@ -513,13 +453,10 @@ exports.fetchTask = async function fetchTask(parameters) {
  *  tasks for the account
  */
 exports.getTasks = async function getTasks(parameters) {
-  const { context, attempts, workflowSid, assignmentStatus, ordering, limit } =
-    parameters;
+  const { context, attempts, workflowSid, assignmentStatus, ordering, limit } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -17,10 +17,12 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
 exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
   const { attempts, taskSid, attributesUpdate } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isString(taskSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isString(attributesUpdate))
-    throw 'Invalid parameters object passed. Parameters must contain attributesUpdate JSON string';
+    throw new Error('Invalid parameters object passed. Parameters must contain attributesUpdate JSON string');
 
   try {
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;
@@ -79,10 +81,12 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
 exports.completeTask = async function completeTask(parameters) {
   const { attempts, taskSid, reason, context } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
-  if (!isString(reason)) throw 'Invalid parameters object passed. Parameters must contain reason string';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isString(taskSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
+  if (!isString(reason)) throw new Error('Invalid parameters object passed. Parameters must contain reason string');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = context.getTwilioClient();
@@ -131,13 +135,18 @@ exports.completeTask = async function completeTask(parameters) {
 exports.updateReservation = async function updateReservation(parameters) {
   const { attempts, context, taskSid, reservationSid, status } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isString(taskSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isString(reservationSid))
-    throw 'Invalid parameters object passed. Parameters must contain reservationSid string';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+    throw new Error('Invalid parameters object passed. Parameters must contain reservationSid string');
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
   if (!isString(status) || (status !== 'completed' && status !== 'wrapping'))
-    throw 'Invalid parameters object passed. Parameters must contain status to update the reservation to and it must be one of "completed" or "wrapping"';
+    throw new Error(
+      'Invalid parameters object passed. Parameters must contain status to update the reservation to and it must be one of "completed" or "wrapping"',
+    );
 
   try {
     const client = context.getTwilioClient();
@@ -197,13 +206,15 @@ exports.createTask = async function createTask(parameters) {
     attempts,
   } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(workflowSid) || workflowSid.length === 0)
-    throw 'Invalid parameters object passed. Parameters must contain workflowSid string';
+    throw new Error('Invalid parameters object passed. Parameters must contain workflowSid string');
   if (!isString(taskChannel) || taskChannel.length === 0)
-    throw 'Invalid parameters object passed. Parameters must contain taskChannel string';
-  if (!isObject(attributes)) throw 'Invalid parameters object passed. Parameters must contain attributes object';
+    throw new Error('Invalid parameters object passed. Parameters must contain taskChannel string');
+  if (!isObject(attributes))
+    throw new Error('Invalid parameters object passed. Parameters must contain attributes object');
 
   const timeout = overriddenTimeout || 86400;
   const priority = overriddenPriority || 0;
@@ -243,8 +254,9 @@ exports.createTask = async function createTask(parameters) {
 exports.getQueues = async function getQueues(parameters) {
   const { context, attempts } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = context.getTwilioClient();
@@ -274,9 +286,11 @@ exports.getQueues = async function getQueues(parameters) {
 exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
   const { context, attempts, workerSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(workerSid)) throw 'Invalid parameters object passed. Parameters must contain workerSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(workerSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain workerSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -306,13 +320,16 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
 exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
   const { context, attempts, workerSid, workerChannelSid, capacity, available } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(workerSid)) throw 'Invalid parameters object passed. Parameters must contain workerSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(workerSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain workerSid string');
   if (!isString(workerChannelSid))
-    throw 'Invalid parameters object passed. Parameters must contain workerChannelSid string';
-  if (!isNumber(capacity)) throw 'Invalid parameters object passed. Parameters must contain capacity number';
-  if (!isBoolean(available)) throw 'Invalid parameters object passed. Parameters must contain available boolean';
+    throw new Error('Invalid parameters object passed. Parameters must contain workerChannelSid string');
+  if (!isNumber(capacity)) throw new Error('Invalid parameters object passed. Parameters must contain capacity number');
+  if (!isBoolean(available))
+    throw new Error('Invalid parameters object passed. Parameters must contain available boolean');
 
   try {
     const client = context.getTwilioClient();
@@ -344,10 +361,14 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
 exports.updateTask = async function updateTask(parameters) {
   const { attempts, taskSid, updateParams, context } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
-  if (!isObject(updateParams)) throw 'Invalid parameters object passed. Parameters must contain updateParams object';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isString(taskSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
+  if (!isObject(updateParams))
+    throw new Error('Invalid parameters object passed. Parameters must contain updateParams object');
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
 
   try {
     const client = context.getTwilioClient();
@@ -397,9 +418,12 @@ exports.updateTask = async function updateTask(parameters) {
 exports.fetchTask = async function fetchTask(parameters) {
   const { attempts, taskSid, context } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain the taskSid string';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isString(taskSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
+  if (!isObject(context))
+    throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
 
   try {
     const client = context.getTwilioClient();
@@ -450,8 +474,9 @@ exports.fetchTask = async function fetchTask(parameters) {
 exports.getTasks = async function getTasks(parameters) {
   const { context, attempts, workflowSid, assignmentStatus, ordering, limit } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = context.getTwilioClient();

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -1,4 +1,5 @@
 const { merge, isString, isObject, isNumber, isBoolean, omitBy, isNil } = require('lodash');
+const axios = require('axios');
 
 const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
@@ -22,8 +23,6 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
     throw 'Invalid parameters object passed. Parameters must contain attributesUpdate JSON string';
 
   try {
-    const axios = require('axios');
-
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;
     const config = {
       auth: {
@@ -108,7 +107,6 @@ exports.completeTask = async function completeTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { context } = parameters;
       console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
@@ -165,7 +163,6 @@ exports.updateReservation = async function updateReservation(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { context } = parameters;
       console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
@@ -202,9 +199,9 @@ exports.createTask = async function createTask(parameters) {
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
   if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(workflowSid) || workflowSid.length == 0)
+  if (!isString(workflowSid) || workflowSid.length === 0)
     throw 'Invalid parameters object passed. Parameters must contain workflowSid string';
-  if (!isString(taskChannel) || taskChannel.length == 0)
+  if (!isString(taskChannel) || taskChannel.length === 0)
     throw 'Invalid parameters object passed. Parameters must contain taskChannel string';
   if (!isObject(attributes)) throw 'Invalid parameters object passed. Parameters must contain attributes object';
 
@@ -378,7 +375,6 @@ exports.updateTask = async function updateTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { context } = parameters;
       console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,
@@ -428,7 +424,6 @@ exports.fetchTask = async function fetchTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      const { context } = parameters;
       console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
       return {
         success: true,

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -63,7 +63,7 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
       },
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateTaskAttributes);
   }
 };
 
@@ -107,14 +107,14 @@ exports.completeTask = async function completeTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
+      console.warn(`${context.PATH}.completeTask(): ${error.message}`);
       return {
         success: true,
         status: 200,
         message: error.message,
       };
     }
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.completeTask);
   }
 };
 
@@ -136,7 +136,7 @@ exports.updateReservation = async function updateReservation(parameters) {
   if (!isString(reservationSid))
     throw 'Invalid parameters object passed. Parameters must contain reservationSid string';
   if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain reason context object';
-  if (!isString(status) || (status != 'completed' && status != 'wrapping'))
+  if (!isString(status) || (status !== 'completed' && status !== 'wrapping'))
     throw 'Invalid parameters object passed. Parameters must contain status to update the reservation to and it must be one of "completed" or "wrapping"';
 
   try {
@@ -163,14 +163,14 @@ exports.updateReservation = async function updateReservation(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
+      console.warn(`${context.PATH}.updateReservation(): ${error.message}`);
       return {
         success: true,
         status: 200,
         message: error.message,
       };
     }
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateReservation);
   }
 };
 
@@ -228,7 +228,7 @@ exports.createTask = async function createTask(parameters) {
       status: 200,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.createTask);
   }
 };
 
@@ -258,7 +258,7 @@ exports.getQueues = async function getQueues(parameters) {
       queues,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.getQueues);
   }
 };
 
@@ -291,7 +291,7 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
       workerChannels,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.getWorkerChannels);
   }
 };
 
@@ -328,7 +328,7 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
       workerChannelCapacity,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateWorkerChannel);
   }
 };
 
@@ -375,14 +375,14 @@ exports.updateTask = async function updateTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
+      console.warn(`${context.PATH}.updateTask(): ${error.message}`);
       return {
         success: true,
         status: 200,
         message: error.message,
       };
     }
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.updateTask);
   }
 };
 
@@ -424,14 +424,14 @@ exports.fetchTask = async function fetchTask(parameters) {
     // in which case it is also assumed to be completed
     // https://www.twilio.com/docs/api/errors/20404
     if (error.code === 20001 || error.code === 20404) {
-      console.warn(`${context.PATH}.${arguments.callee.name}(): ${error.message}`);
+      console.warn(`${context.PATH}.fetchTask(): ${error.message}`);
       return {
         success: true,
         status: 200,
         message: error.message,
       };
     }
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchTask);
   }
 };
 
@@ -470,6 +470,6 @@ exports.getTasks = async function getTasks(parameters) {
       }),
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.getTasks);
   }
 };

--- a/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
@@ -1,6 +1,4 @@
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 exports.createCallbackTask = async function (parameters) {
   const {
@@ -24,17 +22,16 @@ exports.createCallbackTask = async function (parameters) {
   } = parameters;
 
   // use assigned values or use defaults
-  const workflowSid =
-    overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
+  const workflowSid = overriddenWorkflowSid || process.env.TWILIO_FLEX_CALLBACK_WORKFLOW_SID;
   const timeout = overriddenTimeout || 86400;
   const priority = overriddenPriority || 0;
   const attempts = retryAttempt || 0;
-  const taskChannel = overriddenTaskChannel || "voice";
+  const taskChannel = overriddenTaskChannel || 'voice';
 
   // setup required task attributes for task
   const attributes = {
-    taskType: recordingSid ? "voicemail" : "callback",
-    name: (recordingSid ? "Voicemail" : "Callback") + ` (${numberToCall})`,
+    taskType: recordingSid ? 'voicemail' : 'callback',
+    name: `${recordingSid ? 'Voicemail' : 'Callback'} (${numberToCall})`,
     flow_execution_sid: flexFlowSid,
     message: message || null,
     callBackData: {
@@ -49,13 +46,13 @@ exports.createCallbackTask = async function (parameters) {
       transcriptText,
       isDeleted: isDeleted || false,
     },
-    direction: "inbound",
+    direction: 'inbound',
     conversations: {
       conversation_id,
     },
   };
 
-  const result = await TaskOperations.createTask({
+  return await TaskOperations.createTask({
     context,
     workflowSid,
     taskChannel,
@@ -64,5 +61,4 @@ exports.createCallbackTask = async function (parameters) {
     timeout,
     attempts: 0,
   });
-  return result;
 };

--- a/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
@@ -1,6 +1,6 @@
 const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
-exports.createCallbackTask = async function (parameters) {
+exports.createCallbackTask = async (parameters) => {
   const {
     context,
     numberToCall,
@@ -52,7 +52,7 @@ exports.createCallbackTask = async function (parameters) {
     },
   };
 
-  return await TaskOperations.createTask({
+  return TaskOperations.createTask({
     context,
     workflowSid,
     taskChannel,

--- a/serverless-functions/src/functions/features/callback-and-voicemail/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/flex/create-callback.js
@@ -1,68 +1,60 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()[
-  "common/helpers/prepare-function"
-].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const CallbackOperations = require(Runtime.getFunctions()[
-  "features/callback-and-voicemail/common/callback-operations"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const CallbackOperations = require(Runtime.getFunctions()['features/callback-and-voicemail/common/callback-operations']
+  .path);
 
 const requiredParameters = [
-  { key: "numberToCall", purpose: "the number of the customer to call" },
+  { key: 'numberToCall', purpose: 'the number of the customer to call' },
   {
-    key: "numberToCallFrom",
-    purpose: "the number to call the customer from",
+    key: 'numberToCallFrom',
+    purpose: 'the number to call the customer from',
   },
 ];
 
-exports.handler = prepareFlexFunction(
-  requiredParameters,
-  async (context, event, callback, response, handleError) => {
-    try {
-      const {
-        numberToCall,
-        numberToCallFrom,
-        flexFlowSid,
-        workflowSid: overriddenWorkflowSid,
-        timeout: overriddenTimeout,
-        priority: overriddenPriority,
-        attempts: retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
-        recordingSid,
-        recordingUrl,
-        transcriptSid,
-        transcriptText,
-        isDeleted,
-        taskChannel: overriddenTaskChannel,
-      } = event;
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const {
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      workflowSid: overriddenWorkflowSid,
+      timeout: overriddenTimeout,
+      priority: overriddenPriority,
+      attempts: retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid,
+      recordingUrl,
+      transcriptSid,
+      transcriptText,
+      isDeleted,
+      taskChannel: overriddenTaskChannel,
+    } = event;
 
-      const result = await CallbackOperations.createCallbackTask({
-        context,
-        numberToCall,
-        numberToCallFrom,
-        flexFlowSid,
-        overriddenWorkflowSid,
-        overriddenTimeout,
-        overriddenPriority,
-        retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
-        recordingSid: recordingSid,
-        recordingUrl: recordingUrl,
-        transcriptSid: transcriptSid,
-        transcriptText: transcriptText,
-        isDeleted,
-        overriddenTaskChannel,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success, taskSid: result.taskSid });
-      callback(null, response);
-    } catch (error) {
-      handleError(error);
-    }
+    const result = await CallbackOperations.createCallbackTask({
+      context,
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      overriddenWorkflowSid,
+      overriddenTimeout,
+      overriddenPriority,
+      retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid,
+      recordingUrl,
+      transcriptSid,
+      transcriptText,
+      isDeleted,
+      overriddenTaskChannel,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success, taskSid: result.taskSid });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
-);
+});

--- a/serverless-functions/src/functions/features/callback-and-voicemail/flex/create-callback.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/flex/create-callback.js
@@ -1,5 +1,4 @@
 const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
-const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 const CallbackOperations = require(Runtime.getFunctions()['features/callback-and-voicemail/common/callback-operations']
   .path);
 
@@ -53,8 +52,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     });
     response.setStatusCode(result.status);
     response.setBody({ success: result.success, taskSid: result.taskSid });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/create-callback.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/create-callback.protected.js
@@ -1,5 +1,4 @@
 const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
-const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 const CallbackOperations = require(Runtime.getFunctions()['features/callback-and-voicemail/common/callback-operations']
   .path);
 
@@ -57,8 +56,8 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
     });
     response.setStatusCode(result.status);
     response.setBody({ success: result.success, taskSid: result.taskSid });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/create-callback.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/create-callback.protected.js
@@ -1,72 +1,64 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()[
-  "common/helpers/prepare-function"
-].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const CallbackOperations = require(Runtime.getFunctions()[
-  "features/callback-and-voicemail/common/callback-operations"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const CallbackOperations = require(Runtime.getFunctions()['features/callback-and-voicemail/common/callback-operations']
+  .path);
 
 const requiredParameters = [
-  { key: "numberToCall", purpose: "the number of the customer to call" },
+  { key: 'numberToCall', purpose: 'the number of the customer to call' },
   {
-    key: "numberToCallFrom",
-    purpose: "the number to call the customer from",
+    key: 'numberToCallFrom',
+    purpose: 'the number to call the customer from',
   },
 ];
 
-exports.handler = prepareStudioFunction(
-  requiredParameters,
-  async (context, event, callback, response, handleError) => {
-    try {
-      const {
-        numberToCall,
-        numberToCallFrom,
-        flexFlowSid,
-        workflowSid: overriddenWorkflowSid,
-        timeout: overriddenTimeout,
-        priority: overriddenPriority,
-        attempts: retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
-        recordingSid,
-        RecordingSid,
-        recordingUrl,
-        RecordingUrl,
-        transcriptSid,
-        TranscriptionSid,
-        transcriptText,
-        TranscriptionText,
-        isDeleted,
-        taskChannel: overriddenTaskChannel,
-      } = event;
+exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  try {
+    const {
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      workflowSid: overriddenWorkflowSid,
+      timeout: overriddenTimeout,
+      priority: overriddenPriority,
+      attempts: retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid,
+      RecordingSid,
+      recordingUrl,
+      RecordingUrl,
+      transcriptSid,
+      TranscriptionSid,
+      transcriptText,
+      TranscriptionText,
+      isDeleted,
+      taskChannel: overriddenTaskChannel,
+    } = event;
 
-      const result = await CallbackOperations.createCallbackTask({
-        context,
-        numberToCall,
-        numberToCallFrom,
-        flexFlowSid,
-        overriddenWorkflowSid,
-        overriddenTimeout,
-        overriddenPriority,
-        retryAttempt,
-        conversation_id,
-        message,
-        utcDateTimeReceived,
-        recordingSid: recordingSid || RecordingSid,
-        recordingUrl: recordingUrl || RecordingUrl,
-        transcriptSid: transcriptSid || TranscriptionSid,
-        transcriptText: transcriptText || TranscriptionText,
-        isDeleted,
-        overriddenTaskChannel,
-      });
-      response.setStatusCode(result.status);
-      response.setBody({ success: result.success, taskSid: result.taskSid });
-      callback(null, response);
-    } catch (error) {
-      handleError(error);
-    }
+    const result = await CallbackOperations.createCallbackTask({
+      context,
+      numberToCall,
+      numberToCallFrom,
+      flexFlowSid,
+      overriddenWorkflowSid,
+      overriddenTimeout,
+      overriddenPriority,
+      retryAttempt,
+      conversation_id,
+      message,
+      utcDateTimeReceived,
+      recordingSid: recordingSid || RecordingSid,
+      recordingUrl: recordingUrl || RecordingUrl,
+      transcriptSid: transcriptSid || TranscriptionSid,
+      transcriptText: transcriptText || TranscriptionText,
+      isDeleted,
+      overriddenTaskChannel,
+    });
+    response.setStatusCode(result.status);
+    response.setBody({ success: result.success, taskSid: result.taskSid });
+    callback(null, response);
+  } catch (error) {
+    handleError(error);
   }
-);
+});

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
@@ -3,40 +3,30 @@
  * They can - at any point - press the star key to leave a voicemail and abandon the ongoing call.
  *
  */
-const TaskRouterOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
-const CallbackOperations = require(Runtime.getFunctions()[
-  "features/callback-and-voicemail/common/callback-operations"
-].path);
+const TaskRouterOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
+const CallbackOperations = require(Runtime.getFunctions()['features/callback-and-voicemail/common/callback-operations']
+  .path);
 
 const options = {
-  sayOptions: { voice: "Polly.Joanna" },
-  holdMusicUrl:
-    "/features/callback-and-voicemail/wait-experience-music-30s.mp3",
+  sayOptions: { voice: 'Polly.Joanna' },
+  holdMusicUrl: '/features/callback-and-voicemail/wait-experience-music-30s.mp3',
   messages: {
-    initialGreeting:
-      "Please wait while we direct your call to the next available representative.",
+    initialGreeting: 'Please wait while we direct your call to the next available representative.',
     repeatingPrompt:
-      "To request a callback, or to leave a voicemail, press the star key at anytime... Otherwise, please continue to hold.",
+      'To request a callback, or to leave a voicemail, press the star key at anytime... Otherwise, please continue to hold.',
     callbackOrVoicemailChoice:
-      "To request a callback when a representative becomes available, press 1. \
+      'To request a callback when a representative becomes available, press 1. \
           To leave a voicemail for the next available representative, press 2. \
-          To continue holding, press any other key, or remain on the line.",
-    callbackSubmitted:
-      "Thank you. A callback has been requested. You will receive a call shortly. Goodbye.",
+          To continue holding, press any other key, or remain on the line.',
+    callbackSubmitted: 'Thank you. A callback has been requested. You will receive a call shortly. Goodbye.',
     recordVoicemailPrompt:
-      "Please leave a message at the tone. When you are finished recording, you may hang up, or press the star key.",
+      'Please leave a message at the tone. When you are finished recording, you may hang up, or press the star key.',
     voicemailNotCaptured: "Sorry. We weren't able to capture your message.",
-    voicemailRecorded:
-      "Your voicemail has been successfully recorded... Goodbye",
+    voicemailRecorded: 'Your voicemail has been successfully recorded... Goodbye',
     callbackAndVoicemailUnavailable:
-      "The option to request a callback or leave a voicemail is not available at this time. Please continue to hold.",
-    processingError:
-      "Sorry, we were unable to perform this operation. Please remain on the line.",
+      'The option to request a callback or leave a voicemail is not available at this time. Please continue to hold.',
+    processingError: 'Sorry, we were unable to perform this operation. Please remain on the line.',
   },
 };
 
@@ -54,9 +44,9 @@ async function getPendingTaskByCallSid(context, callSid, workflowSid) {
   const result = await TaskRouterOperations.getTasks({
     context,
     attempts: 0,
-    assignmentStatus: ["pending", "reserved"],
+    assignmentStatus: ['pending', 'reserved'],
     workflowSid,
-    ordering: "DateCreated:desc",
+    ordering: 'DateCreated:desc',
     limit: 50,
   });
 
@@ -90,7 +80,7 @@ async function cancelTask(context, task, cancelReason) {
     ...task.attributes,
     conversations: {
       ...task.attributes.conversations,
-      abandoned: "Follow-Up",
+      abandoned: 'Follow-Up',
     },
   };
 
@@ -98,7 +88,7 @@ async function cancelTask(context, task, cancelReason) {
     context,
     taskSid: task.sid,
     updateParams: {
-      assignmentStatus: "canceled",
+      assignmentStatus: 'canceled',
       reason: cancelReason,
       attributes: JSON.stringify(newAttributes),
     },
@@ -117,19 +107,12 @@ async function cancelTask(context, task, cancelReason) {
  * @param {*} taskSid
  * @returns
  */
-async function handleCallbackOrVoicemailSelected(
-  context,
-  isVoicemail,
-  callSid,
-  taskSid
-) {
+async function handleCallbackOrVoicemailSelected(context, isVoicemail, callSid, taskSid) {
   const twiml = new Twilio.twiml.VoiceResponse();
   const domain = `https://${context.DOMAIN_NAME}`;
 
-  const cancelReason = isVoicemail
-    ? "Opted to leave a voicemail"
-    : "Opted to request a callback";
-  const mode = isVoicemail ? "record-voicemail" : "submit-callback";
+  const cancelReason = isVoicemail ? 'Opted to leave a voicemail' : 'Opted to request a callback';
+  const mode = isVoicemail ? 'record-voicemail' : 'submit-callback';
 
   const task = await fetchTask(context, taskSid);
 
@@ -140,7 +123,7 @@ async function handleCallbackOrVoicemailSelected(
     context,
     callSid,
     params: {
-      method: "POST",
+      method: 'POST',
       url: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=${mode}&CallSid=${callSid}&enqueuedTaskSid=${taskSid}`,
     },
     attempts: 0,
@@ -151,16 +134,14 @@ async function handleCallbackOrVoicemailSelected(
     //  Cancel (update) the task with handy attributes for reporting
     await cancelTask(context, task, cancelReason);
   } else {
-    console.error(
-      `Failed to update call ${callSid} with new TwiML. Status: ${status}`
-    );
+    console.error(`Failed to update call ${callSid} with new TwiML. Status: ${status}`);
     twiml.say(options.sayOptions, options.messages.processingError);
     twiml.redirect(
-      `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${callSid}&enqueuedTaskSid=${taskSid}&skipGreeting=true`
+      `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${callSid}&enqueuedTaskSid=${taskSid}&skipGreeting=true`,
     );
     return twiml;
   }
-  return "";
+  return '';
 }
 
 exports.handler = async function (context, event, callback) {
@@ -170,59 +151,42 @@ exports.handler = async function (context, event, callback) {
 
   // Make relative hold music URLs absolute
   // <Play> does not support relative URLs
-  if (
-    !holdMusicUrl.startsWith("http://") &&
-    !holdMusicUrl.startsWith("https://")
-  ) {
+  if (!holdMusicUrl.startsWith('http://') && !holdMusicUrl.startsWith('https://')) {
     holdMusicUrl = domain + holdMusicUrl;
   }
 
-  const {
-    Digits,
-    CallSid,
-    enqueuedWorkflowSid,
-    mode,
-    enqueuedTaskSid,
-    skipGreeting,
-  } = event;
+  const { Digits, CallSid, enqueuedWorkflowSid, mode, enqueuedTaskSid, skipGreeting } = event;
 
-  let message = "";
+  const message = '';
 
   switch (mode) {
-    case "initialize":
+    case 'initialize':
       // Initial logic to find the associated task for the call, and propagate it through to the rest of the TwiML execution
       // If the lookup fails to find the task, the remaining TwiML logic will not offer any callback or voicemail options.
-      const enqueuedTask = await getPendingTaskByCallSid(
-        context,
-        CallSid,
-        enqueuedWorkflowSid
-      );
+      const enqueuedTask = await getPendingTaskByCallSid(context, CallSid, enqueuedWorkflowSid);
 
       const redirectBaseUrl = `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}`;
 
       if (enqueuedTask == null) {
         // Log an error for our own debugging purposes, but don't fail the call
         console.error(
-          `Failed to find the pending task with callSid: ${CallSid}. This is potentially due to higher call volume than the API query had accounted for.`
+          `Failed to find the pending task with callSid: ${CallSid}. This is potentially due to higher call volume than the API query had accounted for.`,
         );
         twiml.redirect(redirectBaseUrl);
       } else {
-        twiml.redirect(
-          redirectBaseUrl +
-            (enqueuedTask ? `&enqueuedTaskSid=${enqueuedTask.sid}` : "")
-        );
+        twiml.redirect(redirectBaseUrl + (enqueuedTask ? `&enqueuedTaskSid=${enqueuedTask.sid}` : ''));
       }
       return callback(null, twiml);
 
-    case "main-wait-loop":
-      if (skipGreeting !== "true") {
+    case 'main-wait-loop':
+      if (skipGreeting !== 'true') {
         twiml.say(options.sayOptions, options.messages.initialGreeting);
       }
       if (enqueuedTaskSid != null) {
         // Nest the <Say>/<Play> within the <Gather> to allow the caller to press a key at any time during the nested verbs' execution.
         const initialGather = twiml.gather({
-          input: "dtmf",
-          timeout: "2",
+          input: 'dtmf',
+          timeout: '2',
           action: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=handle-initial-choice&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`,
         });
         initialGather.say(options.sayOptions, options.messages.repeatingPrompt);
@@ -230,61 +194,47 @@ exports.handler = async function (context, event, callback) {
       } else {
         // If the task lookup failed to find the task previously, don't offer callback or voicemail options - since we aren't able to cancel
         // the ongoing call task
-        twiml.say(
-          options.sayOptions,
-          options.messages.callbackAndVoicemailUnavailable
-        );
+        twiml.say(options.sayOptions, options.messages.callbackAndVoicemailUnavailable);
         twiml.play(holdMusicUrl);
       }
       // Loop back to the start if we reach this point
       twiml.redirect(
-        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`
+        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`,
       );
       return callback(null, twiml);
 
-    case "handle-initial-choice":
+    case 'handle-initial-choice':
       // If the caller pressed the star key, prompt for callback or voicemail
-      if (Digits === "*") {
+      if (Digits === '*') {
         // Nest the <Say>/<Play> within the <Gather> to allow the caller to press a key at any time during the nested verbs' execution.
         const callbackOrVoicemailGather = twiml.gather({
-          input: "dtmf",
-          timeout: "2",
+          input: 'dtmf',
+          timeout: '2',
           action: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=handle-callback-or-voicemail-choice&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`,
         });
-        callbackOrVoicemailGather.say(
-          options.sayOptions,
-          options.messages.callbackOrVoicemailChoice
-        );
+        callbackOrVoicemailGather.say(options.sayOptions, options.messages.callbackOrVoicemailChoice);
       }
 
       // Loop back to the start of the wait loop
       twiml.redirect(
-        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`
+        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`,
       );
       return callback(null, twiml);
 
-    case "handle-callback-or-voicemail-choice":
-      if (Digits === "1" || Digits === "2") {
+    case 'handle-callback-or-voicemail-choice':
+      if (Digits === '1' || Digits === '2') {
         // 1 = callback, 2 = voicemail
-        const isVoicemail = Digits === "2";
-        return callback(
-          null,
-          await handleCallbackOrVoicemailSelected(
-            context,
-            isVoicemail,
-            CallSid,
-            enqueuedTaskSid
-          )
-        );
+        const isVoicemail = Digits === '2';
+        return callback(null, await handleCallbackOrVoicemailSelected(context, isVoicemail, CallSid, enqueuedTaskSid));
       }
 
       // Loop back to the start of the wait loop if the caller pressed any other key
       twiml.redirect(
-        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`
+        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`,
       );
       return callback(null, twiml);
 
-    case "submit-callback":
+    case 'submit-callback':
       // Create the Callback task
       // Option to pull in a few more things from original task like conversation_id or even the workflowSid
       await CallbackOperations.createCallbackTask({
@@ -298,31 +248,31 @@ exports.handler = async function (context, event, callback) {
       twiml.hangup();
       return callback(null, twiml);
 
-    case "record-voicemail":
+    case 'record-voicemail':
       //  Main logic for Recording the voicemail
       twiml.say(options.sayOptions, options.messages.recordVoicemailPrompt);
       twiml.record({
         action: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=voicemail-recorded&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`,
         transcribeCallback: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=submit-voicemail&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`,
-        method: "GET",
-        playBeep: "true",
+        method: 'GET',
+        playBeep: 'true',
         transcribe: true,
         timeout: 10,
-        finishOnKey: "*",
+        finishOnKey: '*',
       });
       twiml.say(options.sayOptions, options.messages.voicemailNotCaptured);
       twiml.redirect(
-        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=record-voicemail&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`
+        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=record-voicemail&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}`,
       );
       return callback(null, twiml);
 
-    case "voicemail-recorded":
+    case 'voicemail-recorded':
       // End the interaction. Hangup the call.
       twiml.say(options.sayOptions, options.messages.voicemailRecorded);
       twiml.hangup();
       return callback(null, twiml);
 
-    case "submit-voicemail":
+    case 'submit-voicemail':
       // Submit the voicemail to Taskrouter (and/or to your backend if you have a voicemail handling solution)
 
       // Create the Voicemail task
@@ -338,13 +288,13 @@ exports.handler = async function (context, event, callback) {
         transcriptText: event.TranscriptionText,
       });
 
-      return callback(null, "");
+      return callback(null, '');
 
     default:
       //  Default case - if we don't recognize the mode, redirect to the main wait loop
       twiml.say(options.sayOptions, options.messages.processingError);
       twiml.redirect(
-        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`
+        `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=main-wait-loop&CallSid=${CallSid}&enqueuedTaskSid=${enqueuedTaskSid}&skipGreeting=true`,
       );
       return callback(null, twiml);
   }

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
@@ -1,34 +1,31 @@
-const AccessToken = require("twilio").jwt.AccessToken;
-const { SyncGrant, VideoGrant } = AccessToken;
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const SyncOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/sync"
-].path);
+const AccessToken = require('twilio').jwt.AccessToken;
 
-const requiredParameters = [
-  { key: "DocumentSid", purpose: "used for sync document" },
-];
+const { SyncGrant, VideoGrant } = AccessToken;
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const SyncOperations = require(Runtime.getFunctions()['common/twilio-wrappers/sync'].path);
+
+const requiredParameters = [{ key: 'DocumentSid', purpose: 'used for sync document' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { DocumentSid: document_sid } = event;
     const client = context.getTwilioClient();
-    
+
     const documentData = await SyncOperations.fetchDocument({
       attempts: 0,
       context,
       documentSid: document_sid,
     });
-    
+
     if (!documentData) {
       response.setStatusCode(403);
       response.setBody({ error: `Invalid document SID.` });
       console.log(response);
       return callback(null, response);
     }
-    
+
     const { document } = documentData;
-    
+
     // Check if the video room is already created
     let room_name = document.data.room;
     if (!room_name) {
@@ -49,20 +46,20 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
             context,
             documentSid: document_sid,
             updateData: new_document_data,
-          })
+          }),
         )
         .catch((reason) => false);
-    
+
       if (!room_created) {
         response.setStatusCode(503);
         response.setBody({ error: `Error starting video.` });
         return callback(null, response);
       }
     }
-    
+
     // We use the agent's FLEX identity
     const agent_identity = event.TokenResult.identity;
-    
+
     /*
       - Authorize the agent Frontend to connect to SYNC
       - Note: not  directly utilized in this implementation
@@ -70,25 +67,22 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const syncGrant = new SyncGrant({
       serviceSid: context.TWILIO_FLEX_SYNC_SID,
     });
-    
+
     // Authorize the agent Frontend to connect to VIDEO
     const videoGrant = new VideoGrant({
       room: room_name,
     });
-    
+
     // Create an access token which we will sign and return to the agent,
-    const token = new AccessToken(
-      context.ACCOUNT_SID,
-      context.TWILIO_API_KEY,
-      context.TWILIO_API_SECRET,
-      { identity: agent_identity }
-    );
+    const token = new AccessToken(context.ACCOUNT_SID, context.TWILIO_API_KEY, context.TWILIO_API_SECRET, {
+      identity: agent_identity,
+    });
     token.addGrant(syncGrant);
     token.addGrant(videoGrant);
-    
+
     // Respond to the AGENT frontend with a dual-use token (sync + video)
     response.setBody({ token: token.toJwt() });
-    
+
     callback(null, response);
   } catch (error) {
     handleError(error);

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
@@ -48,7 +48,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
             updateData: new_document_data,
           }),
         )
-        .catch((reason) => false);
+        .catch();
 
       if (!room_created) {
         response.setStatusCode(503);
@@ -83,8 +83,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     // Respond to the AGENT frontend with a dual-use token (sync + video)
     response.setBody({ token: token.toJwt() });
 
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
@@ -38,7 +38,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       .documents(code)
       .documentPermissions(client_identity)
       .update({ read: true, write: false, manage: false })
-      .then((document_permission) => true)
       .catch((reason) => {
         console.error(`Error giving permission to ${code}: ${reason}`);
         return null;
@@ -60,8 +59,8 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
     */
     response.setBody({ token: token.toJwt() });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
@@ -1,40 +1,37 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const randomstring = require("randomstring");
-const AccessToken = require("twilio").jwt.AccessToken;
-const SyncOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/sync"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const randomstring = require('randomstring');
+const AccessToken = require('twilio').jwt.AccessToken;
+
+const SyncOperations = require(Runtime.getFunctions()['common/twilio-wrappers/sync'].path);
 const { SyncGrant } = AccessToken;
 
-const requiredParameters = [
-  { key: "code", purpose: "used for unique name of Sync document" },
-];
+const requiredParameters = [{ key: 'code', purpose: 'used for unique name of Sync document' }];
 
 exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const client = context.getTwilioClient();
     const { code } = event;
-    
+
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
       attempts: 0,
       context,
       documentSid: code,
     });
-    
+
     if (!documentData) {
       response.setStatusCode(403);
       response.setBody({ error: `Invalid code.` });
       return callback(null, response);
     }
-    
+
     /*
       - Generate a random identity for the customer
       - This could also be a name we ask to provide before joining the room
     */
     const client_identity = randomstring.generate();
-    console.log("Client identity for Sync : ", client_identity);
-    
+    console.log('Client identity for Sync : ', client_identity);
+
     // Give read-only rights to the SYNC Document to this identity so the UI can subscribe to live updates
     await client.sync
       .services(context.TWILIO_FLEX_SYNC_SID)
@@ -46,21 +43,18 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
         console.error(`Error giving permission to ${code}: ${reason}`);
         return null;
       });
-    
+
     // Create an access token which we will sign and return to the client,
-    const token = new AccessToken(
-      context.ACCOUNT_SID,
-      context.TWILIO_API_KEY,
-      context.TWILIO_API_SECRET,
-      { identity: client_identity }
-    );
-    
+    const token = new AccessToken(context.ACCOUNT_SID, context.TWILIO_API_KEY, context.TWILIO_API_SECRET, {
+      identity: client_identity,
+    });
+
     // Add grants to the SYNC document and the VIDEO room to that token
     const syncGrant = new SyncGrant({
       serviceSid: context.TWILIO_FLEX_SYNC_SID,
     });
     token.addGrant(syncGrant);
-    
+
     /*
       - Respond to the client with identity and token
       - Frontend JS can subscribe to the SYNC document and get notified when the agent connects

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
@@ -1,35 +1,32 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const randomstring = require("randomstring");
-const AccessToken = require("twilio").jwt.AccessToken;
-const SyncOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/sync"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const randomstring = require('randomstring');
+const AccessToken = require('twilio').jwt.AccessToken;
+
+const SyncOperations = require(Runtime.getFunctions()['common/twilio-wrappers/sync'].path);
 const { VideoGrant } = AccessToken;
 
-const requiredParameters = [
-  { key: "code", purpose: "used for connecting to the video room" },
-];
+const requiredParameters = [{ key: 'code', purpose: 'used for connecting to the video room' }];
 
 exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { code } = event;
-    
+
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
       attempts: 0,
       context,
       documentSid: code,
     });
-    
+
     if (!documentData) {
       response.setStatusCode(403);
       response.setBody({ error: `Invalid code.` });
       return callback(null, response);
     }
-    
+
     // Check if the video room was created already (i.e.: is the agent connected?)
     const { document } = documentData;
-    let room_name = document.data.room;
+    const room_name = document.data.room;
     if (!room_name) {
       response.setStatusCode(405);
       response.setBody({
@@ -37,33 +34,30 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       });
       return callback(null, response);
     }
-    
+
     /*
       - Generate a random identity for the customer
       - Note: could be replaced with additional data passed to the function
     */
     const client_identity = randomstring.generate();
-    
+
     // Create an access token which we will sign and return to the client,
-    const token = new AccessToken(
-      context.ACCOUNT_SID,
-      context.TWILIO_API_KEY,
-      context.TWILIO_API_SECRET,
-      { identity: client_identity }
-    );
-    
+    const token = new AccessToken(context.ACCOUNT_SID, context.TWILIO_API_KEY, context.TWILIO_API_SECRET, {
+      identity: client_identity,
+    });
+
     // Authorize the client Frontend to connect to VIDEO
     const videoGrant = new VideoGrant({
       room: room_name,
     });
     token.addGrant(videoGrant);
-    
+
     /*
       - Respond to the client with identity and token
       - Frontend JS can subscribe to the SYNC document and get notified when the agent connects
     */
     response.setBody({ token: token.toJwt() });
-    
+
     callback(null, response);
   } catch (error) {
     handleError(error);

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
@@ -58,8 +58,8 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
     */
     response.setBody({ token: token.toJwt() });
 
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
@@ -57,8 +57,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       full_url: `https://${context.DOMAIN_NAME}/features/chat-to-video/index.html?code=${unique_code}`,
     });
 
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
@@ -1,16 +1,12 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const SyncOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/sync"
-].path);
-const randomstring = require("randomstring");
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const SyncOperations = require(Runtime.getFunctions()['common/twilio-wrappers/sync'].path);
+const randomstring = require('randomstring');
 
 const requiredParameters = [
   {
-    key: "taskSid",
-    purpose: "used to update the task attributes and store in Sync document",
+    key: 'taskSid',
+    purpose: 'used to update the task attributes and store in Sync document',
   },
 ];
 
@@ -22,15 +18,15 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     - The unique code is also the unique name of the document so it's easy to find later on. 
     */
     const { taskSid } = event;
-    let unique_code = "";
+    let unique_code = '';
     let document = null;
-    
+
     while (!document) {
       unique_code = randomstring.generate({
         length: context.VIDEO_CODE_LENGTH,
-        charset: "alphanumeric",
+        charset: 'alphanumeric',
       });
-    
+
       document = await SyncOperations.createDocument({
         attempts: 0,
         context,
@@ -42,25 +38,25 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         },
       });
     }
-    
+
     const attributesUpdate = {
       syncDocument: document.document.sid,
     };
-    
+
     const result = await TaskOperations.updateTaskAttributes({
       context,
       taskSid,
       attributesUpdate: JSON.stringify(attributesUpdate),
       attempts: 0,
     });
-    
+
     response.setStatusCode(result.status);
     response.setBody({
-      unique_code: unique_code,
+      unique_code,
       valid_until: document.dateExpires,
       full_url: `https://${context.DOMAIN_NAME}/features/chat-to-video/index.html?code=${unique_code}`,
     });
-    
+
     callback(null, response);
   } catch (error) {
     handleError(error);

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -1,4 +1,5 @@
 const { isString, isObject, isNumber } = require('lodash');
+const axios = require('axios');
 
 const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
@@ -17,7 +18,7 @@ const COMPLETED = 'completed';
  *  channel data and marked as being "inflight".  Later setTaskToCompleteOnChannel
  *  is called which marks the task as "completed"
  */
-exports.addTaskToChannel = async function (parameters) {
+exports.addTaskToChannel = async (parameters) => {
   const { attempts, context, channelSid, taskSid } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -65,7 +66,7 @@ exports.addTaskToChannel = async function (parameters) {
  *  the chat channel attributes.  When called, the task sid is updated/added on the
  *  channel data and marked as being "complete".
  */
-exports.setTaskToCompleteOnChannel = async function (parameters) {
+exports.setTaskToCompleteOnChannel = async (parameters) => {
   const { attempts, context, channelSid, taskSid } = parameters;
 
   if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
@@ -121,8 +122,6 @@ exports.removeChannelSidFromTask = async function removeChannelSidFromTask(param
   if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
 
   try {
-    const axios = require('axios');
-
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;
     const config = {
       auth: {

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -51,7 +51,7 @@ exports.addTaskToChannel = async (parameters) => {
       channel: updatedChannel,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.addTaskToChannel);
   }
 };
 
@@ -99,7 +99,7 @@ exports.setTaskToCompleteOnChannel = async (parameters) => {
       channel: updatedChannel,
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.setTaskToCompleteOnChannel);
   }
 };
 
@@ -163,6 +163,6 @@ exports.removeChannelSidFromTask = async function removeChannelSidFromTask(param
       },
     };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.removeChannelSidFromTask);
   }
 };

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -1,11 +1,9 @@
-const { isString, isObject, isNumber } = require("lodash");
+const { isString, isObject, isNumber } = require('lodash');
 
-const retryHandler = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/retry-handler"
-].path).retryHandler;
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
-const INFLIGHT = "inflight";
-const COMPLETED = "completed";
+const INFLIGHT = 'inflight';
+const COMPLETED = 'completed';
 
 /**
  * @param {object} parameters the parameters for the function
@@ -22,26 +20,19 @@ const COMPLETED = "completed";
 exports.addTaskToChannel = async function (parameters) {
   const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(channelSid))
-    throw "Invalid parameters object passed. Parameters must contain channelSid string";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain taskSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
 
   try {
     const client = context.getTwilioClient();
-    const channel = await client.chat
-      .services(context.TWILIO_FLEX_CHAT_SERVICE_SID)
-      .channels(channelSid)
-      .fetch();
+    const channel = await client.chat.services(context.TWILIO_FLEX_CHAT_SERVICE_SID).channels(channelSid).fetch();
 
-    if (!channel) return { success: false, message: "channel not found" };
+    if (!channel) return { success: false, message: 'channel not found' };
 
     const currentAttributes = JSON.parse(channel.attributes);
-    let associatedTasks = currentAttributes.associatedTasks || {};
+    const associatedTasks = currentAttributes.associatedTasks || {};
     associatedTasks[taskSid] = INFLIGHT;
     const newAttributes = {
       ...currentAttributes,
@@ -77,26 +68,19 @@ exports.addTaskToChannel = async function (parameters) {
 exports.setTaskToCompleteOnChannel = async function (parameters) {
   const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(channelSid))
-    throw "Invalid parameters object passed. Parameters must contain channelSid string";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain taskSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
 
   try {
     const client = context.getTwilioClient();
-    const channel = await client.chat
-      .services(context.TWILIO_FLEX_CHAT_SERVICE_SID)
-      .channels(channelSid)
-      .fetch();
+    const channel = await client.chat.services(context.TWILIO_FLEX_CHAT_SERVICE_SID).channels(channelSid).fetch();
 
-    if (!channel) return { success: false, message: "channel not found" };
+    if (!channel) return { success: false, message: 'channel not found' };
 
     const currentAttributes = JSON.parse(channel.attributes);
-    let associatedTasks = currentAttributes.associatedTasks || {};
+    const associatedTasks = currentAttributes.associatedTasks || {};
     associatedTasks[taskSid] = COMPLETED;
     const newAttributes = {
       ...currentAttributes,
@@ -129,23 +113,18 @@ exports.setTaskToCompleteOnChannel = async function (parameters) {
  *  janitor will clean up chat channels if a task is completed that has
  *  a channel sid.
  */
-exports.removeChannelSidFromTask = async function removeChannelSidFromTask(
-  parameters
-) {
+exports.removeChannelSidFromTask = async function removeChannelSidFromTask(parameters) {
   const { attempts, context, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if (!isObject(context))
-    throw "Invalid parameters object passed. Parameters must contain context object";
-  if (!isString(taskSid))
-    throw "Invalid parameters object passed. Parameters must contain taskSid string";
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
 
   try {
-    const axios = require("axios");
+    const axios = require('axios');
 
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;
-    let config = {
+    const config = {
       auth: {
         username: context.ACCOUNT_SID,
         password: context.AUTH_TOKEN,
@@ -160,14 +139,14 @@ exports.removeChannelSidFromTask = async function removeChannelSidFromTask(
     task.revision = JSON.parse(getResponse.headers.etag);
 
     // merge the objects
-    let updatedTaskAttributes = task.attributes;
+    const updatedTaskAttributes = task.attributes;
     delete updatedTaskAttributes.channelSid;
 
     // if-match the revision number to ensure
     // no update collisions
     config.headers = {
-      "If-Match": task.revision,
-      "content-type": "application/x-www-form-urlencoded",
+      'If-Match': task.revision,
+      'content-type': 'application/x-www-form-urlencoded',
     };
 
     data = new URLSearchParams({

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -21,10 +21,12 @@ const COMPLETED = 'completed';
 exports.addTaskToChannel = async (parameters) => {
   const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');
+  if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -69,10 +71,12 @@ exports.addTaskToChannel = async (parameters) => {
 exports.setTaskToCompleteOnChannel = async (parameters) => {
   const { attempts, context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(channelSid)) throw 'Invalid parameters object passed. Parameters must contain channelSid string';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');
+  if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -117,9 +121,10 @@ exports.setTaskToCompleteOnChannel = async (parameters) => {
 exports.removeChannelSidFromTask = async function removeChannelSidFromTask(parameters) {
   const { attempts, context, taskSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(taskSid)) throw 'Invalid parameters object passed. Parameters must contain taskSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
 
   try {
     const taskContextURL = `https://taskrouter.twilio.com/v1/Workspaces/${process.env.TWILIO_FLEX_WORKSPACE_SID}/Tasks/${taskSid}`;

--- a/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
@@ -1,14 +1,10 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const ChatOperations = require(Runtime.getFunctions()[
-  "features/chat-transfer/common/chat-operations"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const ChatOperations = require(Runtime.getFunctions()['features/chat-transfer/common/chat-operations'].path);
 
 const requiredParameters = [
-  { key: "taskSid", purpose: "task sid to remove the chat channel from" },
-  { key: "transferType", purpose: "COLD or WARM transfer" },
+  { key: 'taskSid', purpose: 'task sid to remove the chat channel from' },
+  { key: 'transferType', purpose: 'COLD or WARM transfer' },
 ];
 
 /*
@@ -20,17 +16,16 @@ const requiredParameters = [
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { taskSid, transferType, channelSid } = event;
-    
+
     if (channelSid) {
       // remove channel sid from task to prevent janitor from closing chat channel
-      const { success: removeSidSuccess, message } =
-        await ChatOperations.removeChannelSidFromTask({
-          context,
-          taskSid,
-          attempts: 0,
-        });
+      const { success: removeSidSuccess, message } = await ChatOperations.removeChannelSidFromTask({
+        context,
+        taskSid,
+        attempts: 0,
+      });
       if (!removeSidSuccess) return { success: removeSidSuccess, message };
-      
+
       // update task data in channel to show this task is no longer in flight
       try {
         await ChatOperations.setTaskToCompleteOnChannel({
@@ -40,14 +35,18 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           attempts: 0,
         });
       } catch (error) {
-        console.error("Error updating chat channel with task sid as completed");
+        console.error('Error updating chat channel with task sid as completed');
       }
     }
-    
+
     // move the task to completed
     const reason = `Task ${transferType} Transfered to new task`;
-    const { success: completeTaskSuccess, message: completeTaskMessage } =
-      await TaskOperations.completeTask({context, taskSid, reason, attempts: 0});
+    const { success: completeTaskSuccess, message: completeTaskMessage } = await TaskOperations.completeTask({
+      context,
+      taskSid,
+      reason,
+      attempts: 0,
+    });
     response.setBody({ success: completeTaskSuccess, completeTaskMessage });
     callback(null, response);
   } catch (error) {

--- a/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
@@ -48,8 +48,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       attempts: 0,
     });
     response.setBody({ success: completeTaskSuccess, completeTaskMessage });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
@@ -1,32 +1,27 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
-const ChatOperations = require(Runtime.getFunctions()[
-  "features/chat-transfer/common/chat-operations"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
+const ChatOperations = require(Runtime.getFunctions()['features/chat-transfer/common/chat-operations'].path);
 
 const requiredParameters = [
   {
-    key: "conversationId",
-    purpose: "conversation_id to link tasks for reporting",
+    key: 'conversationId',
+    purpose: 'conversation_id to link tasks for reporting',
   },
   {
-    key: "jsonAttributes",
-    purpose: "JSON calling tasks attributes to perpetuate onto new task",
+    key: 'jsonAttributes',
+    purpose: 'JSON calling tasks attributes to perpetuate onto new task',
   },
   {
-    key: "transferTargetSid",
-    purpose: "sid of target worker or target queue",
+    key: 'transferTargetSid',
+    purpose: 'sid of target worker or target queue',
   },
   {
-    key: "transferQueueName",
-    purpose:
-      "name of the queue if transfering to a queue, otherwise empty string",
+    key: 'transferQueueName',
+    purpose: 'name of the queue if transfering to a queue, otherwise empty string',
   },
   {
-    key: "ignoreWorkerContactUri",
-    purpose: "woker Contact Uri to ignore when transfering",
+    key: 'ignoreWorkerContactUri',
+    purpose: 'woker Contact Uri to ignore when transfering',
   },
 ];
 
@@ -42,14 +37,12 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       timeout: overriddenTimeout,
       priority: overriddenPriority,
     } = event;
-    
+
     // use assigned values or use defaults
-    const workflowSid =
-      overriddenWorkflowSid ||
-      process.env.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID;
+    const workflowSid = overriddenWorkflowSid || process.env.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID;
     const timeout = overriddenTimeout || 86400;
     const priority = overriddenPriority || 0;
-    
+
     // setup the new task attributes based on the old
     const originalTaskAttributes = JSON.parse(jsonAttributes);
     const newAttributes = {
@@ -57,15 +50,13 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       ignoreWorkerContactUri,
       transferTargetSid,
       transferQueueName,
-      transferTargetType: transferTargetSid.startsWith("WK")
-        ? "worker"
-        : "queue",
+      transferTargetType: transferTargetSid.startsWith('WK') ? 'worker' : 'queue',
       conversations: {
         ...originalTaskAttributes.conversations,
         conversation_id: conversationId,
       },
     };
-    
+
     // create task for transfer
     const {
       success: createTaskSuccess,
@@ -74,13 +65,13 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     } = await TaskOperations.createTask({
       context,
       workflowSid,
-      taskChannel: "chat",
+      taskChannel: 'chat',
       attributes: newAttributes,
       priority,
       timeout,
       attempts: 0,
     });
-    
+
     // push task data into chat meta data so that should we end the chat while in queue
     // the customer front end can trigger cancelling tasks associated to the chat channel
     // this is not critical to transfer but is ideal
@@ -93,14 +84,12 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           attempts: 0,
         });
     } catch (error) {
-      console.error(
-        "Error updating chat channel with task sid created for it"
-      );
+      console.error('Error updating chat channel with task sid created for it');
     }
-    
+
     response.setStatusCode(createTaskStatus);
     response.setBody({ success: createTaskSuccess, taskSid: newTask.sid });
-    
+
     callback(null, response);
   } catch (error) {
     handleError(error);

--- a/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
@@ -90,8 +90,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     response.setStatusCode(createTaskStatus);
     response.setBody({ success: createTaskSuccess, taskSid: newTask.sid });
 
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
+++ b/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
@@ -1,11 +1,9 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ChatOperations = require(Runtime.getFunctions()[
-  "features/chat-transfer/common/chat-operations"
-].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ChatOperations = require(Runtime.getFunctions()['features/chat-transfer/common/chat-operations'].path);
 
 const requiredParameters = [
-  { key: "taskSid", purpose: "taskSid to add to channel attributes" },
-  { key: "channelSid", purpose: "channelSid to add task information to" },
+  { key: 'taskSid', purpose: 'taskSid to add to channel attributes' },
+  { key: 'channelSid', purpose: 'channelSid to add task information to' },
 ];
 
 exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {

--- a/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
+++ b/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
@@ -16,8 +16,8 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       attempts: 0,
     });
     response.setBody({ success });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -69,7 +69,6 @@ const getRoutingParams = (
 };
 
 exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, event, callback) {
-  const scriptName = arguments.callee.name;
   const response = new Twilio.Response();
 
   const requiredParameters = getRequiredParameters();
@@ -126,7 +125,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
       interactionSid: flexInteractionSid,
       channelSid: flexInteractionChannelSid,
       context,
-      scriptName,
       attempts: 0,
     };
 
@@ -148,7 +146,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
         interactionSid: flexInteractionSid,
         channelSid: flexInteractionChannelSid,
         participantSid: removeFlexInteractionParticipantSid,
-        scriptName,
         context,
         attempts: 0,
       });

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
@@ -21,7 +21,6 @@ const getRequiredParameters = () => {
 };
 
 exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, event, callback) {
-  const scriptName = arguments.callee.name;
   const response = new Twilio.Response();
 
   const requiredParameters = getRequiredParameters();
@@ -51,7 +50,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
       interactionSid: flexInteractionSid,
       channelSid: flexInteractionChannelSid,
       participantSid: flexInteractionParticipantSid,
-      scriptName,
       context,
       attempts: 0,
     });

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
@@ -1,51 +1,39 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
-const InteractionsOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/interactions"
-].path);
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
+const InteractionsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/interactions'].path);
 
 const getRequiredParameters = (event) => {
-  const requiredParameters = [
+  return [
     {
-      key: "flexInteractionSid",
-      purpose: "KDxxx sid for inteactions API",
+      key: 'flexInteractionSid',
+      purpose: 'KDxxx sid for inteactions API',
     },
     {
-      key: "flexInteractionChannelSid",
-      purpose: "UOxxx sid for interactions API",
+      key: 'flexInteractionChannelSid',
+      purpose: 'UOxxx sid for interactions API',
     },
     {
-      key: "flexInteractionParticipantSid",
-      purpose: "UTxxx sid for interactions API",
+      key: 'flexInteractionParticipantSid',
+      purpose: 'UTxxx sid for interactions API',
     },
   ];
-  return requiredParameters;
 };
 
-exports.handler = TokenValidator(async function chat_transfer_v2_cbm(
-  context,
-  event,
-  callback
-) {
+exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, event, callback) {
   const scriptName = arguments.callee.name;
   const response = new Twilio.Response();
 
   const requiredParameters = getRequiredParameters(event);
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
+  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
 
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+  response.appendHeader('Access-Control-Allow-Origin', '*');
+  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
+  response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
   if (Object.keys(event).length === 0) {
-    console.log("Empty event object, likely an OPTIONS request");
+    console.log('Empty event object, likely an OPTIONS request');
     return callback(null, response);
   }
 
@@ -55,14 +43,10 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(
     callback(null, response);
   } else {
     try {
-      const {
-        flexInteractionSid,
-        flexInteractionChannelSid,
-        flexInteractionParticipantSid,
-      } = event;
+      const { flexInteractionSid, flexInteractionChannelSid, flexInteractionParticipantSid } = event;
 
       await InteractionsOperations.participantUpdate({
-        status: "closed",
+        status: 'closed',
         interactionSid: flexInteractionSid,
         channelSid: flexInteractionChannelSid,
         participantSid: flexInteractionParticipantSid,

--- a/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
+++ b/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
@@ -1,27 +1,23 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
-const requiredParameters = [
-  { key: "callSid", purpose: "unique ID of call to record" },
-];
+const requiredParameters = [{ key: 'callSid', purpose: 'unique ID of call to record' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid } = event;
-    
+
     const result = await VoiceOperations.createRecording({
       context,
       callSid,
       params: {
-        recordingChannels: 'dual'
+        recordingChannels: 'dual',
       },
       attempts: 0,
     });
-    
+
     const { success, recording, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);

--- a/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
+++ b/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
@@ -20,8 +20,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, recording });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
+++ b/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
@@ -1,4 +1,4 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
@@ -8,21 +8,17 @@ const requiredParameters = [
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-    const {
-        conference,
-        participant
-    } = event;
-    
-    const result = await ConferenceOperations.fetchParticipant(
-      {
-        context,
-        conference,
-        participant,
-        attempts: 0
-      });
-    
+    const { conference, participant } = event;
+
+    const result = await ConferenceOperations.fetchParticipant({
+      context,
+      conference,
+      participant,
+      attempts: 0,
+    });
+
     const { success, participantsResponse, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
     callback(null, response);

--- a/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
+++ b/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
@@ -21,8 +21,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, participantsResponse });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/internal-call/common/agent-join-conference.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/agent-join-conference.protected.js
@@ -8,5 +8,5 @@ exports.handler = (context, event, callback) => {
     event.conferenceName,
   );
 
-  callback(null, twiml);
+  return callback(null, twiml);
 };

--- a/serverless-functions/src/functions/features/internal-call/common/agent-join-conference.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/agent-join-conference.protected.js
@@ -1,9 +1,12 @@
 exports.handler = (context, event, callback) => {
-	let twiml = new Twilio.twiml.VoiceResponse();
+  const twiml = new Twilio.twiml.VoiceResponse();
 
-    twiml.dial().conference({
-        endConferenceOnExit: true,
-    }, event.conferenceName);
-    
-    callback(null, twiml);
+  twiml.dial().conference(
+    {
+      endConferenceOnExit: true,
+    },
+    event.conferenceName,
+  );
+
+  callback(null, twiml);
 };

--- a/serverless-functions/src/functions/features/internal-call/common/agent-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/agent-outbound-join.protected.js
@@ -10,5 +10,5 @@ exports.handler = (context, event, callback) => {
     event.taskSid,
   );
 
-  callback(null, twiml);
+  return callback(null, twiml);
 };

--- a/serverless-functions/src/functions/features/internal-call/common/agent-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/agent-outbound-join.protected.js
@@ -1,11 +1,14 @@
 exports.handler = (context, event, callback) => {
-    let twiml = new Twilio.twiml.VoiceResponse();
-  
-        twiml.dial().conference({
-          statusCallback: 'call-outbound-join',
-          statusCallbackEvent: 'join end',
-          endConferenceOnExit: true,
-        }, event.taskSid);
-    
-      callback(null, twiml);
-  };
+  const twiml = new Twilio.twiml.VoiceResponse();
+
+  twiml.dial().conference(
+    {
+      statusCallback: 'call-outbound-join',
+      statusCallbackEvent: 'join end',
+      endConferenceOnExit: true,
+    },
+    event.taskSid,
+  );
+
+  callback(null, twiml);
+};

--- a/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
@@ -1,17 +1,15 @@
-const TaskOperations = require(Runtime.getFunctions()["common/twilio-wrappers/taskrouter"].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 exports.handler = async function callOutboundJoin(context, event, callback) {
   const client = context.getTwilioClient();
   const { FriendlyName: taskSid, ConferenceSid } = event;
 
-  if (event.StatusCallbackEvent === "participant-join") {
-    console.log(
-      `callSid ${event.CallSid} joined, task is ${taskSid}, conference is ${event.ConferenceSid}`
-    );
+  if (event.StatusCallbackEvent === 'participant-join') {
+    console.log(`callSid ${event.CallSid} joined, task is ${taskSid}, conference is ${event.ConferenceSid}`);
 
     const call = await client.calls(event.CallSid).fetch();
 
-    if (call.to.includes("client")) {
+    if (call.to.includes('client')) {
       console.log(`agent ${call.to} joined the conference`);
 
       const fetchTaskResult = await TaskOperations.fetchTask({
@@ -19,10 +17,10 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
         taskSid,
         attempts: 0,
       });
-      
+
       const { task } = fetchTaskResult;
 
-      let newAttributes = {
+      const newAttributes = {
         conference: {
           sid: event.ConferenceSid,
           participants: {
@@ -33,32 +31,32 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
 
       if (task.attributes.worker_call_sid === newAttributes.conference.participants.worker) {
         const { to, fromName, targetWorker } = task.attributes;
-        
-        if (to.substring(0, 6) === "client") {
+
+        if (to.substring(0, 6) === 'client') {
           const createTaskResult = await TaskOperations.createTask({
             context,
             attributes: {
-              to: to,
+              to,
               name: fromName,
               from: targetWorker,
               targetWorker: to,
-              autoAnswer: "false",
+              autoAnswer: 'false',
               conferenceSid: taskSid,
               conference: {
                 sid: ConferenceSid,
                 friendlyName: taskSid,
               },
-              internal: "true",
+              internal: 'true',
               client_call: true,
             },
             workflowSid: process.env.TWILIO_FLEX_INTERNAL_CALL_WORKFLOW_SID,
-            taskChannel: "voice",
+            taskChannel: 'voice',
             attempts: 0,
           });
-          
+
           newAttributes.conference.participants.taskSid = createTaskResult.task.sid;
         }
-        
+
         await TaskOperations.updateTaskAttributes({
           context,
           taskSid,
@@ -69,29 +67,28 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
     }
   }
 
-  if (event.StatusCallbackEvent === "conference-end") {
+  if (event.StatusCallbackEvent === 'conference-end') {
     try {
       const fetchTaskResult = await TaskOperations.fetchTask({
         context,
         taskSid,
         attempts: 0,
       });
-      
+
       const { task } = fetchTaskResult;
 
-      if (["assigned", "pending", "reserved"].includes(task.assignmentStatus)) {
+      if (['assigned', 'pending', 'reserved'].includes(task.assignmentStatus)) {
         await TaskOperations.updateTask({
           context,
           taskSid,
           updateParams: {
-            assignmentStatus:
-              task.assignmentStatus === "assigned" ? "wrapping" : "canceled",
-            reason: "conference is complete",
+            assignmentStatus: task.assignmentStatus === 'assigned' ? 'wrapping' : 'canceled',
+            reason: 'conference is complete',
           },
           attempts: 0,
         });
       }
-      
+
       const targetTaskSid = task.attributes.conference?.participants?.taskSid;
 
       if (targetTaskSid) {
@@ -100,17 +97,16 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
           taskSid: targetTaskSid,
           attempts: 0,
         });
-        
+
         const { task: targetTask } = fetchTargetTaskResult;
 
-        if (["assigned", "pending", "reserved"].includes(targetTask.assignmentStatus)) {
+        if (['assigned', 'pending', 'reserved'].includes(targetTask.assignmentStatus)) {
           await TaskOperations.updateTask({
             context,
             taskSid: targetTaskSid,
             updateParams: {
-              assignmentStatus:
-                targetTask.assignmentStatus === "assigned" ? "wrapping" : "canceled",
-              reason: "conference is complete",
+              assignmentStatus: targetTask.assignmentStatus === 'assigned' ? 'wrapping' : 'canceled',
+              reason: 'conference is complete',
             },
             attempts: 0,
           });

--- a/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
@@ -117,5 +117,5 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
     }
   }
 
-  callback(null);
+  return callback(null);
 };

--- a/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
+++ b/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
@@ -16,8 +16,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     });
 
     if (!conferencesResponse.success) {
-      callback(null, assets.response('json', {}));
-      return;
+      return callback(null, assets.response('json', {}));
     }
 
     await Promise.all(
@@ -32,8 +31,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     );
 
     response.setBody({});
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
+++ b/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
@@ -1,38 +1,36 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
-const requiredParameters = [
-  { key: 'taskSid', purpose: 'unique ID of task to clean up' },
-];
+const requiredParameters = [{ key: 'taskSid', purpose: 'unique ID of task to clean up' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { taskSid } = event;
-    
-    const conferencesResponse = await ConferenceOperations.fetchByTask(
-    {
+
+    const conferencesResponse = await ConferenceOperations.fetchByTask({
       context,
       taskSid,
       status: 'in-progress',
       limit: 20,
-      attempts: 0
+      attempts: 0,
     });
-    
+
     if (!conferencesResponse.success) {
-      callback(null, assets.response("json", {}));
+      callback(null, assets.response('json', {}));
       return;
     }
-      
-    await Promise.all(conferencesResponse.conferences.map(conference => {
-      return ConferenceOperations.updateConference(
-        {
+
+    await Promise.all(
+      conferencesResponse.conferences.map((conference) => {
+        return ConferenceOperations.updateConference({
           context,
           conference: conference.sid,
-          updateParams: {status: 'completed'},
-          attempts: 0
+          updateParams: { status: 'completed' },
+          attempts: 0,
         });
-    }))
-    
+      }),
+    );
+
     response.setBody({});
     callback(null, response);
   } catch (error) {

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
@@ -22,8 +22,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, recording });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
@@ -1,29 +1,25 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
-const requiredParameters = [
-  { key: "callSid", purpose: "unique ID of call to pause recording" },
-];
+const requiredParameters = [{ key: 'callSid', purpose: 'unique ID of call to pause recording' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, pauseBehavior, recordingSid } = event;
-    
+
     const result = await VoiceOperations.updateCallRecording({
       context,
       callSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {
         status: 'paused',
-        pauseBehavior: pauseBehavior ?? 'silence'
+        pauseBehavior: pauseBehavior ?? 'silence',
       },
       attempts: 0,
     });
-    
+
     const { success, recording, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
@@ -22,8 +22,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, recording });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
@@ -1,29 +1,25 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
-const requiredParameters = [
-  { key: "conferenceSid", purpose: "unique ID of conference to pause recording" },
-];
+const requiredParameters = [{ key: 'conferenceSid', purpose: 'unique ID of conference to pause recording' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conferenceSid, pauseBehavior, recordingSid } = event;
-    
+
     const result = await VoiceOperations.updateConferenceRecording({
       context,
       conferenceSid,
       recordingSid: recordingSid ?? 'Twilio.CURRENT',
       params: {
         status: 'paused',
-        pauseBehavior: pauseBehavior ?? 'silence'
+        pauseBehavior: pauseBehavior ?? 'silence',
       },
       attempts: 0,
     });
-    
+
     const { success, recording, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
@@ -1,29 +1,27 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
 const requiredParameters = [
-  { key: "callSid", purpose: "unique ID of call to resume recording" },
-  { key: "recordingSid", purpose: "unique ID of recording to resume" },
+  { key: 'callSid', purpose: 'unique ID of call to resume recording' },
+  { key: 'recordingSid', purpose: 'unique ID of recording to resume' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { callSid, recordingSid } = event;
-    
+
     const result = await VoiceOperations.updateCallRecording({
       context,
       callSid,
       recordingSid,
       params: {
-        status: 'in-progress'
+        status: 'in-progress',
       },
       attempts: 0,
     });
-    
+
     const { success, recording, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
@@ -24,8 +24,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, recording });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
@@ -24,8 +24,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, recording });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
@@ -1,29 +1,27 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const VoiceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/programmable-voice"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
 const requiredParameters = [
-  { key: "conferenceSid", purpose: "unique ID of conference to resume recording" },
-  { key: "recordingSid", purpose: "unique ID of recording to resume" },
+  { key: 'conferenceSid', purpose: 'unique ID of conference to resume recording' },
+  { key: 'recordingSid', purpose: 'unique ID of recording to resume' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { conferenceSid, recordingSid } = event;
-    
+
     const result = await VoiceOperations.updateConferenceRecording({
       context,
       conferenceSid,
       recordingSid,
       params: {
-        status: 'in-progress'
+        status: 'in-progress',
       },
       attempts: 0,
     });
-    
+
     const { success, recording, status } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, recording });
     callback(null, response);

--- a/serverless-functions/src/functions/features/queue-stats-and-metadata/refresh-stats.protected.js
+++ b/serverless-functions/src/functions/features/queue-stats-and-metadata/refresh-stats.protected.js
@@ -1,679 +1,678 @@
 /*
  *  Written By: Jared Hunter
  *
- *  This function was written to reliably list all taskrouter queues for a 
- *  flex workspace and maintains them in a sync map (adding and removing 
+ *  This function was written to reliably list all taskrouter queues for a
+ *  flex workspace and maintains them in a sync map (adding and removing
  *  from the sync map as queues are added or deleted)
- * 
- *  this sync map can then be used to manage metadata for each queue.  
- *  Each time this function is run stats for the queue are fetched and 
+ *
+ *  this sync map can then be used to manage metadata for each queue.
+ *  Each time this function is run stats for the queue are fetched and
  *   merged with the metadata.
- * 
- *  all this data is returned to the calling location which is intended to be 
- *  a backend system that can periodically calls this function, caches the result, 
- *  and expose the cache via its own API.  This is useful when a solution wants to 
+ *
+ *  all this data is returned to the calling location which is intended to be
+ *  a backend system that can periodically calls this function, caches the result,
+ *  and expose the cache via its own API.  This is useful when a solution wants to
  *  expose queue stats or queue configuration to something outside of flex such as
- *  the IVR.  An example use case might be for returning operational hours 
- *  (metadata) and approximate wait times to be used in the IVR in a scalable 
- *  manner.  
- * 
+ *  the IVR.  An example use case might be for returning operational hours
+ *  (metadata) and approximate wait times to be used in the IVR in a scalable
+ *  manner.
+ *
  *  the sync map allows for managing the metadata through an admin panel
  *  in a custom component in flex ui
  *
  *  DEPENDENCIES: After creating function ensure environment variable is added
  *     TWILIO_FLEX_WORKSPACE_SID    - assign the value of your flex workspace
- *     TWILIO_FLEX_SYNC_SID         - assign the value of the sync service to map 
+ *     TWILIO_FLEX_SYNC_SID         - assign the value of the sync service to map
  *                                  stats
- * 
- *     TWILIO_SERVICE_RETRY_LIMIT   - max number of retry attempts, 
+ *
+ *     TWILIO_SERVICE_RETRY_LIMIT   - max number of retry attempts,
  *                                  applicable to sync and task router queries
  *     TWILIO_SERVICE_MAX_BACKOFF   - max back of period the queries to task router
  *                                  will take when retrying, recommend 0 if twilio
  *                                  hosted
  *     TWILIO_SERVICE_MIN_BACKOFF   - min back of period the queries to task router
- *                                  will take when retrying, recommend 0 if twilio 
+ *                                  will take when retrying, recommend 0 if twilio
  *                                  hosted
- * 
- *     TWILIO_SYNC_MAX_BACKOFF      - max back of period the queries to sync will 
+ *
+ *     TWILIO_SYNC_MAX_BACKOFF      - max back of period the queries to sync will
  *                                  take when retrying, recommend 2000
- *     TWILIO_SYNC_MIN_BACKOFF      - min back of period the queries to task router 
+ *     TWILIO_SYNC_MIN_BACKOFF      - min back of period the queries to task router
  *                                  will take when retrying, recommend 1000
- *     
+ *
  *     QUEUE_STATS_MAP_NAME         - name of syncMap to store stats
- *     QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES  - period in minutes from which to 
+ *     QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES  - period in minutes from which to
  *                                            count stats backwards from now
- *     QUEUE_STATS_SLA_SPLIT_PERIODS - split periods to cut cumulative stats 
+ *     QUEUE_STATS_SLA_SPLIT_PERIODS - split periods to cut cumulative stats
  *                                    by 30,60,120
- *     QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE - throttle on max concurrent requests 
+ *     QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE - throttle on max concurrent requests
  *                                             to task router
- *     QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE - throttle on max concurrent 
+ *     QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE - throttle on max concurrent
  *                                            requests to sync
  */
 
-exports.handler = function refreshStats (context, event, callback) {
-    const client = context.getTwilioClient();
-    const syncService = client.sync.services(context.TWILIO_FLEX_SYNC_SID);
-    const response = new Twilio.Response();
+exports.handler = function refreshStats(context, event, callback) {
+  const client = context.getTwilioClient();
+  const syncService = client.sync.services(context.TWILIO_FLEX_SYNC_SID);
+  const response = new Twilio.Response();
 
-    const QUEUE_STATS_MAP_NAME = process.env.QUEUE_STATS_MAP_NAME
-    const START_DATE = new Date((new Date()) - process.env.QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES*60000);
-    const QUEUE_STATS_SLA_SPLIT_PERIODS = process.env.QUEUE_STATS_SLA_SPLIT_PERIODS
-    const TWILIO_SERVICE_MAX_BACKOFF = process.env.TWILIO_SERVICE_MAX_BACKOFF
-    const TWILIO_SERVICE_MIN_BACKOFF = process.env.TWILIO_SERVICE_MIN_BACKOFF
-    const TWILIO_SYNC_MAX_BACKOFF = process.env.TWILIO_SYNC_MAX_BACKOFF
-    const TWILIO_SYNC_MIN_BACKOFF = process.env.TWILIO_SYNC_MIN_BACKOFF
-    const TWILIO_SERVICE_RETRY_LIMIT = process.env.TWILIO_SERVICE_RETRY_LIMIT
-    const QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE = process.env.QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE
-    const QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE = process.env.QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE
+  const QUEUE_STATS_MAP_NAME = process.env.QUEUE_STATS_MAP_NAME;
+  const START_DATE = new Date(new Date() - process.env.QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES * 60000);
+  const QUEUE_STATS_SLA_SPLIT_PERIODS = process.env.QUEUE_STATS_SLA_SPLIT_PERIODS;
+  const TWILIO_SERVICE_MAX_BACKOFF = process.env.TWILIO_SERVICE_MAX_BACKOFF;
+  const TWILIO_SERVICE_MIN_BACKOFF = process.env.TWILIO_SERVICE_MIN_BACKOFF;
+  const TWILIO_SYNC_MAX_BACKOFF = process.env.TWILIO_SYNC_MAX_BACKOFF;
+  const TWILIO_SYNC_MIN_BACKOFF = process.env.TWILIO_SYNC_MIN_BACKOFF;
+  const TWILIO_SERVICE_RETRY_LIMIT = process.env.TWILIO_SERVICE_RETRY_LIMIT;
+  const QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE = process.env.QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE;
+  const QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE = process.env.QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE;
 
-    var errorMessages;
-  
-    response.appendHeader("Access-Control-Allow-Origin", "*");
-    response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-    response.appendHeader("Content-Type", "application/json");
-    response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-  
-    const validateParameters = function(context, event) {
-      errorMessages = "";
-      errorMessages += context.TWILIO_FLEX_WORKSPACE_SID
-        ? ""
-        : "Missing TWILIO_FLEX_WORKSPACE_SID from context environment variables, ";
-      errorMessages += context.TWILIO_FLEX_SYNC_SID
-        ? ""
-        : "Missing TWILIO_FLEX_SYNC_SID from context environment variables, ";
-      errorMessages += context.QUEUE_STATS_MAP_NAME
-        ? ""
-        : "Missing QUEUE_STATS_MAP_NAME from context environment variables, ";
-      errorMessages += context.QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES
-        ? ""
-        : "Missing QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES  from context environment variables, ";
-      errorMessages += context.QUEUE_STATS_SLA_SPLIT_PERIODS
-      ? ""
-      : "Missing QUEUE_STATS_SLA_SPLIT_PERIODS from context environment variables, ";
-      errorMessages += context.TWILIO_SERVICE_MAX_BACKOFF
-      ? ""
-      : "Missing TWILIO_SERVICE_MAX_BACKOFF from context environment variables, ";
-      errorMessages += context.TWILIO_SERVICE_MIN_BACKOFF
-      ? ""
-      : "Missing TWILIO_SERVICE_MIN_BACKOFF from context environment variables, ";
-      errorMessages += context.TWILIO_SYNC_MAX_BACKOFF
-      ? ""
-      : "Missing TWILIO_SYNC_MAX_BACKOFF from context environment variables, ";
-      errorMessages += context.TWILIO_SYNC_MIN_BACKOFF
-      ? ""
-      : "Missing TWILIO_SYNC_MIN_BACKOFF from context environment variables, ";
-      errorMessages += context.TWILIO_SERVICE_RETRY_LIMIT
-      ? ""
-      : "Missing TWILIO_SERVICE_RETRY_LIMIT from context environment variables, ";
-      errorMessages += context.QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE
-      ? ""
-      : "Missing QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE from context environment variables, ";
-      errorMessages += context.QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE
-      ? ""
-      : "Missing QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE from context environment variables, ";
-      if (errorMessages === "") {
-        return true;
+  let errorMessages;
+
+  response.appendHeader('Access-Control-Allow-Origin', '*');
+  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
+  response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  const validateParameters = function (context, event) {
+    errorMessages = '';
+    errorMessages += context.TWILIO_FLEX_WORKSPACE_SID
+      ? ''
+      : 'Missing TWILIO_FLEX_WORKSPACE_SID from context environment variables, ';
+    errorMessages += context.TWILIO_FLEX_SYNC_SID
+      ? ''
+      : 'Missing TWILIO_FLEX_SYNC_SID from context environment variables, ';
+    errorMessages += context.QUEUE_STATS_MAP_NAME
+      ? ''
+      : 'Missing QUEUE_STATS_MAP_NAME from context environment variables, ';
+    errorMessages += context.QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES
+      ? ''
+      : 'Missing QUEUE_STATS_CUMULATIVE_PERIOD_MINUTES  from context environment variables, ';
+    errorMessages += context.QUEUE_STATS_SLA_SPLIT_PERIODS
+      ? ''
+      : 'Missing QUEUE_STATS_SLA_SPLIT_PERIODS from context environment variables, ';
+    errorMessages += context.TWILIO_SERVICE_MAX_BACKOFF
+      ? ''
+      : 'Missing TWILIO_SERVICE_MAX_BACKOFF from context environment variables, ';
+    errorMessages += context.TWILIO_SERVICE_MIN_BACKOFF
+      ? ''
+      : 'Missing TWILIO_SERVICE_MIN_BACKOFF from context environment variables, ';
+    errorMessages += context.TWILIO_SYNC_MAX_BACKOFF
+      ? ''
+      : 'Missing TWILIO_SYNC_MAX_BACKOFF from context environment variables, ';
+    errorMessages += context.TWILIO_SYNC_MIN_BACKOFF
+      ? ''
+      : 'Missing TWILIO_SYNC_MIN_BACKOFF from context environment variables, ';
+    errorMessages += context.TWILIO_SERVICE_RETRY_LIMIT
+      ? ''
+      : 'Missing TWILIO_SERVICE_RETRY_LIMIT from context environment variables, ';
+    errorMessages += context.QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE
+      ? ''
+      : 'Missing QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE from context environment variables, ';
+    errorMessages += context.QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE
+      ? ''
+      : 'Missing QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE from context environment variables, ';
+    if (errorMessages === '') {
+      return true;
+    }
+    return false;
+  };
+
+  const snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const getRandomIntInclusive = function (min, max) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1) + min); // The maximum is inclusive and the minimum is inclusive
+  };
+
+  const chunkArray = function (array, size) {
+    const result = [];
+    for (value of array) {
+      const lastArray = result[result.length - 1];
+      if (!lastArray || lastArray.length == size) {
+        result.push([value]);
       } else {
-        return false;
+        lastArray.push(value);
       }
-    };
-
-    const snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
-
-    const getRandomIntInclusive = function (min, max) {
-      min = Math.ceil(min);
-      max = Math.floor(max);
-      return Math.floor(Math.random() * (max - min + 1) + min); //The maximum is inclusive and the minimum is inclusive 
     }
+    return result;
+  };
 
-    const chunkArray = function (array, size) {
-      let result = []
-      for (value of array){
-          let lastArray = result[result.length -1 ]
-          if(!lastArray || lastArray.length == size){
-              result.push([value])
-          } else{
-              lastArray.push(value)
-          }
-      }
-      return result
-    }
-
-    const listQueues = function(twilioClient) {
-      return new Promise(function(resolve, reject) {
-        twilioClient.taskrouter
-          .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
-          .taskQueues.list()
-          .then(result => {
-            var queueArray = [];
-            result.forEach(arrayItem => {
-              queueArray.push({
-                sid: arrayItem.sid,
-                friendlyName: arrayItem.friendlyName,
-                realTimeStats: {},
-                cumulativeStats: {},
-                customQueueConfiguration: {}
-              });
+  const listQueues = function (twilioClient) {
+    return new Promise(function (resolve, reject) {
+      twilioClient.taskrouter
+        .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
+        .taskQueues.list()
+        .then((result) => {
+          const queueArray = [];
+          result.forEach((arrayItem) => {
+            queueArray.push({
+              sid: arrayItem.sid,
+              friendlyName: arrayItem.friendlyName,
+              realTimeStats: {},
+              cumulativeStats: {},
+              customQueueConfiguration: {},
             });
-            resolve({ success: true, queueArray: queueArray });
-          })
-          .catch(err => {
-            console.log("err message: ", err.message);
-            resolve({ success: false, message: err.message });
           });
-      });
-    }
+          resolve({ success: true, queueArray });
+        })
+        .catch((err) => {
+          console.log('err message: ', err.message);
+          resolve({ success: false, message: err.message });
+        });
+    });
+  };
 
-    // retrieves all queues for the environment configured workspace
-    // then proceeds to fetch all stats data for them
-    // returns an array of objects for each queue populated with the relevant stats nested on
-    // the object.  This is done by batching up the requests as promises and execute the promises 
-    // in batches
-    // {
-    //   sid:   // queue SID
-    //   friendlyName: // queue friendly name
-    //   realTimeStats: {}, // queue real time stats information
-    //   cumulativeStats: {}, // queue cumulative stats for the preset configured period
-    //   customQueueConfiguration: {} // configuration object for the custom queue meta data such as open and close times
-    // }
-    const fetchAllQueueStatistics = function(twilioClient) {
-      return new Promise(async function(resolve, reject) {
-        listQueues(twilioClient).then(result => {
+  // retrieves all queues for the environment configured workspace
+  // then proceeds to fetch all stats data for them
+  // returns an array of objects for each queue populated with the relevant stats nested on
+  // the object.  This is done by batching up the requests as promises and execute the promises
+  // in batches
+  // {
+  //   sid:   // queue SID
+  //   friendlyName: // queue friendly name
+  //   realTimeStats: {}, // queue real time stats information
+  //   cumulativeStats: {}, // queue cumulative stats for the preset configured period
+  //   customQueueConfiguration: {} // configuration object for the custom queue meta data such as open and close times
+  // }
+  const fetchAllQueueStatistics = function (twilioClient) {
+    return new Promise(async function (resolve, reject) {
+      listQueues(twilioClient)
+        .then((result) => {
           if (result.success) {
-            var queueResultsArray = result.queueArray;
-            var getStatsPromiseArray = [];
-            queueResultsArray.forEach(queueItem => {
-              
+            const queueResultsArray = result.queueArray;
+            const getStatsPromiseArray = [];
+            queueResultsArray.forEach((queueItem) => {
               // Every cycle retreive realtime stats and cumulative stats for all known channels
               // comment out the channel if it is not used,
               // to save on redundent calls to backend
 
-              getStatsPromiseArray.push(
-                populateRealTimeStatsForQueueItem(twilioClient, queueItem, null, 0, 0)
-              );
-  
-              //get stats filtered by channel
-              getStatsPromiseArray.push(
-                populateRealTimeStatsForQueueItem(twilioClient, queueItem, "voice", 0, 0)
-              );
+              getStatsPromiseArray.push(populateRealTimeStatsForQueueItem(twilioClient, queueItem, null, 0, 0));
 
-               getStatsPromiseArray.push(
-                populateRealTimeStatsForQueueItem(twilioClient, queueItem, "chat", 0, 0)
-              );
-              
-  
-              //Now get cumulative stats for each queue, broken down by channel
-              getStatsPromiseArray.push(
-                populateCumulativeStatsForQueueItem(twilioClient, queueItem, null, 0, 0)
-              );
-  
-              getStatsPromiseArray.push(
-                populateCumulativeStatsForQueueItem(twilioClient, queueItem, "voice", 0, 0)
-              );
-  
-              getStatsPromiseArray.push(
-                populateCumulativeStatsForQueueItem(twilioClient, queueItem, "chat", 0, 0)
-              );
-  
+              // get stats filtered by channel
+              getStatsPromiseArray.push(populateRealTimeStatsForQueueItem(twilioClient, queueItem, 'voice', 0, 0));
+
+              getStatsPromiseArray.push(populateRealTimeStatsForQueueItem(twilioClient, queueItem, 'chat', 0, 0));
+
+              // Now get cumulative stats for each queue, broken down by channel
+              getStatsPromiseArray.push(populateCumulativeStatsForQueueItem(twilioClient, queueItem, null, 0, 0));
+
+              getStatsPromiseArray.push(populateCumulativeStatsForQueueItem(twilioClient, queueItem, 'voice', 0, 0));
+
+              getStatsPromiseArray.push(populateCumulativeStatsForQueueItem(twilioClient, queueItem, 'chat', 0, 0));
             });
 
-            //break the array into batches and process each batch sequentially to throttle max API calls used
+            // break the array into batches and process each batch sequentially to throttle max API calls used
             // remember there is a max of 100 concurrent inbound calls to twilio and there are other
             // customer solutions/features that will be making calls.
-            var batchedArrays = chunkArray(getStatsPromiseArray, QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE);
+            const batchedArrays = chunkArray(getStatsPromiseArray, QUEUE_STATS_TASKROUTER_STATS_BATCH_SIZE);
 
-            processPromiseBatchArray(batchedArrays.reverse())
-            .then(() => {
-              resolve(queueResultsArray)
+            processPromiseBatchArray(batchedArrays.reverse()).then(() => {
+              resolve(queueResultsArray);
             });
-
-          }
-          else {
+          } else {
             console.log(`ERROR: Failure retrieving queues`);
             reject('ERROR: Failed to retrieve queues');
           }
         })
-        .catch(err => {
+        .catch((err) => {
           console.log(`ERROR: Failure retrieving queues: ${err}`);
           reject(`ERROR: Failed to retrieve queuest. ${err.message}`);
-        })
-      });
-    }
+        });
+    });
+  };
 
-    // Generic function for processing a batched array of promise arrays
-    const processPromiseBatchArray = function(promiseBatchArray){
-      return new Promise(async function(resolve, reject) {
-        var batch = promiseBatchArray.pop()
-        if(batch){
-          Promise.all(batch)
+  // Generic function for processing a batched array of promise arrays
+  const processPromiseBatchArray = function (promiseBatchArray) {
+    return new Promise(async function (resolve, reject) {
+      const batch = promiseBatchArray.pop();
+      if (batch) {
+        Promise.all(batch)
           .then(() => {
-            if(promiseBatchArray.length > 0){
-              processPromiseBatchArray(promiseBatchArray)
-              .then(() => {
-                resolve()
+            if (promiseBatchArray.length > 0) {
+              processPromiseBatchArray(promiseBatchArray).then(() => {
+                resolve();
               });
-            }
-            else{
+            } else {
               resolve();
             }
           })
-          .catch(err => {
+          .catch((err) => {
             console.log(`ERROR DURING processing BATCH`);
           });
-        }
-        else{
-          console.log(`batch empty`)
-          resolve();
-        }
-      });
-    }
+      } else {
+        console.log(`batch empty`);
+        resolve();
+      }
+    });
+  };
 
-    // function for retrieving or creating sync map which will retry recursively
-    const fetchOrCreateSyncMap = function(mapName, create, delay, retryAttempts) {
-      return new Promise(async function(resolve, reject) {
+  // function for retrieving or creating sync map which will retry recursively
+  const fetchOrCreateSyncMap = function (mapName, create, delay, retryAttempts) {
+    return new Promise(async function (resolve, reject) {
+      // delay random backoff period
+      await snooze(delay);
 
-        // delay random backoff period
-        await snooze(delay);
-
-        if(create == false){
-          syncService
+      if (create == false) {
+        syncService
           .syncMaps(mapName)
           .fetch()
-          .then(syncMap => {
-            resolve(syncMap)
+          .then((syncMap) => {
+            resolve(syncMap);
           })
-          .catch(err => {
+          .catch((err) => {
             // 20404 item not found https://www.twilio.com/docs/api/errors/20404
             // attempt to create it
-            if(err.code == 20404){
+            if (err.code == 20404) {
               console.log(`syncMap ${mapName} not found, attempting to create it`);
-              fetchOrCreateSyncMap(mapName, true, delay, retryAttempts+1)
-              .then(syncMap => {
-                resolve(syncMap)
-              })
-              .catch(err => {
-                reject(err);
-              })
+              fetchOrCreateSyncMap(mapName, true, delay, retryAttempts + 1)
+                .then((syncMap) => {
+                  resolve(syncMap);
+                })
+                .catch((err) => {
+                  reject(err);
+                });
             }
             // sync rate limit exceeded https://www.twilio.com/docs/api/errors/54009
             // retry after a delay
-            else{
-              if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-                console.log(`error fetching syncMap ${mapName}, sync rate limit reached, retrying ${retryAttempts+1}`);
-                fetchOrCreateSyncMap(mapName, create, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-                .then(syncMap => {
-                  resolve(syncMap)
+            else if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+              console.log(`error fetching syncMap ${mapName}, sync rate limit reached, retrying ${retryAttempts + 1}`);
+              fetchOrCreateSyncMap(
+                mapName,
+                create,
+                delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+                retryAttempts + 1,
+              )
+                .then((syncMap) => {
+                  resolve(syncMap);
                 })
-                .catch(err => {
+                .catch((err) => {
                   reject(err);
-                })
-              }
-              else{
-                // too many retry attempts
-                console.log(`error fetching syncMap ${mapName}, too many retry attempts`);
-                reject(err);
-              }
+                });
+            } else {
+              // too many retry attempts
+              console.log(`error fetching syncMap ${mapName}, too many retry attempts`);
+              reject(err);
             }
           });
-        }
-        else{
-          syncService
-          .syncMaps
+      } else {
+        syncService.syncMaps
           .create({ uniqueName: mapName })
-          .then(sync_map => {
-            console.log("sync map created: " + sync_map.sid);
+          .then((sync_map) => {
+            console.log(`sync map created: ${sync_map.sid}`);
             resolve();
           })
-          .catch(err =>{
-            if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-              console.log(`error creating syncMap ${mapName}, sync rate limit reached, retrying ${retryAttempts+1}`);
-              fetchOrCreateSyncMap(mapName, create, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-              .then(syncMap => {
-                resolve(syncMap)
-              })
-              .catch(err => {
-                reject(err);
-              })
-            }
-            else{
+          .catch((err) => {
+            if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+              console.log(`error creating syncMap ${mapName}, sync rate limit reached, retrying ${retryAttempts + 1}`);
+              fetchOrCreateSyncMap(
+                mapName,
+                create,
+                delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+                retryAttempts + 1,
+              )
+                .then((syncMap) => {
+                  resolve(syncMap);
+                })
+                .catch((err) => {
+                  reject(err);
+                });
+            } else {
               // too many retry attempts
               console.log(`error creating syncMap ${mapName}, too many retry attempts`);
               reject(err);
             }
           });
-        }
-      });
-    };
+      }
+    });
+  };
 
-    // function for retrieving sync map items which will retry recursively
-    const fetchSyncMapItems = function(mapName, delay, retryAttempts) {
-      return new Promise(async function(resolve, reject) {
+  // function for retrieving sync map items which will retry recursively
+  const fetchSyncMapItems = function (mapName, delay, retryAttempts) {
+    return new Promise(async function (resolve, reject) {
+      // delay random backoff period
+      await snooze(delay);
 
-        // delay random backoff period
-        await snooze(delay);
-
-        syncService
+      syncService
         .syncMaps(mapName)
-        .syncMapItems
-        .list({limit: 100})
-        .then(syncMapItems => {
-          resolve(syncMapItems)
+        .syncMapItems.list({ limit: 100 })
+        .then((syncMapItems) => {
+          resolve(syncMapItems);
         })
-        .catch(err => {
+        .catch((err) => {
           // if map doesnt exist create it first then retry
-          if(err.code == 20404){
+          if (err.code == 20404) {
             console.log(`syncMap ${mapName} not found, attempting to create it`);
             fetchOrCreateSyncMap(mapName, true, 0, 0)
-            .then(syncMap => {
-              fetchSyncMapItems(mapName, 0, retryAttempts+1)
-              .then(syncMapItems => {
-                resolve(syncMapItems)
+              .then((syncMap) => {
+                fetchSyncMapItems(mapName, 0, retryAttempts + 1)
+                  .then((syncMapItems) => {
+                    resolve(syncMapItems);
+                  })
+                  .catch((err) => {
+                    reject(err);
+                  });
               })
-              .catch(err => {
+              .catch((err) => {
                 reject(err);
-              })
-            })
-            .catch(err => {
-              reject(err);
-            })
+              });
           }
           // sync rate limit exceeded https://www.twilio.com/docs/api/errors/54009
           // retry after a delay
-          else if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-            console.log(`error fetching syncMap items ${mapName}, sync rate limit reached, retrying ${retryAttempts+1}`);
-            fetchSyncMapItems(mapName, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-            .then(syncMapItems => {
-              resolve(syncMapItems)
-            })
-            .catch(err => {
-              reject(err);
-            })
-          }
-          else{
+          else if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+            console.log(
+              `error fetching syncMap items ${mapName}, sync rate limit reached, retrying ${retryAttempts + 1}`,
+            );
+            fetchSyncMapItems(
+              mapName,
+              delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+              retryAttempts + 1,
+            )
+              .then((syncMapItems) => {
+                resolve(syncMapItems);
+              })
+              .catch((err) => {
+                reject(err);
+              });
+          } else {
             // too many retry attempts
             console.log(`error fetching syncMap ${mapName}, too many retry attempts`);
             reject(err);
           }
         });
-      });
-    };
+    });
+  };
 
-    // function for updating or creating an item in a given sync map which will retry recursively
-    const updateOrCreateSyncMapItem = function(mapName, queueItem, create, delay, retryAttempts) {
-      return new Promise(async function(resolve, reject) {
+  // function for updating or creating an item in a given sync map which will retry recursively
+  const updateOrCreateSyncMapItem = function (mapName, queueItem, create, delay, retryAttempts) {
+    return new Promise(async function (resolve, reject) {
+      // delay random backoff period
+      await snooze(delay);
 
-        // delay random backoff period
-        await snooze(delay);
-
-        if(create == false)
-        {
-          syncService
+      if (create == false) {
+        syncService
           .syncMaps(mapName)
           .syncMapItems(queueItem.sid)
           .update({ data: queueItem })
-          .then(item => {
+          .then((item) => {
             resolve(item);
           })
-          .catch(err => {
+          .catch((err) => {
             // 20404 item not found https://www.twilio.com/docs/api/errors/20404
             // attempt to create it
-            if(err.code == 20404){
+            if (err.code == 20404) {
               console.log(`syncItem ${mapName}:${queueItem.sid} not found, attempting to create it`);
-              updateOrCreateSyncMapItem(mapName, queueItem, true, delay, retryAttempts+1)
-              .then(item => {
-                resolve(item)
-              })
-              .catch(err => {
-                reject(err);
-              })
-            }
-            else{
-              if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-                console.log(`error updating syncItem ${mapName}:${queueItem.sid}, sync rate limit reached, retrying ${retryAttempts+1}`);
-                updateOrCreateSyncMapItem(mapName, queueItem, create, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-                .then(item => {
-                  resolve(item)
+              updateOrCreateSyncMapItem(mapName, queueItem, true, delay, retryAttempts + 1)
+                .then((item) => {
+                  resolve(item);
                 })
-                .catch(err => {
+                .catch((err) => {
                   reject(err);
+                });
+            } else if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+              console.log(
+                `error updating syncItem ${mapName}:${queueItem.sid}, sync rate limit reached, retrying ${
+                  retryAttempts + 1
+                }`,
+              );
+              updateOrCreateSyncMapItem(
+                mapName,
+                queueItem,
+                create,
+                delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+                retryAttempts + 1,
+              )
+                .then((item) => {
+                  resolve(item);
                 })
-              }
-              else{
-                // too many retry attempts
-                console.log(`error updating syncItem ${mapName}:${queueItem.sid}, too many retry attempts`);
-                reject(err);
-              }
+                .catch((err) => {
+                  reject(err);
+                });
+            } else {
+              // too many retry attempts
+              console.log(`error updating syncItem ${mapName}:${queueItem.sid}, too many retry attempts`);
+              reject(err);
             }
           });
-        }
-        else
-        {
-          syncService
+      } else {
+        syncService
           .syncMaps(mapName)
           .syncMapItems.create({
             key: queueItem.sid,
-            data: queueItem
+            data: queueItem,
           })
-          .then(item => {
+          .then((item) => {
             console.log(`Item created ${mapName}:${queueItem.sid}`);
             resolve(item);
           })
-          .catch(err => {
+          .catch((err) => {
             // sync rate limit exceeded https://www.twilio.com/docs/api/errors/54009
             // retry after a delay
-              if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-                console.log(`error creating syncItem ${mapName}:${queueItem.sid}, sync rate limit reached, retrying ${retryAttempts+1}`);
-                updateOrCreateSyncMapItem(mapName, queueItem, create, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-                .then(item => {
-                  resolve(item)
+            if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+              console.log(
+                `error creating syncItem ${mapName}:${queueItem.sid}, sync rate limit reached, retrying ${
+                  retryAttempts + 1
+                }`,
+              );
+              updateOrCreateSyncMapItem(
+                mapName,
+                queueItem,
+                create,
+                delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+                retryAttempts + 1,
+              )
+                .then((item) => {
+                  resolve(item);
                 })
-                .catch(err => {
+                .catch((err) => {
                   reject(err);
-                })
-              }
-              else{
-                // too many retry attempts
-                console.log(`error creating syncItem ${mapName}:${queueItem.sid}, too many retry attempts`);
-                reject(err);
-              }
+                });
+            } else {
+              // too many retry attempts
+              console.log(`error creating syncItem ${mapName}:${queueItem.sid}, too many retry attempts`);
+              reject(err);
+            }
           });
-        }
-      });
-    };
+      }
+    });
+  };
 
-    // function for deleting an item in a given sync map which will retry recursively
-    const deleteSyncMapItem = function(mapName, item, delay, retryAttempts) {
-      return new Promise(async function(resolve, reject) {
+  // function for deleting an item in a given sync map which will retry recursively
+  const deleteSyncMapItem = function (mapName, item, delay, retryAttempts) {
+    return new Promise(async function (resolve, reject) {
+      // delay random backoff period
+      await snooze(delay);
 
-        // delay random backoff period
-        await snooze(delay);
-
-          syncService
-          .syncMaps(mapName)
-          .syncMapItems(item.key)
-          .remove()
-          .then(() => {
-            console.log(`Succesffully removed sync item ${mapName}:${item.key}`);
+      syncService
+        .syncMaps(mapName)
+        .syncMapItems(item.key)
+        .remove()
+        .then(() => {
+          console.log(`Succesffully removed sync item ${mapName}:${item.key}`);
+          resolve(item);
+        })
+        .catch((err) => {
+          // 20404 item not found https://www.twilio.com/docs/api/errors/20404
+          // already removed
+          if (err.code == 20404) {
+            console.log(`Already removed sync item ${mapName}:${item.key}`);
             resolve(item);
-          })
-          .catch(err => {
-            // 20404 item not found https://www.twilio.com/docs/api/errors/20404
-            // already removed
-            if(err.code == 20404){
-                console.log(`Already removed sync item ${mapName}:${item.key}`);
-                resolve(item)
-            }
-            else{
-              if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-                console.log(`error deleting syncItem ${mapName}:${item.key}, sync rate limit reached, retrying ${retryAttempts+1}`);
-                deleteSyncMapItem(mapName, item, ((delay*2)+getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF)), retryAttempts+1)
-                .then(() => {
-                  resolve(item)
-                })
-                .catch(err => {
-                  reject(err);
-                })
-              }
-              else{
-                // too many retry attempts
-                console.log(`error deleting syncItem ${mapName}:${item.key}, too many retry attempts`);
+          } else if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+            console.log(
+              `error deleting syncItem ${mapName}:${item.key}, sync rate limit reached, retrying ${retryAttempts + 1}`,
+            );
+            deleteSyncMapItem(
+              mapName,
+              item,
+              delay * 2 + getRandomIntInclusive(TWILIO_SYNC_MIN_BACKOFF, TWILIO_SYNC_MAX_BACKOFF),
+              retryAttempts + 1,
+            )
+              .then(() => {
+                resolve(item);
+              })
+              .catch((err) => {
                 reject(err);
-              }
-            }
-          });
-      });
-    };
-  
-    // given a queue item from the listQueues function, query the realtime stats API and place it on the queue object.
-    const populateRealTimeStatsForQueueItem = function (twilioClient, queueItem, taskChannel, delay, retryAttempts) {
-      return new Promise(async function(resolve) {
-
-        await snooze(delay);
-
-        twilioClient.taskrouter
-          .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
-          .taskQueues(queueItem.sid)
-          .realTimeStatistics()
-          .fetch({ taskChannel: taskChannel ? taskChannel : undefined })
-          .then(result => {
-            taskChannel = !taskChannel ? "all" : taskChannel;
-            queueItem.realTimeStats[taskChannel] = minimizeRealTimeStats(result);
-            queueItem.realTimeStats[taskChannel]["error"] = null;
-            resolve(queueItem);
-          })
-          .catch(err => {
-            if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-              console.log(`error fetching realtimestats for ${queueItem.sid}, retrying ${retryAttempts+1}`);
-              populateRealTimeStatsForQueueItem(twilioClient, queueItem, taskChannel, ((delay*2)+getRandomIntInclusive(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF)), retryAttempts+1)
-              .then(() => {
-                resolve(queueItem);
-              })
-            }
-            else{
-              // too many retry attempts
-              console.log(`error fetching realtimestats for ${queueItem.sid}, too many retry attempts`);
-              queueItem.realTimeStats[taskChannel]["error"] = err;
-              resolve(queueItem);
-            }
-          });
-      });
-    }
-  
-    // given a queue item from the listQueues function, query the cumulative stats API and place it on the queue object.
-    const populateCumulativeStatsForQueueItem = function (twilioClient, queueItem, taskChannel, delay, retryAttempts) {
-      return new Promise(async function(resolve) {
-        
-        await snooze(delay);
-
-        twilioClient.taskrouter
-          .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
-          .taskQueues(queueItem.sid)
-          .cumulativeStatistics()
-          .fetch({
-            taskChannel: taskChannel ? taskChannel : undefined,
-            startDate: START_DATE,
-            splitByWaitTime: QUEUE_STATS_SLA_SPLIT_PERIODS
-          })
-          .then(result => {
-            taskChannel = !taskChannel ? "all" : taskChannel;
-            queueItem.cumulativeStats[taskChannel] = minimizeCumulativeStats(result);
-            queueItem.cumulativeStats[taskChannel]["error"] = null;
-            resolve(queueItem);
-          })
-          .catch(err => {
-            if(retryAttempts < TWILIO_SERVICE_RETRY_LIMIT){
-              console.log(`error fetching cumulative stats for ${queueItem.sid}, retrying ${retryAttempts+1}`);
-              populateCumulativeStatsForQueueItem(twilioClient, queueItem, taskChannel, ((delay*2)+getRandomIntInclusive(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF)), retryAttempts+1)
-              .then(() => {
-                resolve(queueItem)
-              })
-            }
-            else{
-              // too many retry attempts
-              console.log(`error fetching cumulative stats for ${queueItem.sid}, too many retry attempts`);
-              queueItem.cumulativeStats[taskChannel] = {"error": err };
-              resolve(queueItem);
-            }
-          });
-      });
-    }
-  
-    // As there is a maximum size of 16KB per sync map item, minimize the text in the object to minimize the footprint on the object
-    const minimizeRealTimeStats = function(realTimeStats) {
-      if (realTimeStats) {
-        var result = {};
-        result.activityStatistics = [];
-  
-        realTimeStats.activityStatistics.forEach(activity => {
-          result.activityStatistics.push({
-            friendly_name: activity.friendly_name,
-            workers: activity.workers
-          });
+              });
+          } else {
+            // too many retry attempts
+            console.log(`error deleting syncItem ${mapName}:${item.key}, too many retry attempts`);
+            reject(err);
+          }
         });
-  
-        result.oldestTask = realTimeStats.longestTaskWaitingAge;
-        result.tasksByPriority = realTimeStats.tasksByPriority;
-        result.tasksByStatus = realTimeStats.tasksByStatus;
-        result.availableWorkers = realTimeStats.totalAvailableWorkers;
-        result.eligibleWorkers = realTimeStats.totalEligibleWorkers;
-        result.totalTasks = realTimeStats.totalTasks;
-  
-        return result;
-      } else {
-        return null;
-      }
+    });
+  };
+
+  // given a queue item from the listQueues function, query the realtime stats API and place it on the queue object.
+  const populateRealTimeStatsForQueueItem = function (twilioClient, queueItem, taskChannel, delay, retryAttempts) {
+    return new Promise(async function (resolve) {
+      await snooze(delay);
+
+      twilioClient.taskrouter
+        .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
+        .taskQueues(queueItem.sid)
+        .realTimeStatistics()
+        .fetch({ taskChannel: taskChannel ? taskChannel : undefined })
+        .then((result) => {
+          taskChannel = !taskChannel ? 'all' : taskChannel;
+          queueItem.realTimeStats[taskChannel] = minimizeRealTimeStats(result);
+          queueItem.realTimeStats[taskChannel].error = null;
+          resolve(queueItem);
+        })
+        .catch((err) => {
+          if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+            console.log(`error fetching realtimestats for ${queueItem.sid}, retrying ${retryAttempts + 1}`);
+            populateRealTimeStatsForQueueItem(
+              twilioClient,
+              queueItem,
+              taskChannel,
+              delay * 2 + getRandomIntInclusive(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF),
+              retryAttempts + 1,
+            ).then(() => {
+              resolve(queueItem);
+            });
+          } else {
+            // too many retry attempts
+            console.log(`error fetching realtimestats for ${queueItem.sid}, too many retry attempts`);
+            queueItem.realTimeStats[taskChannel].error = err;
+            resolve(queueItem);
+          }
+        });
+    });
+  };
+
+  // given a queue item from the listQueues function, query the cumulative stats API and place it on the queue object.
+  const populateCumulativeStatsForQueueItem = function (twilioClient, queueItem, taskChannel, delay, retryAttempts) {
+    return new Promise(async function (resolve) {
+      await snooze(delay);
+
+      twilioClient.taskrouter
+        .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
+        .taskQueues(queueItem.sid)
+        .cumulativeStatistics()
+        .fetch({
+          taskChannel: taskChannel ? taskChannel : undefined,
+          startDate: START_DATE,
+          splitByWaitTime: QUEUE_STATS_SLA_SPLIT_PERIODS,
+        })
+        .then((result) => {
+          taskChannel = !taskChannel ? 'all' : taskChannel;
+          queueItem.cumulativeStats[taskChannel] = minimizeCumulativeStats(result);
+          queueItem.cumulativeStats[taskChannel].error = null;
+          resolve(queueItem);
+        })
+        .catch((err) => {
+          if (retryAttempts < TWILIO_SERVICE_RETRY_LIMIT) {
+            console.log(`error fetching cumulative stats for ${queueItem.sid}, retrying ${retryAttempts + 1}`);
+            populateCumulativeStatsForQueueItem(
+              twilioClient,
+              queueItem,
+              taskChannel,
+              delay * 2 + getRandomIntInclusive(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF),
+              retryAttempts + 1,
+            ).then(() => {
+              resolve(queueItem);
+            });
+          } else {
+            // too many retry attempts
+            console.log(`error fetching cumulative stats for ${queueItem.sid}, too many retry attempts`);
+            queueItem.cumulativeStats[taskChannel] = { error: err };
+            resolve(queueItem);
+          }
+        });
+    });
+  };
+
+  // As there is a maximum size of 16KB per sync map item, minimize the text in the object to minimize the footprint on the object
+  const minimizeRealTimeStats = function (realTimeStats) {
+    if (realTimeStats) {
+      const result = {};
+      result.activityStatistics = [];
+
+      realTimeStats.activityStatistics.forEach((activity) => {
+        result.activityStatistics.push({
+          friendly_name: activity.friendly_name,
+          workers: activity.workers,
+        });
+      });
+
+      result.oldestTask = realTimeStats.longestTaskWaitingAge;
+      result.tasksByPriority = realTimeStats.tasksByPriority;
+      result.tasksByStatus = realTimeStats.tasksByStatus;
+      result.availableWorkers = realTimeStats.totalAvailableWorkers;
+      result.eligibleWorkers = realTimeStats.totalEligibleWorkers;
+      result.totalTasks = realTimeStats.totalTasks;
+
+      return result;
     }
-  
-    // As there is a maximum size of 16KB per sync map item, minimize the text in the object to minimize the footprint on the object
-    const minimizeCumulativeStats = function(cumulativeStatistics) {
-      if (cumulativeStatistics) {
-        var minimizedCumulativeStats = {
-          rCreated: cumulativeStatistics.reservationsCreated,
-          rRej: cumulativeStatistics.reservationsRejected,
-          rAccepted: cumulativeStatistics.reservationsAccepted,
-          rTimedOut: cumulativeStatistics.reservationsTimedOut,
-          rCancel: cumulativeStatistics.reservationsCanceled,
-          rRescind: cumulativeStatistics.reservationsRescinded,
-  
-          tCompl: cumulativeStatistics.tasksCompleted,
-          tMoved: cumulativeStatistics.tasksMoved,
-          tEnter: cumulativeStatistics.tasksEntered,
-          tCanc: cumulativeStatistics.tasksCanceled,
-          tDel: cumulativeStatistics.tasksDeleted,
-  
-          waitUntilCancel: cumulativeStatistics.waitDurationUntilCanceled,
-          waitUntilAccept: cumulativeStatistics.waitDurationUntilAccepted,
-          splitByWaitTime: cumulativeStatistics.splitByWaitTime,
-  
-          endTime: cumulativeStatistics.endTime,
-          startTime: cumulativeStatistics.startTime,
-  
-          avgTaskAcceptanceTime: cumulativeStatistics.avgTaskAcceptanceTime
-        };
-  
-        return minimizedCumulativeStats;
-      } else {
-        return null;
-      }
+    return null;
+  };
+
+  // As there is a maximum size of 16KB per sync map item, minimize the text in the object to minimize the footprint on the object
+  const minimizeCumulativeStats = function (cumulativeStatistics) {
+    if (cumulativeStatistics) {
+      return {
+        rCreated: cumulativeStatistics.reservationsCreated,
+        rRej: cumulativeStatistics.reservationsRejected,
+        rAccepted: cumulativeStatistics.reservationsAccepted,
+        rTimedOut: cumulativeStatistics.reservationsTimedOut,
+        rCancel: cumulativeStatistics.reservationsCanceled,
+        rRescind: cumulativeStatistics.reservationsRescinded,
+
+        tCompl: cumulativeStatistics.tasksCompleted,
+        tMoved: cumulativeStatistics.tasksMoved,
+        tEnter: cumulativeStatistics.tasksEntered,
+        tCanc: cumulativeStatistics.tasksCanceled,
+        tDel: cumulativeStatistics.tasksDeleted,
+
+        waitUntilCancel: cumulativeStatistics.waitDurationUntilCanceled,
+        waitUntilAccept: cumulativeStatistics.waitDurationUntilAccepted,
+        splitByWaitTime: cumulativeStatistics.splitByWaitTime,
+
+        endTime: cumulativeStatistics.endTime,
+        startTime: cumulativeStatistics.startTime,
+
+        avgTaskAcceptanceTime: cumulativeStatistics.avgTaskAcceptanceTime,
+      };
     }
+    return null;
+  };
 
+  // MAIN Function
+  // validate the parameters are setup for the account then fetch all the queues and their associated statistics
+  // fetch or create the sync map to ensure it exists
+  // then for each queue item, generate a promise to update or create it in the sync map
+  // batch up the promises and update the sync map in batches with a backoff and retry period set in the configuration
+  // finally remove from the sync map and items that appear that arent in the queue list (queue has been deleted)
+  if (validateParameters(context, event)) {
+    fetchAllQueueStatistics(client)
+      .then((queueStatsArray) => {
+        fetchSyncMapItems(QUEUE_STATS_MAP_NAME, 0, 0)
+          .then((items) => {
+            const updateSyncMapPromiseArray = [];
+            const itemsToDeleteArray = [];
 
-    // MAIN Function
-    // validate the parameters are setup for the account then fetch all the queues and their associated statistics
-    // fetch or create the sync map to ensure it exists
-    // then for each queue item, generate a promise to update or create it in the sync map
-    // batch up the promises and update the sync map in batches with a backoff and retry period set in the configuration
-    // finally remove from the sync map and items that appear that arent in the queue list (queue has been deleted)
-    if (validateParameters(context, event)) {
-        fetchAllQueueStatistics(client)
-        .then(queueStatsArray => {
-          fetchSyncMapItems(QUEUE_STATS_MAP_NAME, 0, 0)
-          .then(items => {
-            var updateSyncMapPromiseArray = [];
-            var itemsToDeleteArray = [];
-
-            items.forEach(item =>{
-              const matchingQueueStats = queueStatsArray.find(queue => queue.sid === item.key);
+            items.forEach((item) => {
+              const matchingQueueStats = queueStatsArray.find((queue) => queue.sid === item.key);
               if (matchingQueueStats) {
                 // Copy over customQueueConfiguration property to queueStats object
                 matchingQueueStats.customQueueConfiguration = item.data.customQueueConfiguration;
@@ -683,25 +682,29 @@ exports.handler = function refreshStats (context, event, callback) {
               }
             });
 
-            queueStatsArray.forEach(queueItem => {
+            queueStatsArray.forEach((queueItem) => {
               const { sid, friendlyName, customQueueConfiguration } = queueItem;
-              const matchingSyncMapItem = items.find(item => item.key === sid);
+              const matchingSyncMapItem = items.find((item) => item.key === sid);
 
               // Create any missing SyncMap Items for queues that were added to TaskRouter since last refresh
               if (matchingSyncMapItem === undefined) {
                 const newSyncMapItemData = { sid, friendlyName, customQueueConfiguration };
-                updateSyncMapPromiseArray.push(updateOrCreateSyncMapItem(QUEUE_STATS_MAP_NAME, newSyncMapItemData, true, 0, 0));
+                updateSyncMapPromiseArray.push(
+                  updateOrCreateSyncMapItem(QUEUE_STATS_MAP_NAME, newSyncMapItemData, true, 0, 0),
+                );
               }
 
               // Update any SyncMap Items for queues that have been changed in TaskRouter since last refresh
               if (matchingSyncMapItem !== undefined && matchingSyncMapItem.data.friendlyName !== friendlyName) {
                 const { friendlyName } = queueItem;
                 const updatedSyncMapItemData = { ...matchingSyncMapItem.data, friendlyName };
-                updateSyncMapPromiseArray.push(updateOrCreateSyncMapItem(QUEUE_STATS_MAP_NAME, updatedSyncMapItemData, false, 0, 0));
+                updateSyncMapPromiseArray.push(
+                  updateOrCreateSyncMapItem(QUEUE_STATS_MAP_NAME, updatedSyncMapItemData, false, 0, 0),
+                );
               }
             });
 
-            var batchedArrays = chunkArray(updateSyncMapPromiseArray, QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE);
+            let batchedArrays = chunkArray(updateSyncMapPromiseArray, QUEUE_STATS_SYNC_MAP_UPDATE_BATCH_SIZE);
             processPromiseBatchArray(batchedArrays.reverse()).then(() => {
               response.setBody(queueStatsArray);
               // chunk the items to be deleted into batches and delete them
@@ -719,15 +722,14 @@ exports.handler = function refreshStats (context, event, callback) {
             response.setBody(queueStatsArray);
             callback(null, response);
           });
-        })
-        .catch(err => {
-          console.error(err);
-          // an error occurred somewhere in the promise chain
-          callback(null, { success: false, message: err })
-        })
-    } else {
-      // An error occurred checking valid environment variables were setup
-      callback(null, { success: false, message: errorMessages });
-    }
-  };
-  
+      })
+      .catch((err) => {
+        console.error(err);
+        // an error occurred somewhere in the promise chain
+        callback(null, { success: false, message: err });
+      });
+  } else {
+    // An error occurred checking valid environment variables were setup
+    callback(null, { success: false, message: errorMessages });
+  }
+};

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -1,33 +1,28 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const ConferenceOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/conference-participant"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const ConferenceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conference-participant'].path);
 
 const requiredParameters = [
-  { key: "conferenceSid", purpose: "conference sid to target for changes" },
+  { key: 'conferenceSid', purpose: 'conference sid to target for changes' },
   {
-    key: "participantSid",
-    purpose: "participant sid to target for conference changes",
+    key: 'participantSid',
+    purpose: 'participant sid to target for conference changes',
   },
   {
-    key: "muted",
-    purpose:
-      "boolean to determine the muted status of the participant in the conference",
+    key: 'muted',
+    purpose: 'boolean to determine the muted status of the participant in the conference',
   },
   {
-    key: "coaching",
-    purpose:
-      "boolean to determine the coaching status of the participant in the conference",
+    key: 'coaching',
+    purpose: 'boolean to determine the coaching status of the participant in the conference',
   },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-    const { conferenceSid, participantSid, agentSid, muted, coaching } =
-      event;
-    
+    const { conferenceSid, participantSid, agentSid, muted, coaching } = event;
+
     // If agentSid isn't null/blank, we know we are updating the conference coaching status
-    if (agentSid != "") {
+    if (agentSid != '') {
       const result = await ConferenceOperations.coachToggle({
         context,
         conferenceSid,
@@ -44,7 +39,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       });
     }
     // If the agentSid is null/blank, we know we are updating the conference muted status
-    if (agentSid === "") {
+    if (agentSid === '') {
       const result = await ConferenceOperations.bargeToggle({
         context,
         conferenceSid,

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -22,7 +22,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const { conferenceSid, participantSid, agentSid, muted, coaching } = event;
 
     // If agentSid isn't null/blank, we know we are updating the conference coaching status
-    if (agentSid != '') {
+    if (agentSid && agentSid !== '') {
       const result = await ConferenceOperations.coachToggle({
         context,
         conferenceSid,
@@ -53,8 +53,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         conference: result.conferenceSid,
       });
     }
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
+++ b/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
@@ -1,27 +1,23 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
-const TaskOperations = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/taskrouter"
-].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
+const TaskOperations = require(Runtime.getFunctions()['common/twilio-wrappers/taskrouter'].path);
 
 const requiredParameters = [
-  { key: "taskSid", purpose: "sid of the task" },
-  { key: "reservationSid", purpose: "sid of the specific reservation to update" },
-  { key: "status", purpose: "status to move the reservation to" }
+  { key: 'taskSid', purpose: 'sid of the task' },
+  { key: 'reservationSid', purpose: 'sid of the specific reservation to update' },
+  { key: 'status', purpose: 'status to move the reservation to' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-
-
     /** on the surface this function only adds a redundant laye
      * around updateReservation but it provides a convenient hook
      * point to introduce custom behaviors on completing reservations
      * that may differ across task types.
-     * 
+     *
      * it is also worth noting that recording a reason is only applicable
      * when completing a task and we can't complete the task without knowing
      * if there are other open resrvations or not.
-     * 
+     *
      * ideally we could record some outcome code in the task attributes but again
      * this gets complex quickly with voice tasks sharing task attributes across
      * reservations and we risk overwriting an outcome of a subsequent transfer
@@ -35,11 +31,11 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       taskSid,
       reservationSid,
-      status: taskStatus
-    })
+      status: taskStatus,
+    });
 
     const { success, status, reservation, message } = result;
-    
+
     response.setStatusCode(status);
     response.setBody({ success, reservation, message });
     callback(null, response);

--- a/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
+++ b/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
@@ -38,8 +38,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(status);
     response.setBody({ success, reservation, message });
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });


### PR DESCRIPTION
### Summary

Basically the same thing as #165 but for the serverless-functions package:

- Used twilio style as a base
- Turned off non-risky and annoying rules to prevent unnecessary friction
- CI adds comments and annotations for errors and warnings. Only errors prevent merging.
- Used `npm run lint:fix` to auto-fix what could be (mostly `prettier`), then made manual fixes for the remaining errors and warnings.
- None of the code changes should change functionality.

The largest code changes were in the refresh-stats function, which is unused in the Flex plugin. It should behave the same, but extra testing would be appreciated.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
