### PR TITLE
Dynamic max capacity in omni-channel-capacity-management feature

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -52,7 +52,9 @@
         "supervisor_alert_toggle": true
       },
       "omni_channel_capacity_management": {
-        "enabled": false
+        "enabled": false,
+        "channel": "chat",
+        "default_max_capacity": 2
       },
       "device_manager": {
         "enabled": true

--- a/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/README.md
@@ -2,13 +2,13 @@
 
 This feature is intended for use when the solution imposes the following parameters
 
-- chat and other channels are mututally exclusive (using workflow expressions, see below)
+- chat and other channels are mutually exclusive (using workflow expressions, see below)
 - chat users have a capacity greater than 1
 
 The reason for this is; if for example voice has a capacity of 1 and chat has a capacity of 2 and there is a backlog of chat work, the agent would be locked into doing that chat work as each time a chat task is dismissed, another chat task would take its place. This means that the chat backlog would
 need to be exhausted before the user would ever qualify for voice work.
 
-To address this, this feature toggles agents between a chat capacity of 2 and chat capacity of 1 ensuring taskrouter can route the most important piece of work to the user, across both channels.
+To address this, this feature toggles agents between the configured chat capacity and a chat capacity of 1, ensuring taskrouter can route the most important piece of work to the user across both channels.
 
 # flex-user-experience
 
@@ -18,9 +18,9 @@ Example delivery of callbacks (on voice channel of capacity 1) and chat tasks (m
 
 # setup and dependencies
 
-1. Make sure the feauter is enabled in the flex-config
+1. Make sure the feature is enabled in the flex-config, and the affected channel and default max capacity settings are configured as desired.
 
-2. Ensure that for your workflows assinging work, they use the relevant workflow expression.
+2. Ensure that for your workflows assigning work, they use the relevant workflow expression.
 
 &ensp;&ensp;&ensp;&ensp;&ensp;For example for workflows assinging chat work to queues
 <br>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- worker.channel.voice.available_capacity_percentage == 100
@@ -30,4 +30,4 @@ Example delivery of callbacks (on voice channel of capacity 1) and chat tasks (m
 
 # how does it work?
 
-By using the workflow expressions to keep reservations of different channels mutually excluded, the solution works by moving the agents channel capacity to 1 anytime they hit their max capacity. Then this allows taskrouter to assign the next relevant piece of work. As soon as that work is accepted, this feature automatically puts their capacity back to 2. Further enhancements would need to be made to this feature if each agent was to have a different max capacity.
+By using the workflow expressions to keep reservations of different channels mutually excluded, the solution works by moving the agents channel capacity to 1 any time they hit their max capacity, while storing the previous max capacity in local storage. Then this allows taskrouter to assign the next relevant piece of work. As soon as that work is accepted, this feature automatically puts their capacity back to the previous setting from local storage.

--- a/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/config.ts
@@ -1,9 +1,20 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import OmniChannelCapacityManagementConfig from './types/ServiceConfiguration';
 
-const { enabled = false } =
-  (getFeatureFlags()?.features?.omni_channel_capacity_management as OmniChannelCapacityManagementConfig) || {};
+const {
+  enabled = false,
+  channel = 'chat',
+  default_max_capacity = 2,
+} = (getFeatureFlags()?.features?.omni_channel_capacity_management as OmniChannelCapacityManagementConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const getConfigChannel = () => {
+  return channel;
+};
+
+export const getDefaultMaxCapacity = () => {
+  return default_max_capacity;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/omni-channel-capacity-management/types/ServiceConfiguration.ts
@@ -1,3 +1,5 @@
 export default interface OmniChannelCapacityManagementConfig {
   enabled: boolean;
+  channel: string;
+  default_max_capacity: number;
 }


### PR DESCRIPTION
### Summary

Before setting the capacity to 1, we now save the current configured capacity in local storage. This is then used to restore the capacity rather than the hard coded setting of 2. If local storage is missing, a configurable fallback value is used.

Also added a config option for the affected channel while at it.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
