### PR TITLE
Add eslint to serverless-schedule-manager

### DIFF
--- a/.github/workflows/check_schedule_manager.yaml
+++ b/.github/workflows/check_schedule_manager.yaml
@@ -1,0 +1,64 @@
+name: check_schedule_manager
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+    paths:
+      - 'serverless-schedule-manager/**'
+  # Enable running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install packages
+        working-directory: ./serverless-schedule-manager
+        run: npm install
+      - name: Run eslint
+        working-directory: ./serverless-schedule-manager
+        run: npm run lint:report
+        continue-on-error: true
+      - name: Annotate Code Linting Results
+        id: annotate
+        uses: ataylorme/eslint-annotate-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "serverless-functions/eslint_report.json"
+      - name: Comment on error
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount > 0
+        with:
+          message: |
+            Linter results for serverless-schedule-manager:
+            ${{steps.annotate.outputs.summary}}
+            :rotating_light: Errors must be resolved before merging, and have been annotated in the "Files changed" tab. Run `npm run lint` from the serverless-schedule-manager directory if you would like to see results locally.
+      - name: Comment on warning
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount < 1 && steps.annotate.outputs.warningCount > 0
+        with:
+          message: |
+            Linter results for serverless-schedule-manager:
+            ${{steps.annotate.outputs.summary}}
+            :warning: Merging is still possible with these warnings, but please fix them if possible! Annotations are available in the "Files changed" tab. Run `npm run lint` from the serverless-schedule-manager directory if you would like to see results locally.
+      - name: Comment on no issues
+        uses: mshick/add-pr-comment@v2
+        if: always() && steps.annotate.outputs.errorCount < 1 && steps.annotate.outputs.warningCount < 1
+        with:
+          message: |
+            Linter results for serverless-schedule-manager:
+            ${{steps.annotate.outputs.summary}}
+            :white_check_mark: No issues found!

--- a/.github/workflows/check_schedule_manager.yaml
+++ b/.github/workflows/check_schedule_manager.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: ataylorme/eslint-annotate-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          report-json: "serverless-functions/eslint_report.json"
+          report-json: "serverless-schedule-manager/eslint_report.json"
       - name: Comment on error
         uses: mshick/add-pr-comment@v2
         if: always() && steps.annotate.outputs.errorCount > 0

--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ Lastly, this package manages the github action workflows - with one example bein
 
 (the following is only applicable when using the flex v2 plugin)
 
