### PR TITLE
Fix queueNoWorkerDataFilter display by using Redux

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -86,7 +86,7 @@
           "queue_no_worker_data": true,
           "queue_worker_data": false,
           "team": true,
-          "agent_skills": true
+          "agent_skills": false
         },
         "department_options": [
           "General Management",

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
@@ -25,11 +25,11 @@ export type OwnProps = {
 export const MultiSelectFilter = (props: OwnProps) => {
   const pillState = useFormPillState();
   const [selectedItems, setSelectedItems] = useState([] as string[]);
-  
+
   const { selectedQueue } = useSelector(
     (state: AppState) => state[reduxNamespace].queueNoWorkerDataFilter as QueueNoWorkerDataFilterState,
   );
-  
+
   useEffect(() => {
     if (props.handleChange) {
       props.handleChange(selectedItems);
@@ -47,7 +47,7 @@ export const MultiSelectFilter = (props: OwnProps) => {
         setSelectedItems([selectedQueue]);
         return;
       }
-      
+
       setSelectedItems([]);
     }
   }, [props.currentValue]);

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { styled } from '@twilio/flex-ui';
 import { Select, Option } from '@twilio-paste/core/select';
 import { Stack } from '@twilio-paste/core/stack';
 import { useFormPillState, FormPillGroup, FormPill } from '@twilio-paste/core/form-pill-group';
 
 import { FilterDefinitionOption } from '../../types/FilterDefinitionOption';
+import AppState from '../../../../types/manager/AppState';
+import { reduxNamespace } from '../../../../utils/state';
+import { QueueNoWorkerDataFilterState } from '../../flex-hooks/states/QueueNoWorkerDataFilterSlice';
 
 const FilterContainer = styled('div')`
   margin-left: 16px;
@@ -21,7 +25,11 @@ export type OwnProps = {
 export const MultiSelectFilter = (props: OwnProps) => {
   const pillState = useFormPillState();
   const [selectedItems, setSelectedItems] = useState([] as string[]);
-
+  
+  const { selectedQueue } = useSelector(
+    (state: AppState) => state[reduxNamespace].queueNoWorkerDataFilter as QueueNoWorkerDataFilterState,
+  );
+  
   useEffect(() => {
     if (props.handleChange) {
       props.handleChange(selectedItems);
@@ -30,6 +38,16 @@ export const MultiSelectFilter = (props: OwnProps) => {
 
   useEffect(() => {
     if (!props.currentValue) {
+      // This is a bit of a hack to enable the queueNoWorkerDataFilter to render the currently filtered queue accurately.
+      // Because that filter actually applies skill filters instead via logic in beforeApplyTeamsViewFilters,
+      // our component's value is 'reset' by Flex. The beforeApplyTeamsViewFilters logic saves and resets the selected queue
+      // in state, so we can rely on that to know when to persist the selected queue versus when to actually reset.
+      // The name 'queue' is unique to the queueNoWorkerDataFilter (queueWorkerDataFilter uses the name 'queues' instead).
+      if (props.name === 'queue' && selectedQueue !== '') {
+        setSelectedItems([selectedQueue]);
+        return;
+      }
+      
       setSelectedItems([]);
     }
   }, [props.currentValue]);
@@ -58,13 +76,13 @@ export const MultiSelectFilter = (props: OwnProps) => {
           onChange={handleChange}
           value={props.IsMulti ? 'placeholder' : selectedItems.length === 1 ? selectedItems[0] : 'placeholder'}
         >
-          <Option disabled={true} value="placeholder">
+          <Option disabled={true} key="placeholder" value="placeholder">
             {props.IsMulti ? 'Select one or more items...' : 'Select an item...'}
           </Option>
           {props.options
             ? props.options.map((item: FilterDefinitionOption) => {
                 const selectedItem = selectedItems.find((i) => i === item.value);
-                if (props.IsMulti && selectedItem) return <></>;
+                if (props.IsMulti && selectedItem) return null;
                 return (
                   <Option value={item.value} key={item.value}>
                     {item.label}
@@ -77,7 +95,7 @@ export const MultiSelectFilter = (props: OwnProps) => {
           <FormPillGroup {...pillState} aria-label="Selected items:">
             {selectedItems.map((item) => {
               const filterItem = props.options?.find((i) => i.value === item);
-              if (!filterItem) return <></>;
+              if (!filterItem) return null;
               return (
                 <FormPill
                   key={filterItem.value}

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/actions/beforeApplyTeamsViewFilters.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/actions/beforeApplyTeamsViewFilters.ts
@@ -5,7 +5,7 @@ import TaskRouterService from '../../../../utils/serverless/TaskRouter/TaskRoute
 import { TeamViewQueueFilterNotification } from '../notifications/TeamViewQueueFilter';
 import { isQueueNoWorkerDataFilterEnabled } from '../../config';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
-import { selectQueue } from '../../flex-hooks/states/QueueNoWorkerDataFilterSlice';
+import { selectQueue } from '../states/QueueNoWorkerDataFilterSlice';
 
 export interface ApplyTeamsViewFiltersPayload {
   extraFilterQuery?: string;
@@ -147,7 +147,7 @@ function replaceQueueFiltersForTeamView(flex: typeof Flex, manager: Flex.Manager
 
         payload.filters = [...newFilter, ...queueFiltersArray];
       }
-      
+
       // store selected queue in state so that the UI can display it properly
       manager.store.dispatch(selectQueue(queue.friendlyName));
     },

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
@@ -13,7 +13,7 @@ const queueNoWorkerDataFilterSlice = createSlice({
   reducers: {
     selectQueue(state, action: PayloadAction<string>) {
       state.selectedQueue = action.payload;
-    }
+    },
   },
 });
 

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
@@ -5,6 +5,8 @@ export interface QueueNoWorkerDataFilterState {
   selectedQueue: string;
 }
 
+export const ResetQueuePlaceholder = '__PS_QUEUE_FILTER_RESET__';
+
 const initialState = { selectedQueue: '' } as QueueNoWorkerDataFilterState;
 
 const queueNoWorkerDataFilterSlice = createSlice({

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/states/QueueNoWorkerDataFilterSlice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface QueueNoWorkerDataFilterState {
+  selectedQueue: string;
+}
+
+const initialState = { selectedQueue: '' } as QueueNoWorkerDataFilterState;
+
+const queueNoWorkerDataFilterSlice = createSlice({
+  name: 'queueNoWorkerDataFilter',
+  initialState,
+  reducers: {
+    selectQueue(state, action: PayloadAction<string>) {
+      state.selectedQueue = action.payload;
+    }
+  },
+});
+
+export const { selectQueue } = queueNoWorkerDataFilterSlice.actions;
+export const reducerHook = () => ({ queueNoWorkerDataFilter: queueNoWorkerDataFilterSlice.reducer });


### PR DESCRIPTION
### Summary

Per the feature readme, the queueNoWorkerDataFilter actually is a facade and it is just setting skill filters under the hood. Because of this, Flex clears out the queue filter component when applying filters, which is a pretty confusing UX.

This fixes that by storing the selected queue in Redux, and then applying it when Flex clears the component.

Also disabled the agent skills filter by default, as it conflicts with the queueNoWorkerDataFilter if both are enabled (due to the queue filter also setting skill filters). It can be enabled instead of queueNoWorkerDataFilter, or can also be enabled in tandem with a more robust queue filter solution (i.e. queueWorkerDataFilter).

This hack seems to work a bit better than I was expecting, so please give it a spin to make sure I didn't miss anything 😄 

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
