### PR TITLE
Handle errors when multi-call is enabled

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -226,6 +226,9 @@ export const handleFlexCallIncoming = (manager: Manager, call: Call) => {
   // register listeners for the new SecondDevice
   SecondDevice?.on('incoming', handleSecondCallIncoming);
   SecondDevice?.on('registered', handleSecondDeviceRegistered);
+  SecondDevice?.on('error', (error) => {
+    console.log('MultiCall: Error in SecondDevice', error);
+  });
 
   // register the new device with Twilio
   SecondDevice?.register();


### PR DESCRIPTION
### Summary

The Voice SDK throws errors when the network connection goes away. Previously, this would crash Flex if the network disconnected while on a call and multi-call is enabled. Adding an error handler prevents the crash.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
