### PR TITLE
Canned responses improvements

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesCRM/Response/Response.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesCRM/Response/Response.tsx
@@ -15,32 +15,30 @@ interface ResponseProps {
 }
 
 const Response: React.FunctionComponent<ResponseProps> = ({ text, task }) => {
-  const inputState = useFlexSelector(
-    (state) =>
-      state.flex.chat.conversationInput[task.attributes.conversationSid ?? task.attributes.channelSid].inputText,
-  );
+  const conversationSid = task.attributes.conversationSid ?? task.attributes.channelSid;
+  const inputState = useFlexSelector((state) => state.flex.chat.conversationInput[conversationSid]?.inputText);
 
   const onClickSend = async () => {
-    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
+    if (!conversationSid) return;
     await Actions.invokeAction('SendMessage', {
       body: text,
-      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
+      conversationSid,
     });
     Actions.invokeAction('SetInputText', {
       body: inputState,
-      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
+      conversationSid,
     });
   };
 
   const onClickInsert = () => {
-    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
+    if (!conversationSid) return;
     let currentInput = inputState;
     if (currentInput.length > 0 && currentInput.charAt(currentInput.length - 1) !== ' ') {
       currentInput += ' ';
     }
     Actions.invokeAction('SetInputText', {
       body: currentInput + text,
-      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
+      conversationSid,
     });
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Actions, ITask, useFlexSelector } from '@twilio/flex-ui';
+import { Actions, ITask, useFlexSelector, TaskHelper } from '@twilio/flex-ui';
 import { Box } from '@twilio-paste/core/box';
 import { Tooltip } from '@twilio-paste/tooltip';
 import { Menu, MenuButton, MenuItem, MenuGroup, useMenuState } from '@twilio-paste/core/menu';
@@ -19,10 +19,8 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
   const [responseCategories, setResponseCategories] = useState<undefined | CannedResponseCategories>(undefined);
-  const inputState = useFlexSelector(
-    (state) =>
-      state.flex.chat.conversationInput[task.attributes.conversationSid ?? task.attributes.channelSid].inputText,
-  );
+  const conversationSid = task.attributes.conversationSid ?? task.attributes.channelSid;
+  const inputState = useFlexSelector((state) => state.flex.chat.conversationInput[conversationSid]?.inputText);
 
   const menu = useMenuState({
     placement: 'top-start',
@@ -30,14 +28,14 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   });
 
   const onClickInsert = (text: string) => {
-    if (!task.attributes.conversationSid && !task.attributes.channelSid) return;
+    if (!conversationSid) return;
     let currentInput = inputState;
     if (currentInput.length > 0 && currentInput.charAt(currentInput.length - 1) !== ' ') {
       currentInput += ' ';
     }
     Actions.invokeAction('SetInputText', {
       body: currentInput + text,
-      conversationSid: task.attributes.conversationSid ?? task.attributes.channelSid,
+      conversationSid,
     });
   };
 
@@ -61,7 +59,7 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
       {isLoading && <SkeletonLoader />}
       {Boolean(responseCategories) && !isLoading && (
         <>
-          <MenuButton {...menu} variant={'primary_icon'}>
+          <MenuButton {...menu} variant={'primary_icon'} disabled={TaskHelper.isInWrapupMode(task)}>
             <ChatIcon decorative />
           </MenuButton>
           <Menu {...menu} aria-label="canned-responses" element="CANNED_RESPONSES_MENU">

--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/flex-hooks/components/CRMContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/flex-hooks/components/CRMContainer.tsx
@@ -12,10 +12,11 @@ export const componentHook = function addCannedResponsesCRMContainer(flex: typeo
       // In the AgentDesktopView, we don't, however we have access to all the tasks and the selected one that we could retrieve
       // When completing the task, selectedTaskSid still exist but the task in the map has been removed, so we have to check the size of it
       if (props.task) {
-        return Flex.TaskHelper.isChatBasedTask(props.task);
+        return Flex.TaskHelper.isChatBasedTask(props.task) && !Flex.TaskHelper.isInWrapupMode(props.task);
       }
       if (props.selectedTaskSid && props.tasks.size > 0) {
-        return Flex.TaskHelper.isChatBasedTask(props.tasks.get(props.selectedTaskSid));
+        const selectedTaskSid = props.tasks.get(props.selectedTaskSid);
+        return Flex.TaskHelper.isChatBasedTask(selectedTaskSid) && !Flex.TaskHelper.isInWrapupMode(selectedTaskSid);
       }
       return false;
     },

--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/utils/CannedResponsesService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/utils/CannedResponsesService.ts
@@ -7,8 +7,15 @@ export interface CannedResponsesReponse {
 }
 
 class CannedResponsesService extends ApiService {
+  cannedResponseCache: CannedResponsesReponse | null = null;
+
   fetchCannedResponses = async (): Promise<CannedResponsesReponse> => {
     return new Promise((resolve, reject) => {
+      if (this.cannedResponseCache) {
+        resolve(this.cannedResponseCache);
+        return;
+      }
+
       const encodedParams: EncodedParams = {
         Token: encodeURIComponent(this.manager.store.getState().flex.session.ssoTokenPayload.token),
       };
@@ -22,6 +29,7 @@ class CannedResponsesService extends ApiService {
         },
       )
         .then((response) => {
+          this.cannedResponseCache = response;
           resolve(response);
         })
         .catch((error) => {


### PR DESCRIPTION
### Summary

- The crash fix from #198 was incomplete; it would still crash on the second task handled. That should now be fully resolved.
- Added a really basic cache to the canned responses service so that it doesn't need to hit the function for each task. This seemed like a simple shoe-in, let me know if you'd like it done differently or if there was reasoning around the lack of a cache that I'm not aware of.
- Disable/hide canned responses in wrapup mode when they cannot be sent

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