-ESLint is configured for the v2 plugin and the serverless-functions package, using [Twilio Style](https://github.com/twilio-labs/twilio-style) as a base with some relaxations. When opening a pull request, the included GitHub workflows will run the linter, preventing merge if errors are present. Therefore, it is convenient to run the linter locally to identify any errors that you may need to fix ahead of time.
+ESLint is configured for the v2 plugin, the serverless-functions package, and the serverless-schedule-manager package, using [Twilio Style](https://github.com/twilio-labs/twilio-style) as a base with some relaxations. When opening a pull request, the included GitHub workflows will run the linter, preventing merge if errors are present. Therefore, it is convenient to run the linter locally to identify any errors that you may need to fix ahead of time.
 
-Before pushing changes, run the following command from the `plugin-flex-ts-template-v2` dir and/or the `serverless-functions` dir to see the linter results.
+Before pushing changes, run the following command from the `plugin-flex-ts-template-v2` dir, the `serverless-functions` dir, and/or the `serverless-schedule-manager` dir to see the linter results.
 
 ```bash
 npm run lint

--- a/serverless-schedule-manager/.prettierrc.js
+++ b/serverless-schedule-manager/.prettierrc.js
@@ -1,0 +1,5 @@
+const baseConfig = require('./node_modules/eslint-config-twilio/rules/prettier');
+
+module.exports = {
+  ...baseConfig,
+};

--- a/serverless-schedule-manager/functions/admin/list.js
+++ b/serverless-schedule-manager/functions/admin/list.js
@@ -1,70 +1,69 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ScheduleUtils = require(Runtime.getFunctions()['common/helpers/schedule-utils'].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
 const requiredParameters = [];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  
   const assetPath = '/config.json';
-  
+
   // load data
   const openData = Runtime.getAssets()[assetPath].open;
   const data = JSON.parse(openData());
-  
+
   try {
     // get latest build
     // this is so we can provide a version sid in the response to avoid racing with multiple users updating config.
     // when updating the config, the client provides the sid, and we will only save if it matches the latest one.
-    
+
     const latestBuildResult = await ServerlessOperations.fetchLatestBuild({ context, attempts: 0 });
-    
+
     if (!latestBuildResult.success) {
       response.setStatusCode(latestBuildResult.status);
       response.setBody({ message: latestBuildResult.message });
       callback(null, response);
       return;
     }
-    
+
     const { latestBuild } = latestBuildResult;
-    
+
     // get the data asset version sid from the latest build
-    const version = latestBuild.assetVersions.find(asset => asset.path == assetPath)?.sid;
-    
+    const version = latestBuild.assetVersions.find((asset) => asset.path == assetPath)?.sid;
+
     if (!version) {
       // error, no data asset in latest build
       callback('Missing asset in latest build');
       return;
     }
-    
+
     // now validate that this build is what is deployed
     const latestDeploymentResult = await ServerlessOperations.fetchLatestDeployment({ context, attempts: 0 });
-    
+
     if (!latestDeploymentResult.success) {
       response.setStatusCode(latestDeploymentResult.status);
       response.setBody({ message: latestDeploymentResult.message });
       callback(null, response);
       return;
     }
-    
+
     const { latestDeployment } = latestDeploymentResult;
-    
+
     const versionIsDeployed = latestDeployment.buildSid === latestBuild.sid;
-    
+
     // for each schedule in data, evaluate the schedule and add to the response payload
     if (data.schedules) {
-      data.schedules.forEach(schedule => {
+      data.schedules.forEach((schedule) => {
         schedule.status = ScheduleUtils.evaluateSchedule(schedule.name);
       });
     }
-    
+
     // return config data plus version data
     const returnData = {
       data,
       version,
-      versionIsDeployed
+      versionIsDeployed,
     };
-    
+
     response.setBody(returnData);
     callback(null, response);
   } catch (error) {

--- a/serverless-schedule-manager/functions/admin/list.js
+++ b/serverless-schedule-manager/functions/admin/list.js
@@ -21,19 +21,17 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     if (!latestBuildResult.success) {
       response.setStatusCode(latestBuildResult.status);
       response.setBody({ message: latestBuildResult.message });
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     const { latestBuild } = latestBuildResult;
 
     // get the data asset version sid from the latest build
-    const version = latestBuild.assetVersions.find((asset) => asset.path == assetPath)?.sid;
+    const version = latestBuild.assetVersions.find((asset) => asset.path === assetPath)?.sid;
 
     if (!version) {
       // error, no data asset in latest build
-      callback('Missing asset in latest build');
-      return;
+      return callback('Missing asset in latest build');
     }
 
     // now validate that this build is what is deployed
@@ -42,8 +40,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     if (!latestDeploymentResult.success) {
       response.setStatusCode(latestDeploymentResult.status);
       response.setBody({ message: latestDeploymentResult.message });
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     const { latestDeployment } = latestDeploymentResult;
@@ -65,8 +62,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     };
 
     response.setBody(returnData);
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/admin/publish.js
+++ b/serverless-schedule-manager/functions/admin/publish.js
@@ -1,25 +1,22 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
-const requiredParameters = [
-  { key: 'buildSid', purpose: 'build SID to deploy' }
-];
+const requiredParameters = [{ key: 'buildSid', purpose: 'build SID to deploy' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  
   const { buildSid, TokenResult } = event;
-  
+
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
-    response.setBody("Not authorized");
+    response.setBody('Not authorized');
     callback(null, response);
     return;
   }
-  
+
   try {
     // create deployment for this build
     const result = await ServerlessOperations.deployBuild({ context, buildSid, attempts: 0 });
-    
+
     response.setStatusCode(result.status);
     response.setBody(result);
     callback(null, response);

--- a/serverless-schedule-manager/functions/admin/publish.js
+++ b/serverless-schedule-manager/functions/admin/publish.js
@@ -9,8 +9,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
     response.setBody('Not authorized');
-    callback(null, response);
-    return;
+    return callback(null, response);
   }
 
   try {
@@ -19,8 +18,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(result.status);
     response.setBody(result);
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/admin/update-status.js
+++ b/serverless-schedule-manager/functions/admin/update-status.js
@@ -1,25 +1,22 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
-const requiredParameters = [
-  { key: 'buildSid', purpose: 'build sid to check status of' }
-];
+const requiredParameters = [{ key: 'buildSid', purpose: 'build sid to check status of' }];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  
   const { buildSid, TokenResult } = event;
-  
+
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
-    response.setBody("Not authorized");
+    response.setBody('Not authorized');
     callback(null, response);
     return;
   }
-  
+
   try {
     // get status of the given build sid
     const buildStatusResult = await ServerlessOperations.fetchBuildStatus({ context, attempts: 0, buildSid });
-    
+
     response.setStatusCode(buildStatusResult.status);
     response.setBody(buildStatusResult);
     callback(null, response);

--- a/serverless-schedule-manager/functions/admin/update-status.js
+++ b/serverless-schedule-manager/functions/admin/update-status.js
@@ -9,8 +9,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
     response.setBody('Not authorized');
-    callback(null, response);
-    return;
+    return callback(null, response);
   }
 
   try {
@@ -19,8 +18,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(buildStatusResult.status);
     response.setBody(buildStatusResult);
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/admin/update.js
+++ b/serverless-schedule-manager/functions/admin/update.js
@@ -1,79 +1,88 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
 const requiredParameters = [
   { key: 'data', purpose: 'data to save' },
-  { key: 'version', purpose: 'asset version SID that is being updated, so that multiple users making updates do not accidentally overwrite each other' }
+  {
+    key: 'version',
+    purpose:
+      'asset version SID that is being updated, so that multiple users making updates do not accidentally overwrite each other',
+  },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
-  
   const assetPath = '/config.json';
-  
+
   const { data, version, TokenResult } = event;
-  
+
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
-    response.setBody("Not authorized");
+    response.setBody('Not authorized');
     callback(null, response);
     return;
   }
-  
+
   try {
     // get latest build
     const latestBuildResult = await ServerlessOperations.fetchLatestBuild({ context, attempts: 0 });
-    
+
     if (!latestBuildResult.success) {
       response.setStatusCode(latestBuildResult.status);
       response.setBody({ message: latestBuildResult.message });
       callback(null, response);
       return;
     }
-    
+
     const { latestBuild } = latestBuildResult;
-    
+
     // compare latest asset version sid to provided version sid
-    const assetVersion = latestBuild.assetVersions.find(asset => asset.path == assetPath);
-    
+    const assetVersion = latestBuild.assetVersions.find((asset) => asset.path == assetPath);
+
     if (!assetVersion) {
       // error, no asset to update
       callback('Missing asset from latest build');
       return;
     }
-    
+
     if (assetVersion.sid != version) {
       // error, someone else made an update
       response.setStatusCode(409);
-      response.setBody("Provided version SID is not the latest deployed asset version SID");
+      response.setBody('Provided version SID is not the latest deployed asset version SID');
       callback(null, response);
       return;
     }
-    
+
     // upload new asset version
     const uploadResult = await ServerlessOperations.uploadAsset({
       context,
       attempts: 0,
       assetSid: assetVersion.asset_sid,
       assetPath,
-      assetData: data
+      assetData: data,
     });
-    
+
     if (!uploadResult.success) {
       response.setStatusCode(uploadResult.status);
       response.setBody({ message: uploadResult.message });
       callback(null, response);
       return;
     }
-      
+
     const newVersionSid = uploadResult.assetVersionSid;
-    
+
     // create new build with the new asset, but with functions and dependencies from the latest build
-    const assetVersions = [ newVersionSid ];
-    const functionVersions = latestBuild.functionVersions.map(version => version.sid);
+    const assetVersions = [newVersionSid];
+    const functionVersions = latestBuild.functionVersions.map((version) => version.sid);
     const dependencies = latestBuild.dependencies;
-    
-    const buildResult = await ServerlessOperations.createBuild({ context, attempts: 0, assetVersions, dependencies, functionVersions });
-    
+
+    const buildResult = await ServerlessOperations.createBuild({
+      context,
+      attempts: 0,
+      assetVersions,
+      dependencies,
+      functionVersions,
+    });
+
     response.setStatusCode(buildResult.status);
     response.setBody(buildResult);
     callback(null, response);

--- a/serverless-schedule-manager/functions/admin/update.js
+++ b/serverless-schedule-manager/functions/admin/update.js
@@ -18,8 +18,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   if (TokenResult.roles.indexOf('admin') < 0) {
     response.setStatusCode(403);
     response.setBody('Not authorized');
-    callback(null, response);
-    return;
+    return callback(null, response);
   }
 
   try {
@@ -29,27 +28,24 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     if (!latestBuildResult.success) {
       response.setStatusCode(latestBuildResult.status);
       response.setBody({ message: latestBuildResult.message });
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     const { latestBuild } = latestBuildResult;
 
     // compare latest asset version sid to provided version sid
-    const assetVersion = latestBuild.assetVersions.find((asset) => asset.path == assetPath);
+    const assetVersion = latestBuild.assetVersions.find((asset) => asset.path === assetPath);
 
     if (!assetVersion) {
       // error, no asset to update
-      callback('Missing asset from latest build');
-      return;
+      return callback('Missing asset from latest build');
     }
 
-    if (assetVersion.sid != version) {
+    if (assetVersion.sid !== version) {
       // error, someone else made an update
       response.setStatusCode(409);
       response.setBody('Provided version SID is not the latest deployed asset version SID');
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     // upload new asset version
@@ -64,15 +60,14 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     if (!uploadResult.success) {
       response.setStatusCode(uploadResult.status);
       response.setBody({ message: uploadResult.message });
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     const newVersionSid = uploadResult.assetVersionSid;
 
     // create new build with the new asset, but with functions and dependencies from the latest build
     const assetVersions = [newVersionSid];
-    const functionVersions = latestBuild.functionVersions.map((version) => version.sid);
+    const functionVersions = latestBuild.functionVersions.map((functionVersion) => functionVersion.sid);
     const dependencies = latestBuild.dependencies;
 
     const buildResult = await ServerlessOperations.createBuild({
@@ -85,8 +80,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     response.setStatusCode(buildResult.status);
     response.setBody(buildResult);
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/check-schedule.js
+++ b/serverless-schedule-manager/functions/check-schedule.js
@@ -15,14 +15,13 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       // fail open to be as graceful as possible
       response.setBody({ isOpen: true, closedReason: 'error', error });
 
-      callback(null, response);
-      return;
+      return callback(null, response);
     }
 
     console.log(`Schedule ${name} result`, returnData);
     response.setBody(returnData);
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-schedule-manager/functions/check-schedule.js
+++ b/serverless-schedule-manager/functions/check-schedule.js
@@ -1,26 +1,24 @@
-const { prepareStudioFunction } = require(Runtime.getFunctions()["common/helpers/prepare-function"].path);
+const { prepareStudioFunction } = require(Runtime.getFunctions()['common/helpers/prepare-function'].path);
 const ScheduleUtils = require(Runtime.getFunctions()['common/helpers/schedule-utils'].path);
 
-const requiredParameters = [
-  { key: 'name', purpose: 'name of the schedule to check' }
-];
+const requiredParameters = [{ key: 'name', purpose: 'name of the schedule to check' }];
 
 exports.handler = prepareStudioFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { name, simulate } = event;
     const returnData = ScheduleUtils.evaluateSchedule(name, simulate);
-    
+
     if (returnData.error) {
       const { error, status } = returnData;
       response.setStatusCode(status);
-      
+
       // fail open to be as graceful as possible
       response.setBody({ isOpen: true, closedReason: 'error', error });
-      
+
       callback(null, response);
       return;
     }
-    
+
     console.log(`Schedule ${name} result`, returnData);
     response.setBody(returnData);
     callback(null, response);

--- a/serverless-schedule-manager/functions/common/helpers/parameter-validator.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/parameter-validator.private.js
@@ -4,15 +4,15 @@
  * @param {Array} requiredKeysArray
  * @returns {string}
  * @description Convenience method to validate properties exist on an object
- * requiredKeysArray should be an array of strings or objects, 
+ * requiredKeysArray should be an array of strings or objects,
  *   { key: 'propertyName', purpose: 'describe need' }
- * error handling will fallback to less useful messages 
+ * error handling will fallback to less useful messages
  * if an array of strings is provided instead of the key and purpose objects
  */
 
-exports.validate = function(callingFunctionPath, parameterObject, requiredKeysArray) {
+exports.validate = function (callingFunctionPath, parameterObject, requiredKeysArray) {
   let errorMessage = '';
-  requiredKeysArray.forEach(data => {
+  requiredKeysArray.forEach((data) => {
     if (module.exports.isString(data)) {
       // Support "lazy" requiredKeysArray of just ['propertyName']
       if (parameterObject[data] === undefined || parameterObject[data] === null) {
@@ -29,20 +29,24 @@ exports.validate = function(callingFunctionPath, parameterObject, requiredKeysAr
     }
   });
   return errorMessage;
-}
+};
 
-exports.isBoolean = function(data) {
+exports.isBoolean = function (data) {
   let valueToCheck = data;
   if (module.exports.isString(valueToCheck)) {
     valueToCheck = Boolean(data);
   }
-  return valueToCheck === true || valueToCheck === false || Object.prototype.toString.call(valueToCheck) === '[object Boolean]';
-}
+  return (
+    valueToCheck === true ||
+    valueToCheck === false ||
+    Object.prototype.toString.call(valueToCheck) === '[object Boolean]'
+  );
+};
 
-exports.isString = function(data) {
+exports.isString = function (data) {
   return typeof data === 'string' || data instanceof String;
-}
+};
 
-exports.isObject = function(data) {
+exports.isObject = function (data) {
   return Object.prototype.toString.call(data) === '[object Object]';
-}
+};

--- a/serverless-schedule-manager/functions/common/helpers/parameter-validator.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/parameter-validator.private.js
@@ -10,7 +10,7 @@
  * if an array of strings is provided instead of the key and purpose objects
  */
 
-exports.validate = function (callingFunctionPath, parameterObject, requiredKeysArray) {
+exports.validate = (callingFunctionPath, parameterObject, requiredKeysArray) => {
   let errorMessage = '';
   requiredKeysArray.forEach((data) => {
     if (module.exports.isString(data)) {
@@ -31,7 +31,7 @@ exports.validate = function (callingFunctionPath, parameterObject, requiredKeysA
   return errorMessage;
 };
 
-exports.isBoolean = function (data) {
+exports.isBoolean = (data) => {
   let valueToCheck = data;
   if (module.exports.isString(valueToCheck)) {
     valueToCheck = Boolean(data);
@@ -43,10 +43,10 @@ exports.isBoolean = function (data) {
   );
 };
 
-exports.isString = function (data) {
+exports.isString = (data) => {
   return typeof data === 'string' || data instanceof String;
 };
 
-exports.isObject = function (data) {
+exports.isObject = (data) => {
   return Object.prototype.toString.call(data) === '[object Object]';
 };

--- a/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
@@ -15,8 +15,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
     console.error(`(${context.PATH}) invalid parameters passed`);
     response.setStatusCode(400);
     response.setBody({ data: null, message: parameterError });
-    callback(null, response);
-    return;
+    return callback(null, response);
   }
 
   const handleError = (error) => {
@@ -26,7 +25,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
       success: false,
       message: error,
     });
-    callback(null, response);
+    return callback(null, response);
   };
 
   return handlerFn(context, event, callback, response, handleError);

--- a/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/prepare-function.private.js
@@ -1,21 +1,16 @@
-const TokenValidator = require("twilio-flex-token-validator").functionValidator;
-const ParameterValidator = require(Runtime.getFunctions()[
-  "common/helpers/parameter-validator"
-].path);
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+const ParameterValidator = require(Runtime.getFunctions()['common/helpers/parameter-validator'].path);
 
 const prepareFunction = (context, event, callback, requiredParameters, handlerFn) => {
   const response = new Twilio.Response();
-  const parameterError = ParameterValidator.validate(
-    context.PATH,
-    event,
-    requiredParameters
-  );
-  
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST GET");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
-  
+  const parameterError = ParameterValidator.validate(context.PATH, event, requiredParameters);
+
+  response.appendHeader('Access-Control-Allow-Origin', '*');
+  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST GET');
+  response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   if (parameterError) {
     console.error(`(${context.PATH}) invalid parameters passed`);
     response.setStatusCode(400);
@@ -23,7 +18,7 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
     callback(null, response);
     return;
   }
-  
+
   const handleError = (error) => {
     console.error(`(${context.PATH}) Unexpected error occurred: ${error}`);
     response.setStatusCode(500);
@@ -32,8 +27,8 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
       message: error,
     });
     callback(null, response);
-  }
-  
+  };
+
   return handlerFn(context, event, callback, response, handleError);
 };
 
@@ -45,7 +40,9 @@ const prepareFunction = (context, event, callback, requiredParameters, handlerFn
  * @param handlerFn             the Twilio Runtime handler function to execute
  */
 exports.prepareFlexFunction = (requiredParameters, handlerFn) => {
-  return TokenValidator((context, event, callback) => prepareFunction(context, event, callback, requiredParameters, handlerFn));
+  return TokenValidator((context, event, callback) =>
+    prepareFunction(context, event, callback, requiredParameters, handlerFn),
+  );
 };
 
 /**

--- a/serverless-schedule-manager/functions/common/helpers/schedule-utils.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/schedule-utils.private.js
@@ -44,7 +44,7 @@ const checkDate = (rule, now) => {
     let matchFound = false;
 
     rrule.all().forEach((occurrence) => {
-      if (now.valueOf() == occurrence.valueOf()) {
+      if (now.valueOf() === occurrence.valueOf()) {
         console.log(`Rule ${rule.name} occurrence matched`, occurrence);
         matchFound = true;
       }
@@ -68,7 +68,7 @@ const checkTime = (rule, nowTz) => {
       return false;
     }
 
-    if (nowTz.hour == startTime.hour && nowTz.minute < startTime.minute) {
+    if (nowTz.hour === startTime.hour && nowTz.minute < startTime.minute) {
       console.log(`Rule ${rule.name} doesn't match: before start minute`, startTime.minute);
       return false;
     }
@@ -82,7 +82,7 @@ const checkTime = (rule, nowTz) => {
       return false;
     }
 
-    if (nowTz.hour == endTime.hour && nowTz.minute >= endTime.minute) {
+    if (nowTz.hour === endTime.hour && nowTz.minute >= endTime.minute) {
       console.log(`Rule ${rule.name} doesn't match: after end minute`, endTime.minute);
       return false;
     }
@@ -99,7 +99,7 @@ exports.evaluateSchedule = (name, simulate) => {
   };
 
   // find schedule by name
-  const schedule = scheduleData.schedules.find((schedule) => schedule.name == name);
+  const schedule = scheduleData.schedules.find((configSchedule) => configSchedule.name === name);
 
   if (!schedule) {
     return {
@@ -133,7 +133,7 @@ exports.evaluateSchedule = (name, simulate) => {
 
   // evaluate each schedule rule to see if it is currently matching
   schedule.rules.forEach((ruleId) => {
-    const rule = scheduleData.rules.find((rule) => rule.id == ruleId);
+    const rule = scheduleData.rules.find((configRule) => configRule.id === ruleId);
     if (rule && checkDate(rule, now) && checkTime(rule, nowTz)) {
       console.log(`Rule ${rule.name} matched`, nowTz.toString());
       matchingRules.push(rule);

--- a/serverless-schedule-manager/functions/common/helpers/schedule-utils.private.js
+++ b/serverless-schedule-manager/functions/common/helpers/schedule-utils.private.js
@@ -9,154 +9,154 @@ const scheduleData = JSON.parse(openScheduleData());
 
 const checkDate = (rule, now) => {
   // first, check the date component of the rule.
-  
+
   // if bounds are provided, check current date against them
   if (rule.startDate) {
     const startDate = new Date(Date.parse(rule.startDate));
-    
+
     if (now.valueOf() < startDate.valueOf()) {
       // before start date; this rule is not a match
       console.log(`Rule ${rule.name} doesn't match: before start date`, startDate);
       return false;
     }
   }
-  
+
   if (rule.endDate) {
     const endDate = new Date(Date.parse(rule.endDate));
-    
+
     if (now.valueOf() > endDate.valueOf()) {
       // after end date; this rule is not a match
       console.log(`Rule ${rule.name} doesn't match: after end date`, endDate);
       return false;
     }
   }
-  
+
   if (rule.dateRRule) {
     // extract rule from settings
     const ruleOptions = RRule.parseString(rule.dateRRule);
-    
+
     // since the rule concerns only dates, and we are only comparing to today, we only need one occurrence
     // by default, past occurrences are not returned
     ruleOptions.count = 1;
     ruleOptions.dtstart = now;
-    
+
     const rrule = new RRule(ruleOptions);
     let matchFound = false;
-    
-    rrule.all().forEach(occurrence => {
+
+    rrule.all().forEach((occurrence) => {
       if (now.valueOf() == occurrence.valueOf()) {
-        console.log(`Rule ${rule.name} occurrence matched`, occurrence)
+        console.log(`Rule ${rule.name} occurrence matched`, occurrence);
         matchFound = true;
       }
-    })
-    
+    });
+
     if (!matchFound) {
       console.log(`Rule ${rule.name} doesn't match: no recurrence match`, ruleOptions);
       return false;
     }
   }
-  
+
   return true;
-}
+};
 
 const checkTime = (rule, nowTz) => {
   if (rule.startTime) {
     const startTime = DateTime.fromISO(rule.startTime);
-    
+
     if (nowTz.hour < startTime.hour) {
       console.log(`Rule ${rule.name} doesn't match: before start hour`, startTime.hour);
       return false;
     }
-    
+
     if (nowTz.hour == startTime.hour && nowTz.minute < startTime.minute) {
       console.log(`Rule ${rule.name} doesn't match: before start minute`, startTime.minute);
       return false;
     }
   }
-  
+
   if (rule.endTime) {
     const endTime = DateTime.fromISO(rule.endTime);
-    
+
     if (nowTz.hour > endTime.hour) {
       console.log(`Rule ${rule.name} doesn't match: after end hour`, endTime.hour);
       return false;
     }
-    
+
     if (nowTz.hour == endTime.hour && nowTz.minute >= endTime.minute) {
       console.log(`Rule ${rule.name} doesn't match: after end minute`, endTime.minute);
       return false;
     }
   }
-  
+
   return true;
-}
+};
 
 exports.evaluateSchedule = (name, simulate) => {
-  let matchingRules = [];
-  let returnData = {
+  const matchingRules = [];
+  const returnData = {
     isOpen: false,
-    closedReason: "closed"
+    closedReason: 'closed',
   };
-  
+
   // find schedule by name
-  const schedule = scheduleData.schedules.find(schedule => schedule.name == name);
-  
+  const schedule = scheduleData.schedules.find((schedule) => schedule.name == name);
+
   if (!schedule) {
     return {
       error: `Schedule ${name} not found`,
-      status: 404
+      status: 404,
     };
   }
-  
-  console.log('Checking schedule ' + schedule.name);
-  
+
+  console.log(`Checking schedule ${schedule.name}`);
+
   // if the schedule is manually closed, we can return immediately
   if (schedule.manualClose) {
     returnData.isOpen = false;
-    returnData.closedReason = "manual";
-    
+    returnData.closedReason = 'manual';
+
     console.log(`Schedule ${schedule.name} is manually closed`);
     return returnData;
   }
-  
+
   let nowTz;
-  
+
   if (simulate) {
     // use the provided ISO 8601 formatted date/time
-    nowTz = DateTime.fromISO(simulate, { setZone: schedule.timeZone })
+    nowTz = DateTime.fromISO(simulate, { setZone: schedule.timeZone });
   } else {
     // get the current date/time in the schedule's timezone
     nowTz = DateTime.utc().setZone(schedule.timeZone);
   }
-  
+
   const now = new Date(Date.UTC(nowTz.year, nowTz.month - 1, nowTz.day));
-  
+
   // evaluate each schedule rule to see if it is currently matching
-  schedule.rules.forEach(ruleId => {
-    const rule = scheduleData.rules.find(rule => rule.id == ruleId);
+  schedule.rules.forEach((ruleId) => {
+    const rule = scheduleData.rules.find((rule) => rule.id == ruleId);
     if (rule && checkDate(rule, now) && checkTime(rule, nowTz)) {
       console.log(`Rule ${rule.name} matched`, nowTz.toString());
       matchingRules.push(rule);
     }
   });
-  
-  const closedMatches = matchingRules.filter(rule => !rule.isOpen);
-  
+
+  const closedMatches = matchingRules.filter((rule) => !rule.isOpen);
+
   // if any non-open schedule(s) match, we are closed
   if (closedMatches.length > 0) {
     returnData.isOpen = false;
     returnData.closedReason = closedMatches[0].closedReason;
   } else {
-    const openMatches = matchingRules.filter(rule => rule.isOpen);
-    
+    const openMatches = matchingRules.filter((rule) => rule.isOpen);
+
     // if only open schedule(s) match, we are open
     if (openMatches.length > 0) {
       returnData.isOpen = true;
       returnData.closedReason = '';
     }
   }
-  
+
   // if nothing matches, the default returnData is used
-  
+
   return returnData;
-}
+};

--- a/serverless-schedule-manager/functions/common/twilio-wrappers/retry-handler.private.js
+++ b/serverless-schedule-manager/functions/common/twilio-wrappers/retry-handler.private.js
@@ -1,6 +1,6 @@
-const { random, isNumber, isString } = require("lodash");
+const { random, isNumber, isString } = require('lodash');
 
-snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
+snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * @param {object} error the error from the calling function
@@ -8,55 +8,46 @@ snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {function} callback the callback function to retry
  * @returns {any}
- * @description the following method is used as a generic retry handler for method 
+ * @description the following method is used as a generic retry handler for method
  *   calls to the twilio client where the response code is 412, 429 or 503.
  *   Although there is a maximum runtime for twilio functions
  *   it is beneficial to retry from within the twilio function as the overhead
- *   of the retry is much lower from within the twilio function 
+ *   of the retry is much lower from within the twilio function
  *   (as its in the same data center) than to go all
- *   the way back to the calling client and retry from there. 
- * 
- *   this is particularly useful if doing a multi transactional 
+ *   the way back to the calling client and retry from there.
+ *
+ *   this is particularly useful if doing a multi transactional
  *   operation from a single twilio function call as it helps minimize
  *   failures here from the occasional 412 or 429 in particular
- *  
+ *
  *   NOTE: Status codes should still be passed back and
  *   retry handler in the browser are still encouraged.
  */
 exports.retryHandler = async (error, parameters, callback) => {
+  if (!isNumber(parameters.attempts))
+    throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
 
-  if(!isNumber(parameters.attempts))
-    throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-
-  const { 
-    TWILIO_SERVICE_MAX_BACKOFF, 
-    TWILIO_SERVICE_MIN_BACKOFF, 
-    TWILIO_SERVICE_RETRY_LIMIT } = process.env;
+  const { TWILIO_SERVICE_MAX_BACKOFF, TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_RETRY_LIMIT } = process.env;
   const { attempts, context } = parameters;
   const { response, message: errorMessage } = error;
-  const status = response? response.status : 500;
+  const status = response ? response.status : 500;
   const logWarning = attempts == 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
-  const message = errorMessage? errorMessage : error;
+  const message = errorMessage ? errorMessage : error;
 
   if (
-    (status == 412 || status == 429 || status == 503)
-    && isNumber(attempts)
-    && attempts < TWILIO_SERVICE_RETRY_LIMIT) 
-    {
-      console.warn(`retrying ${context.PATH}.${callback.name}() after ${logWarning}, status code: ${status}`);
-      if(status === 429 || status === 503)
-        await snooze(
-          random(
-            TWILIO_SERVICE_MIN_BACKOFF,
-            TWILIO_SERVICE_MAX_BACKOFF
-            )
-          );
-      
-      const updatedAttempts = attempts+1
-      const updatedParameters = {...parameters, attempts: updatedAttempts};
-      return callback(updatedParameters);
-  } else {
-    console.error(`retrying ${context.PATH}.${callback.name}() failed after ${logWarning}, status code: ${status}, message: ${message}`);
-    return { success: false, message, status };
+    (status == 412 || status == 429 || status == 503) &&
+    isNumber(attempts) &&
+    attempts < TWILIO_SERVICE_RETRY_LIMIT
+  ) {
+    console.warn(`retrying ${context.PATH}.${callback.name}() after ${logWarning}, status code: ${status}`);
+    if (status === 429 || status === 503) await snooze(random(TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_MAX_BACKOFF));
+
+    const updatedAttempts = attempts + 1;
+    const updatedParameters = { ...parameters, attempts: updatedAttempts };
+    return callback(updatedParameters);
   }
-}
+  console.error(
+    `retrying ${context.PATH}.${callback.name}() failed after ${logWarning}, status code: ${status}, message: ${message}`,
+  );
+  return { success: false, message, status };
+};

--- a/serverless-schedule-manager/functions/common/twilio-wrappers/retry-handler.private.js
+++ b/serverless-schedule-manager/functions/common/twilio-wrappers/retry-handler.private.js
@@ -25,17 +25,17 @@ snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  */
 exports.retryHandler = async (error, parameters, callback) => {
   if (!isNumber(parameters.attempts))
-    throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
 
   const { TWILIO_SERVICE_MAX_BACKOFF, TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_RETRY_LIMIT } = process.env;
   const { attempts, context } = parameters;
   const { response, message: errorMessage } = error;
   const status = response ? response.status : 500;
-  const logWarning = attempts == 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
+  const logWarning = attempts === 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
   const message = errorMessage ? errorMessage : error;
 
   if (
-    (status == 412 || status == 429 || status == 503) &&
+    (status === 412 || status === 429 || status === 503) &&
     isNumber(attempts) &&
     attempts < TWILIO_SERVICE_RETRY_LIMIT
   ) {

--- a/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
+++ b/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
@@ -1,7 +1,8 @@
-const {isString, isObject, isNumber, isArray } = require("lodash");
+const { isString, isObject, isNumber, isArray } = require('lodash');
 const FormData = require('form-data');
 const axios = require('axios');
-const retryHandler = (require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path)).retryHandler;
+
+const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retry-handler'].path).retryHandler;
 
 /**
  * @param {object} parameters the parameters for the function
@@ -12,76 +13,61 @@ const retryHandler = (require(Runtime.getFunctions()['common/twilio-wrappers/ret
  * @description the following method is used to deploy a given build in this environment
  */
 exports.deployBuild = async function (parameters) {
-
   const { attempts, context, buildSid } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  if(!isString(buildSid))
-      throw "Invalid parameters object passed. Parameters must contain buildSid string";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(buildSid)) throw 'Invalid parameters object passed. Parameters must contain buildSid string';
+
   try {
     const client = context.getTwilioClient();
-    
+
     const envSid = context.ENVIRONMENT_SID;
     const serviceSid = context.SERVICE_SID;
-    
-    const deployment = await client.serverless.v1.services(serviceSid).environments(envSid).deployments.create({ buildSid });
+
+    const deployment = await client.serverless.v1
+      .services(serviceSid)
+      .environments(envSid)
+      .deployments.create({ buildSid });
 
     return { success: true, status: 200, deploymentSid: deployment.sid };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
  * @param {number} parameters.attempts the number of retry attempts performed
  * @param {object} parameters.context the context from calling lambda function
- * @param {string} parameters.buildSid the build SID to check status for 
+ * @param {string} parameters.buildSid the build SID to check status for
  * @returns {object} An object containing the deployment sid
  * @description the following method is used to fetch build status for this service
  */
 exports.fetchBuildStatus = async function (parameters) {
-
   const { attempts, context, buildSid } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  if(!isString(buildSid))
-      throw "Invalid parameters object passed. Parameters must contain buildSid string";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(buildSid)) throw 'Invalid parameters object passed. Parameters must contain buildSid string';
+
   try {
     const client = context.getTwilioClient();
-    
+
     const serviceSid = context.SERVICE_SID;
-    
+
     const build = await client.serverless.v1.services(serviceSid).builds(buildSid).buildStatus().fetch();
-    
+
     if (!build) {
       // error, no builds
       return { success: false, status: 400, message: 'Build not found' };
     }
 
     return { success: true, status: 200, buildStatus: build.status };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -91,36 +77,28 @@ exports.fetchBuildStatus = async function (parameters) {
  * @description the following method is used to fetch the latest build for this service
  */
 exports.fetchLatestBuild = async function (parameters) {
-
   const { attempts, context } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+
   try {
     const client = context.getTwilioClient();
-    
+
     const serviceSid = context.SERVICE_SID;
-    
+
     const builds = await client.serverless.v1.services(serviceSid).builds.list({ limit: 1 });
-    
+
     if (builds.length < 1) {
       // error, no builds
       return { success: false, status: 400, message: 'No builds found' };
     }
 
     return { success: true, status: 200, latestBuild: builds[0] };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -130,37 +108,32 @@ exports.fetchLatestBuild = async function (parameters) {
  * @description the following method is used to fetch the latest deployment for this service
  */
 exports.fetchLatestDeployment = async function (parameters) {
-
   const { attempts, context } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+
   try {
     const client = context.getTwilioClient();
-    
+
     const envSid = context.ENVIRONMENT_SID;
     const serviceSid = context.SERVICE_SID;
-    
-    const deployments = await client.serverless.v1.services(serviceSid).environments(envSid).deployments.list({ limit: 1 });
-    
+
+    const deployments = await client.serverless.v1
+      .services(serviceSid)
+      .environments(envSid)
+      .deployments.list({ limit: 1 });
+
     if (deployments.length < 1) {
       // error, no deployments. this should be impossible when running while deployed!
       return { success: false, status: 400, message: 'No deployments found' };
     }
 
     return { success: true, status: 200, latestDeployment: deployments[0] };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -173,38 +146,30 @@ exports.fetchLatestDeployment = async function (parameters) {
  * @description the following method is used to create a new build in this service
  */
 exports.createBuild = async function (parameters) {
-
   const { attempts, context, assetVersions, dependencies, functionVersions } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  if(!isArray(assetVersions))
-      throw "Invalid parameters object passed. Parameters must contain assetVersions array";
-  if(!isArray(dependencies))
-      throw "Invalid parameters object passed. Parameters must contain dependencies array";
-  if(!isArray(functionVersions))
-      throw "Invalid parameters object passed. Parameters must contain functionVersions array";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isArray(assetVersions)) throw 'Invalid parameters object passed. Parameters must contain assetVersions array';
+  if (!isArray(dependencies)) throw 'Invalid parameters object passed. Parameters must contain dependencies array';
+  if (!isArray(functionVersions))
+    throw 'Invalid parameters object passed. Parameters must contain functionVersions array';
+
   try {
     const client = context.getTwilioClient();
-    
+
     const serviceSid = context.SERVICE_SID;
     const dependenciesStr = JSON.stringify(dependencies);
-    
-    const build = await client.serverless.v1.services(serviceSid).builds.create({ assetVersions, dependencies: dependenciesStr, functionVersions });
+
+    const build = await client.serverless.v1
+      .services(serviceSid)
+      .builds.create({ assetVersions, dependencies: dependenciesStr, functionVersions });
 
     return { success: true, status: 200, buildSid: build.sid };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};
 
 /**
  * @param {object} parameters the parameters for the function
@@ -217,35 +182,29 @@ exports.createBuild = async function (parameters) {
  * @description the following method is used to upload a new version of an asset in this service
  */
 exports.uploadAsset = async function (parameters) {
-
   const { attempts, context, assetSid, assetPath, assetData } = parameters;
 
-  if(!isNumber(attempts))
-      throw "Invalid parameters object passed. Parameters must contain the number of attempts";
-  if(!isObject(context))
-      throw "Invalid parameters object passed. Parameters must contain context object";
-  if(!isString(assetSid))
-      throw "Invalid parameters object passed. Parameters must contain assetSid string";
-  if(!isString(assetPath))
-      throw "Invalid parameters object passed. Parameters must contain assetPath string";
-  if(!isObject(assetData))
-      throw "Invalid parameters object passed. Parameters must contain assetData object";
-  
+  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
+  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isString(assetSid)) throw 'Invalid parameters object passed. Parameters must contain assetSid string';
+  if (!isString(assetPath)) throw 'Invalid parameters object passed. Parameters must contain assetPath string';
+  if (!isObject(assetData)) throw 'Invalid parameters object passed. Parameters must contain assetData object';
+
   try {
     const apiKey = context.ACCOUNT_SID;
     const apiSecret = context.AUTH_TOKEN;
     const serviceSid = context.SERVICE_SID;
-    
+
     // set upload parameters
     const uploadUrl = `https://serverless-upload.twilio.com/v1/Services/${serviceSid}/Assets/${assetSid}/Versions`;
-    
+
     const form = new FormData();
     form.append('Path', assetPath);
     form.append('Visibility', 'private');
     form.append('Content', JSON.stringify(assetData), {
       contentType: 'application/json',
     });
-    
+
     // create a new asset version
     const uploadResponse = await axios.post(uploadUrl, form, {
       auth: {
@@ -254,24 +213,19 @@ exports.uploadAsset = async function (parameters) {
       },
       headers: form.getHeaders(),
     });
-    
+
     if (!uploadResponse.data) {
       return { success: false, status: 500, message: 'Missing data in response' };
     }
-      
+
     const newVersionSid = uploadResponse.data.sid;
-    
+
     if (!newVersionSid) {
       return { success: false, status: 500, message: 'Missing new version SID in response' };
     }
 
     return { success: true, status: 200, assetVersionSid: newVersionSid };
+  } catch (error) {
+    return retryHandler(error, parameters, arguments.callee);
   }
-  catch (error) {
-    return retryHandler(
-        error, 
-        parameters,
-        arguments.callee
-    )
-  }
-}
+};

--- a/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
+++ b/serverless-schedule-manager/functions/common/twilio-wrappers/serverless.private.js
@@ -12,12 +12,13 @@ const retryHandler = require(Runtime.getFunctions()['common/twilio-wrappers/retr
  * @returns {object} An object containing the deployment sid
  * @description the following method is used to deploy a given build in this environment
  */
-exports.deployBuild = async function (parameters) {
+exports.deployBuild = async (parameters) => {
   const { attempts, context, buildSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(buildSid)) throw 'Invalid parameters object passed. Parameters must contain buildSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(buildSid)) throw new Error('Invalid parameters object passed. Parameters must contain buildSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -32,7 +33,7 @@ exports.deployBuild = async function (parameters) {
 
     return { success: true, status: 200, deploymentSid: deployment.sid };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.deployBuild);
   }
 };
 
@@ -44,12 +45,13 @@ exports.deployBuild = async function (parameters) {
  * @returns {object} An object containing the deployment sid
  * @description the following method is used to fetch build status for this service
  */
-exports.fetchBuildStatus = async function (parameters) {
+exports.fetchBuildStatus = async (parameters) => {
   const { attempts, context, buildSid } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(buildSid)) throw 'Invalid parameters object passed. Parameters must contain buildSid string';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(buildSid)) throw new Error('Invalid parameters object passed. Parameters must contain buildSid string');
 
   try {
     const client = context.getTwilioClient();
@@ -65,7 +67,7 @@ exports.fetchBuildStatus = async function (parameters) {
 
     return { success: true, status: 200, buildStatus: build.status };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchBuildStatus);
   }
 };
 
@@ -76,11 +78,12 @@ exports.fetchBuildStatus = async function (parameters) {
  * @returns {object} An object containing the deployment sid
  * @description the following method is used to fetch the latest build for this service
  */
-exports.fetchLatestBuild = async function (parameters) {
+exports.fetchLatestBuild = async (parameters) => {
   const { attempts, context } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = context.getTwilioClient();
@@ -96,7 +99,7 @@ exports.fetchLatestBuild = async function (parameters) {
 
     return { success: true, status: 200, latestBuild: builds[0] };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchLatestBuild);
   }
 };
 
@@ -107,11 +110,12 @@ exports.fetchLatestBuild = async function (parameters) {
  * @returns {object} The latest deployment
  * @description the following method is used to fetch the latest deployment for this service
  */
-exports.fetchLatestDeployment = async function (parameters) {
+exports.fetchLatestDeployment = async (parameters) => {
   const { attempts, context } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
     const client = context.getTwilioClient();
@@ -131,7 +135,7 @@ exports.fetchLatestDeployment = async function (parameters) {
 
     return { success: true, status: 200, latestDeployment: deployments[0] };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.fetchLatestDeployment);
   }
 };
 
@@ -145,15 +149,18 @@ exports.fetchLatestDeployment = async function (parameters) {
  * @returns {object} An object containing the build sid
  * @description the following method is used to create a new build in this service
  */
-exports.createBuild = async function (parameters) {
+exports.createBuild = async (parameters) => {
   const { attempts, context, assetVersions, dependencies, functionVersions } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isArray(assetVersions)) throw 'Invalid parameters object passed. Parameters must contain assetVersions array';
-  if (!isArray(dependencies)) throw 'Invalid parameters object passed. Parameters must contain dependencies array';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isArray(assetVersions))
+    throw new Error('Invalid parameters object passed. Parameters must contain assetVersions array');
+  if (!isArray(dependencies))
+    throw new Error('Invalid parameters object passed. Parameters must contain dependencies array');
   if (!isArray(functionVersions))
-    throw 'Invalid parameters object passed. Parameters must contain functionVersions array';
+    throw new Error('Invalid parameters object passed. Parameters must contain functionVersions array');
 
   try {
     const client = context.getTwilioClient();
@@ -167,7 +174,7 @@ exports.createBuild = async function (parameters) {
 
     return { success: true, status: 200, buildSid: build.sid };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.createBuild);
   }
 };
 
@@ -181,14 +188,17 @@ exports.createBuild = async function (parameters) {
  * @returns {object} An object containing the new asset version sid
  * @description the following method is used to upload a new version of an asset in this service
  */
-exports.uploadAsset = async function (parameters) {
+exports.uploadAsset = async (parameters) => {
   const { attempts, context, assetSid, assetPath, assetData } = parameters;
 
-  if (!isNumber(attempts)) throw 'Invalid parameters object passed. Parameters must contain the number of attempts';
-  if (!isObject(context)) throw 'Invalid parameters object passed. Parameters must contain context object';
-  if (!isString(assetSid)) throw 'Invalid parameters object passed. Parameters must contain assetSid string';
-  if (!isString(assetPath)) throw 'Invalid parameters object passed. Parameters must contain assetPath string';
-  if (!isObject(assetData)) throw 'Invalid parameters object passed. Parameters must contain assetData object';
+  if (!isNumber(attempts))
+    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(assetSid)) throw new Error('Invalid parameters object passed. Parameters must contain assetSid string');
+  if (!isString(assetPath))
+    throw new Error('Invalid parameters object passed. Parameters must contain assetPath string');
+  if (!isObject(assetData))
+    throw new Error('Invalid parameters object passed. Parameters must contain assetData object');
 
   try {
     const apiKey = context.ACCOUNT_SID;
@@ -226,6 +236,6 @@ exports.uploadAsset = async function (parameters) {
 
     return { success: true, status: 200, assetVersionSid: newVersionSid };
   } catch (error) {
-    return retryHandler(error, parameters, arguments.callee);
+    return retryHandler(error, parameters, exports.uploadAsset);
   }
 };

--- a/serverless-schedule-manager/package.json
+++ b/serverless-schedule-manager/package.json
@@ -10,7 +10,10 @@
     "deploy:dev": "TWILIO_PROFILE=dev npm run deploy",
     "deploy:test": "TWILIO_PROFILE=test npm run deploy",
     "deploy:qa": "TWILIO_PROFILE=qa npm run deploy",
-    "deploy:prod": "TWILIO_PROFILE=prod npm run deploy"
+    "deploy:prod": "TWILIO_PROFILE=prod npm run deploy",
+    "lint": "eslint --ext js ./functions",
+    "lint:fix": "npm run lint -- --fix",
+    "lint:report": "npm run lint -- --output-file eslint_report.json --format json"
   },
   "dependencies": {
     "@twilio/runtime-handler": "1.2.5",
@@ -23,10 +26,38 @@
     "twilio-flex-token-validator": "^1.5.6"
   },
   "devDependencies": {
+    "eslint": "^8.37.0",
+    "eslint-config-twilio": "^2.0.0",
     "twilio-cli": "^5.2.0",
     "twilio-run": "^3.4.2"
   },
   "engines": {
     "node": "14"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+      "twilio"
+    ],
+    "rules": {
+      "camelcase": "off",
+      "complexity": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": "off",
+      "import/no-mutable-exports": "off",
+      "import/no-unresolved": "off",
+      "import/no-unused-modules": "off",
+      "multiline-comment-style": "off",
+      "no-alert": "off",
+      "no-console": "off",
+      "no-multi-str": "off",
+      "no-use-before-define": "off",
+      "prefer-destructuring": "off",
+      "prefer-named-capture-group": "off",
+      "prefer-promise-reject-errors": "off",
+      "sonarjs/cognitive-complexity": "off",
+      "sonarjs/no-identical-functions": "off",
+      "sonarjs/no-duplicate-string": "off"
+    }
   }
 }


### PR DESCRIPTION
### Summary

Basically the same thing as #177 but for the serverless-schedule-manager package:

- Used twilio style as a base
- Turned off non-risky and annoying rules to prevent unnecessary friction
- CI adds comments and annotations for errors and warnings. Only errors prevent merging.
- Used `npm run lint:fix` to auto-fix what could be (mostly `prettier`), then made manual fixes for the remaining errors and warnings.
- None of the code changes should change functionality.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
