### PR TITLE
Workaround Flex bug in dual channel recording

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
@@ -124,21 +124,21 @@ export const waitForConferenceParticipants = async (task: ITask): Promise<Confer
       if (!worker || !customer) {
         return;
       }
-      
+
       if (!worker?.callSid || !customer?.callSid) {
         console.debug('Looking for call SID');
         // Flex sometimes does not provide callSid in task conference participants, check if it is in the Redux store instead
         const storeConference = manager.store.getState().flex.conferences.states.get(task.taskSid);
-        
+
         if (!storeConference || !storeConference.source) {
           return;
         }
-        
+
         participants = storeConference.source.participants;
-        
+
         const storeWorker = participants.find((p) => p.participantType === 'worker' && p.isCurrentWorker);
         const storeCustomer = participants.find((p) => p.participantType === 'customer');
-        
+
         if (!storeWorker?.callSid || !storeCustomer?.callSid) {
           console.debug('Worker and customer participants joined conference, waiting for call SID');
           return;

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
@@ -114,7 +114,7 @@ export const waitForConferenceParticipants = async (task: ITask): Promise<Confer
       if (conference === undefined) {
         return;
       }
-      const { participants } = conference;
+      let { participants } = conference;
       if (Array.isArray(participants) && participants.length < 2) {
         return;
       }
@@ -123,6 +123,26 @@ export const waitForConferenceParticipants = async (task: ITask): Promise<Confer
 
       if (!worker || !customer) {
         return;
+      }
+      
+      if (!worker?.callSid || !customer?.callSid) {
+        console.debug('Looking for call SID');
+        // Flex sometimes does not provide callSid in task conference participants, check if it is in the Redux store instead
+        const storeConference = manager.store.getState().flex.conferences.states.get(task.taskSid);
+        
+        if (!storeConference || !storeConference.source) {
+          return;
+        }
+        
+        participants = storeConference.source.participants;
+        
+        const storeWorker = participants.find((p) => p.participantType === 'worker' && p.isCurrentWorker);
+        const storeCustomer = participants.find((p) => p.participantType === 'customer');
+        
+        if (!storeWorker?.callSid || !storeCustomer?.callSid) {
+          console.debug('Worker and customer participants joined conference, waiting for call SID');
+          return;
+        }
       }
 
       console.debug('Worker and customer participants joined conference');


### PR DESCRIPTION
### Summary

For some reason, this morning I was encountering an issue where task conference participants had no call SID, but the call SID was present within the Flex store. Added fallback logic to fetch participants from the Flex store if the task value is incomplete.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
