### PR TITLE
add optional chanining

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-flex-ts-template-v2",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "private": true,
   "scripts": {
     "test:watch": "jest --watch",

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/supervisorAlertHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/supervisorAlertHelper.ts
@@ -10,7 +10,7 @@ import { NotificationIds } from '../flex-hooks/notifications/BargeCoachAssist';
 export const alertSupervisorsCheck = () => {
   const state = Flex.Manager.getInstance().store.getState() as AppState;
   const { agentAssistanceArray, enableAgentAssistanceAlerts } = state[reduxNamespace].supervisorBargeCoach;
-  const arrayIndexCheck = agentAssistanceArray.findIndex((agent: any) => agent.agentFN !== '');
+  const arrayIndexCheck = agentAssistanceArray?.findIndex((agent: any) => agent.agentFN !== '');
   if (arrayIndexCheck > -1 && enableAgentAssistanceAlerts) {
     const agentFN = `${agentAssistanceArray[arrayIndexCheck].agentFN}`;
     Flex.Notifications.showNotification(NotificationIds.AGENT_ASSISTANCE, { agentFN: `${agentFN}` });


### PR DESCRIPTION
### Summary

When downloading and running a fresh version of the plugin, I get the following error message: 

```
supervisorAlertHelper.ts:16 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'findIndex')
    at alertSupervisorsCheck (supervisorAlertHelper.ts:16:48)
    at supervisorAlertHelper.ts:37:7
```


This is because the `agentAssistanceArray` is undefined in my scenario.

A simple optional chaining  solves the problem for me and prevents an exception:
` const arrayIndexCheck = agentAssistanceArray?.findIndex((agent: any) => agent.agentFN !== '');`


