### PR TITLE
Expose error response status from ApiService

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/flex-hooks/strings/ScheduleManager.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/flex-hooks/strings/ScheduleManager.ts
@@ -110,7 +110,7 @@ export const stringHook = () => ({
   [StringTemplates.PUBLISH_INFLIGHT]:
     'Another schedule publish is in progress. Publishing now will overwrite other changes.',
   [StringTemplates.PUBLISH_FAILED_OTHER_UPDATE]:
-    'Schedule was updated by someone else and cannot be published. Please reload and try again.',
+    'Schedules were updated by someone else and cannot be published. Please reload and try again.',
   [StringTemplates.PUBLISH_FAILED]: 'Schedule publish failed.',
   [StringTemplates.PUBLISH_FAILED_ACTIVITY]: 'Switch to a non-available activity to publish.',
   [StringTemplates.PUBLISH_SUCCESS]: 'Successfully published schedules.',

--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/ScheduleManagerService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/utils/ScheduleManagerService.ts
@@ -36,11 +36,10 @@ class ScheduleManagerService extends ApiService {
   async update(config: ScheduleManagerConfig): Promise<UpdateConfigResponse> {
     try {
       return await this.#update(config);
-    } catch (error) {
+    } catch (error: any) {
       console.log('Unable to update config', error);
 
-      // TODO: Modify request util to return status too.
-      if (error === 'Provided version SID is not the latest deployed asset version SID') {
+      if (error.status === 409) {
         return {
           success: false,
           buildSid: 'versionError',

--- a/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
@@ -66,7 +66,21 @@ export default abstract class ApiService {
             return await this.fetchJsonWithReject<T>(url, config, attempts + 1);
           }
           return error.json().then((response: any) => {
-            throw response;
+            if (typeof response === 'object' && Object.keys(response).length > 0) {
+              // Error response body is an actual JSON object with keys; return them all
+              // eslint-disable-next-line no-throw-literal
+              throw {
+                status: error.status,
+                ...response,
+              };
+            } else {
+              // Error response body is not JSON
+              // eslint-disable-next-line no-throw-literal
+              throw {
+                status: error.status,
+                message: response,
+              };
+            }
           });
         } catch (e) {
           throw error;


### PR DESCRIPTION
### Summary

Previously, ApiService errors would throw the parsed response body JSON, but this does not include the actual HTTP status returned by the service (unless it is added to the body by the service). Updated ApiService to add a status property to thrown errors, and placed literal errors in the message property, which is the only existing property I could find that is actually used from error responses.

This eliminates a TODO -- now features can use status codes instead of having to parse the complete response in order to handle errors.

Ultimately, the only behavior this changes right now is when the schedule manager receives a 409 from the update function. To test that this still works after the change, first open two instances of Flex, then publish a schedule update from one instance, and then attempt to publish a schedule update from the other instance without reloading it first. You should receive an error due to the 409.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
