### PR TITLE
Fix canned responses with programmable chat

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesCRM/Response/Response.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesCRM/Response/Response.tsx
@@ -16,27 +16,31 @@ interface ResponseProps {
 
 const Response: React.FunctionComponent<ResponseProps> = ({ text, task }) => {
   const inputState = useFlexSelector(
-    (state) => state.flex.chat.conversationInput[task.attributes.conversationSid].inputText,
+    (state) =>
+      state.flex.chat.conversationInput[task.attributes.conversationSid ?? task.attributes.channelSid].inputText,
   );
 
   const onClickSend = async () => {
-    if (!task.attributes.conversationSid) return;
-    await Actions.invokeAction('SendMessage', { body: text, conversationSid: task.attributes.conversationSid });
+    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
+    await Actions.invokeAction('SendMessage', {
+      body: text,
+      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
+    });
     Actions.invokeAction('SetInputText', {
       body: inputState,
-      conversationSid: task.attributes.conversationSid,
+      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
     });
   };
 
   const onClickInsert = () => {
-    if (!task.attributes.conversationSid) return;
+    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
     let currentInput = inputState;
     if (currentInput.length > 0 && currentInput.charAt(currentInput.length - 1) !== ' ') {
       currentInput += ' ';
     }
     Actions.invokeAction('SetInputText', {
       body: currentInput + text,
-      conversationSid: task.attributes.conversationSid,
+      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
     });
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
@@ -20,7 +20,8 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   const [error, setError] = useState(false);
   const [responseCategories, setResponseCategories] = useState<undefined | CannedResponseCategories>(undefined);
   const inputState = useFlexSelector(
-    (state) => state.flex.chat.conversationInput[task.attributes.conversationSid].inputText,
+    (state) =>
+      state.flex.chat.conversationInput[task.attributes.conversationSid ?? task.attributes.channelSid].inputText,
   );
 
   const menu = useMenuState({
@@ -29,14 +30,14 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   });
 
   const onClickInsert = (text: string) => {
-    if (!task.attributes.conversationSid) return;
+    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
     let currentInput = inputState;
     if (currentInput.length > 0 && currentInput.charAt(currentInput.length - 1) !== ' ') {
       currentInput += ' ';
     }
     Actions.invokeAction('SetInputText', {
       body: currentInput + text,
-      conversationSid: task.attributes.conversationSid,
+      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
     });
   };
 


### PR DESCRIPTION
### Summary

Currently, accepting a programmable chat task while canned responses are enabled crashes Flex due to a missing attribute. This fixes that and allows canned responses to be used with programmable chat.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
