### PR TITLE
Replace teams-view-filters multiselect component

### DIFF
--- a/plugin-flex-ts-template-v2/.eslintrc.js
+++ b/plugin-flex-ts-template-v2/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'no-alert': 'off',
     'no-console': 'off',
     'no-duplicate-imports': 'off',
+    'no-nested-ternary': 'off',
     'prefer-destructuring': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-promise-reject-errors': 'off',

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -28,7 +28,6 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-select": "^5.5.0",
     "rrule": "^2.7.1",
     "twilio-video": "^2.24.0",
     "tzdata": "^1.0.35"


### PR DESCRIPTION
### Summary

Before | After:
![Screenshot 2023-04-17 at 4 15 46 PM](https://user-images.githubusercontent.com/7373633/232612771-c0d7a7a5-02db-42f5-ba02-b1072a7ed190.png)

The previous `react-select` solution was a borderline unusable UX, and I intended to replace it with Paste `MultiselectCombobox`, but was unable to due to twilio-labs/paste#2768. It sounds like that won't be addressed any time soon, so I rolled my own based on other Paste components. I think the result is a better UX all around (and knocks off a TODO and removes a dep).

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
