### PR TITLE
Remove need for functions to pass attempts parameter

### DIFF
--- a/serverless-functions/.boiler-plate-function
+++ b/serverless-functions/.boiler-plate-function
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     /* 
     const result = await PhoneNumbers.listPhoneNumbers({
       context,
-      attempts: 0,
     });
 
     const { phoneNumbers, status } = result;

--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -9,7 +9,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   try {
     const result = await PhoneNumberOpertions.listPhoneNumbers({
       context,
-      attempts: 0,
     });
 
     const { phoneNumbers: fullPhoneNumberList } = result;

--- a/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
+++ b/serverless-functions/src/functions/common/flex/programmable-chat/update-channel-attributes.js
@@ -16,7 +16,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       channelSid,
       attributes,
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/add-participant.js
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       taskSid,
       to,
       from,
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/cold-transfer.js
@@ -16,7 +16,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       callSid,
       to,
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/get-call-properties.js
@@ -12,7 +12,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const result = await VoiceOperations.fetchProperties({
       context,
       callSid,
-      attempts: 0,
     });
 
     const { callProperties, status } = result;

--- a/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/hold-participant.js
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       conference,
       participant,
       hold: hold === 'true',
-      attempts: 0,
     });
 
     const { participantsResponse, status } = result;

--- a/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/remove-participant.js
@@ -16,7 +16,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       conference,
       participant,
-      attempts: 0,
     });
 
     const { participantsResponse, status } = result;

--- a/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
+++ b/serverless-functions/src/functions/common/flex/programmable-voice/update-participant.js
@@ -21,7 +21,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       conference,
       participant,
       endConferenceOnExit: endConferenceOnExit === 'true',
-      attempts: 0,
     });
 
     const { participantsResponse, status } = result;

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-queues.js
@@ -9,7 +9,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   try {
     const result = await TaskRouterOperations.getQueues({
       context,
-      attempts: 0,
     });
     const { queues: fullQueueData, status } = result;
     const queues = fullQueueData

--- a/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/get-worker-channels.js
@@ -10,7 +10,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const { workerSid } = event;
     const result = await TaskRouterOperations.getWorkerChannels({
       context,
-      attempts: 0,
       workerSid,
     });
     const { status, workerChannels } = result;

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-assignment-status.js
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       taskSid,
       updateParams: { assignmentStatus },
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-task-attributes.js
@@ -18,7 +18,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       taskSid,
       attributesUpdate,
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
+++ b/serverless-functions/src/functions/common/flex/taskrouter/update-worker-channel.js
@@ -25,7 +25,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const { workerSid, workerChannelSid, capacity, available } = event;
     const result = await TaskRouterOperations.updateWorkerChannel({
       context,
-      attempts: 0,
       workerSid,
       workerChannelSid,
       capacity: Number(capacity),

--- a/serverless-functions/src/functions/common/helpers/retry-handler.private.js
+++ b/serverless-functions/src/functions/common/helpers/retry-handler.private.js
@@ -24,12 +24,9 @@ snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  *   retry handler in the browser are still encouraged.
  */
 exports.retryHandler = async (error, parameters, callback) => {
-  if (!isNumber(parameters.attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
-
   const { TWILIO_SERVICE_MAX_BACKOFF, TWILIO_SERVICE_MIN_BACKOFF, TWILIO_SERVICE_RETRY_LIMIT, ENABLE_LOCAL_LOGGING } =
     process.env;
-  const { attempts, context } = parameters;
+  const { context } = parameters;
   const {
     response,
     message: errorMessage,
@@ -37,9 +34,9 @@ exports.retryHandler = async (error, parameters, callback) => {
     moreInfo: twilioDocPage,
     code: twilioErrorCode,
   } = error;
+  const attempts = parameters.attempts ?? 0;
   const status = errorStatus ? errorStatus : response ? response.status : 500;
-  const retryAttemptsMessage =
-    attempts === 1 ? `${parameters.attempts} retry attempt` : `${parameters.attempts} retry attempts`;
+  const retryAttemptsMessage = attempts === 1 ? `${attempts} retry attempt` : `${attempts} retry attempts`;
   const message = errorMessage ? errorMessage : error;
 
   if (

--- a/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/conference-participant.private.js
@@ -16,7 +16,7 @@ const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handle
  *      within the defined conference
  */
 exports.coachToggle = async function coachToggle(parameters) {
-  const { context, conferenceSid, participantSid, agentSid, muted, coaching, attempts } = parameters;
+  const { context, conferenceSid, participantSid, agentSid, muted, coaching } = parameters;
 
   if (!isObject(context))
     throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
@@ -28,8 +28,6 @@ exports.coachToggle = async function coachToggle(parameters) {
   if (!isString(muted)) throw new Error('Invalid parameters object passed. Parameters must contain muted boolean');
   if (!isString(coaching))
     throw new Error('Invalid parameters object passed. Parameters must contain coaching boolean');
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   try {
     const client = context.getTwilioClient();
 
@@ -56,7 +54,7 @@ exports.coachToggle = async function coachToggle(parameters) {
  *      within the defined conference
  */
 exports.bargeToggle = async function bargeToggle(parameters) {
-  const { context, conferenceSid, participantSid, muted, attempts } = parameters;
+  const { context, conferenceSid, participantSid, muted } = parameters;
 
   if (!isObject(context))
     throw new Error('Invalid parameters object passed. Parameters must contain reason context object');
@@ -65,8 +63,6 @@ exports.bargeToggle = async function bargeToggle(parameters) {
   if (!isString(participantSid))
     throw new Error('Invalid parameters object passed. Parameters must contain participantSid string');
   if (!isString(muted)) throw new Error('Invalid parameters object passed. Parameters must contain muted boolean');
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   try {
     const client = context.getTwilioClient();
 

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -13,10 +13,8 @@ const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handle
  * @description the following method is used to create an Interaction Channel Invite
  */
 exports.participantCreateInvite = async function participantCreateInvite(parameters) {
-  const { attempts, context, interactionSid, channelSid, routing } = parameters;
+  const { context, interactionSid, channelSid, routing } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(interactionSid))
     throw new Error('Invalid parameters object passed. Parameters must contain interactionSid string value');
@@ -49,10 +47,8 @@ exports.participantCreateInvite = async function participantCreateInvite(paramet
  * @description the following method is used to update/modify a channel participant
  */
 exports.participantUpdate = async function participantUpdate(parameters) {
-  const { attempts, context, interactionSid, channelSid, participantSid, status } = parameters;
+  const { context, interactionSid, channelSid, participantSid, status } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(interactionSid))
     throw new Error('Invalid parameters object passed. Parameters must contain interactionSid string value');

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-chat.private.js
@@ -13,10 +13,8 @@ const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handle
  *    to the channel object
  */
 exports.updateChannelAttributes = async function updateChannelAttributes(parameters) {
-  const { attempts, context, channelSid, attributes } = parameters;
+  const { context, channelSid, attributes } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(channelSid))
     throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');

--- a/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/sync.private.js
@@ -12,10 +12,8 @@ const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handle
  * @description the following method is used to remove a Sync Map Item
  */
 exports.deleteMapItem = async function deleteMapItem(parameters) {
-  const { attempts, context, mapSid, key } = parameters;
+  const { context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
     throw new Error('Invalid parameters object passed. Parameters must contain mapSid string value');
@@ -43,10 +41,8 @@ exports.deleteMapItem = async function deleteMapItem(parameters) {
  * @description the following method is used to fetch a Sync Map Item
  */
 exports.fetchMapItem = async function fetchMapItem(parameters) {
-  const { attempts, context, mapSid, key } = parameters;
+  const { context, mapSid, key } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
     throw new Error('Invalid parameters object passed. Parameters must contain context object');
@@ -76,10 +72,8 @@ exports.fetchMapItem = async function fetchMapItem(parameters) {
  * @description the following method is used to create a Sync Map Item
  */
 exports.createMapItem = async function createMapItem(parameters) {
-  const { attempts, context, mapSid, key, ttl, data } = parameters;
+  const { context, mapSid, key, ttl, data } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(mapSid) && !isString(mapSid))
     throw new Error('Invalid parameters object passed. Parameters must contain context object');
@@ -120,10 +114,8 @@ exports.createMapItem = async function createMapItem(parameters) {
  * @description the following method is used to create a sync document
  */
 exports.createDocument = async function createDocument(parameters) {
-  const { attempts, context, uniqueName, ttl, data } = parameters;
+  const { context, uniqueName, ttl, data } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (Boolean(uniqueName) && !isString(uniqueName))
     throw new Error('Invalid parameters object passed. Parameters must contain uniqueName string value');
@@ -157,10 +149,8 @@ exports.createDocument = async function createDocument(parameters) {
  * @description the following method is used to fetch a sync document
  */
 exports.fetchDocument = async function fetchDocument(parameters) {
-  const { attempts, context, documentSid } = parameters;
+  const { context, documentSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(documentSid))
     throw new Error('Invalid parameters object passed. Parameters must contain documentSid string value');
@@ -186,10 +176,8 @@ exports.fetchDocument = async function fetchDocument(parameters) {
  * @description the following method is used to fetch a sync document
  */
 exports.updateDocumentData = async function updateDocumentData(parameters) {
-  const { attempts, context, documentSid, updateData } = parameters;
+  const { context, documentSid, updateData } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(documentSid))
     throw new Error('Invalid parameters object passed. Parameters must contain documentSid string value');

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -17,8 +17,6 @@ const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handle
 exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
   const { attempts, taskSid, attributesUpdate } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isString(taskSid))
     throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isString(attributesUpdate))
@@ -81,8 +79,6 @@ exports.updateTaskAttributes = async function updateTaskAttributes(parameters) {
 exports.completeTask = async function completeTask(parameters) {
   const { attempts, taskSid, reason, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isString(taskSid))
     throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isString(reason)) throw new Error('Invalid parameters object passed. Parameters must contain reason string');
@@ -135,8 +131,6 @@ exports.completeTask = async function completeTask(parameters) {
 exports.updateReservation = async function updateReservation(parameters) {
   const { attempts, context, taskSid, reservationSid, status } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isString(taskSid))
     throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isString(reservationSid))
@@ -206,8 +200,6 @@ exports.createTask = async function createTask(parameters) {
     attempts,
   } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(workflowSid) || workflowSid.length === 0)
     throw new Error('Invalid parameters object passed. Parameters must contain workflowSid string');
@@ -254,8 +246,6 @@ exports.createTask = async function createTask(parameters) {
 exports.getQueues = async function getQueues(parameters) {
   const { context, attempts } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {
@@ -286,8 +276,6 @@ exports.getQueues = async function getQueues(parameters) {
 exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
   const { context, attempts, workerSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(workerSid))
     throw new Error('Invalid parameters object passed. Parameters must contain workerSid string');
@@ -320,8 +308,6 @@ exports.getWorkerChannels = async function updateWorkerChannel(parameters) {
 exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
   const { context, attempts, workerSid, workerChannelSid, capacity, available } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(workerSid))
     throw new Error('Invalid parameters object passed. Parameters must contain workerSid string');
@@ -361,8 +347,6 @@ exports.updateWorkerChannel = async function updateWorkerChannel(parameters) {
 exports.updateTask = async function updateTask(parameters) {
   const { attempts, taskSid, updateParams, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isString(taskSid))
     throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isObject(updateParams))
@@ -418,8 +402,6 @@ exports.updateTask = async function updateTask(parameters) {
 exports.fetchTask = async function fetchTask(parameters) {
   const { attempts, taskSid, context } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isString(taskSid))
     throw new Error('Invalid parameters object passed. Parameters must contain the taskSid string');
   if (!isObject(context))
@@ -474,8 +456,6 @@ exports.fetchTask = async function fetchTask(parameters) {
 exports.getTasks = async function getTasks(parameters) {
   const { context, attempts, workflowSid, assignmentStatus, ordering, limit } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
 
   try {

--- a/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
@@ -59,6 +59,5 @@ exports.createCallbackTask = async (parameters) => {
     attributes,
     priority,
     timeout,
-    attempts: 0,
   });
 };

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
@@ -43,7 +43,6 @@ async function getPendingTaskByCallSid(context, callSid, workflowSid) {
   // Fine tuning of this value can be done based on anticipated call volume and validated through load testing.
   const result = await TaskRouterOperations.getTasks({
     context,
-    attempts: 0,
     assignmentStatus: ['pending', 'reserved'],
     workflowSid,
     ordering: 'DateCreated:desc',
@@ -63,7 +62,6 @@ async function fetchTask(context, taskSid) {
   const result = await TaskRouterOperations.fetchTask({
     context,
     taskSid,
-    attempts: 0,
   });
   return result.task;
 }
@@ -92,7 +90,6 @@ async function cancelTask(context, task, cancelReason) {
       reason: cancelReason,
       attributes: JSON.stringify(newAttributes),
     },
-    attempts: 0,
   });
 }
 
@@ -126,7 +123,6 @@ async function handleCallbackOrVoicemailSelected(context, isVoicemail, callSid, 
       method: 'POST',
       url: `${domain}/features/callback-and-voicemail/studio/wait-experience?mode=${mode}&CallSid=${callSid}&enqueuedTaskSid=${taskSid}`,
     },
-    attempts: 0,
   });
   const { success, status } = result;
 
@@ -161,7 +157,7 @@ exports.handler = async (context, event, callback) => {
     case 'initialize':
       // Initial logic to find the associated task for the call, and propagate it through to the rest of the TwiML execution
       // If the lookup fails to find the task, the remaining TwiML logic will not offer any callback or voicemail options.
-      const enqueuedWorkflowSid = (await VoiceOperations.fetchVoiceQueue({ context, queueSid: QueueSid, attempts: 0 }))
+      const enqueuedWorkflowSid = (await VoiceOperations.fetchVoiceQueue({ context, queueSid: QueueSid }))
         .queueProperties.friendlyName;
       console.log(`Enqueued workflow sid: ${enqueuedWorkflowSid}`);
       const enqueuedTask = await getPendingTaskByCallSid(context, CallSid, enqueuedWorkflowSid);
@@ -242,7 +238,6 @@ exports.handler = async (context, event, callback) => {
         context,
         numberToCall: event.Caller,
         numberToCallFrom: event.Called,
-        attempts: 0,
       });
 
       // End the interaction. Hangup the call.
@@ -288,7 +283,6 @@ exports.handler = async (context, event, callback) => {
         recordingUrl: event.RecordingUrl,
         transcriptSid: event.TranscriptionSid,
         transcriptText: event.TranscriptionText,
-        attempts: 0,
       });
 
       return callback(null, '');

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/agent-get-token.js
@@ -12,7 +12,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const client = context.getTwilioClient();
 
     const documentData = await SyncOperations.fetchDocument({
-      attempts: 0,
       context,
       documentSid: document_sid,
     });
@@ -42,7 +41,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         })
         .then((new_document_data) =>
           SyncOperations.updateDocumentData({
-            attempts: 0,
             context,
             documentSid: document_sid,
             updateData: new_document_data,

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-sync-token.js
@@ -14,7 +14,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
 
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
-      attempts: 0,
       context,
       documentSid: code,
     });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/client-get-video-token.js
@@ -13,7 +13,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
 
     // Validate that the unique code is valid, i.e.: that the SYNC document exists
     const documentData = await SyncOperations.fetchDocument({
-      attempts: 0,
       context,
       documentSid: code,
     });

--- a/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
+++ b/serverless-functions/src/functions/features/chat-to-video-escalation/generate-unique-code.js
@@ -28,7 +28,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       });
 
       document = await SyncOperations.createDocument({
-        attempts: 0,
         context,
         uniqueName: unique_code,
         ttl: context.VIDEO_CODE_TTL,
@@ -47,7 +46,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       taskSid,
       attributesUpdate: JSON.stringify(attributesUpdate),
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
+++ b/serverless-functions/src/functions/features/chat-transfer/common/chat-operations.private.js
@@ -19,10 +19,8 @@ const COMPLETED = 'completed';
  *  is called which marks the task as "completed"
  */
 exports.addTaskToChannel = async (parameters) => {
-  const { attempts, context, channelSid, taskSid } = parameters;
+  const { context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(channelSid))
     throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');
@@ -69,10 +67,8 @@ exports.addTaskToChannel = async (parameters) => {
  *  channel data and marked as being "complete".
  */
 exports.setTaskToCompleteOnChannel = async (parameters) => {
-  const { attempts, context, channelSid, taskSid } = parameters;
+  const { context, channelSid, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(channelSid))
     throw new Error('Invalid parameters object passed. Parameters must contain channelSid string');
@@ -119,10 +115,8 @@ exports.setTaskToCompleteOnChannel = async (parameters) => {
  *  a channel sid.
  */
 exports.removeChannelSidFromTask = async function removeChannelSidFromTask(parameters) {
-  const { attempts, context, taskSid } = parameters;
+  const { context, taskSid } = parameters;
 
-  if (!isNumber(attempts))
-    throw new Error('Invalid parameters object passed. Parameters must contain the number of attempts');
   if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
   if (!isString(taskSid)) throw new Error('Invalid parameters object passed. Parameters must contain taskSid string');
 

--- a/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/complete-task-for-transfer.js
@@ -24,7 +24,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       const removeChannelSidResult = await ChatOperations.removeChannelSidFromTask({
         context,
         taskSid,
-        attempts: 0,
       });
 
       // if it fails, abandon process and return error messages
@@ -41,7 +40,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           context,
           taskSid,
           channelSid,
-          attempts: 0,
         });
       } catch (error) {
         console.error('Error updating chat channel with task sid as completed');
@@ -54,7 +52,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       taskSid,
       reason,
-      attempts: 0,
     });
 
     response.setStatusCode(completeTaskResult.status);

--- a/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
+++ b/serverless-functions/src/functions/features/chat-transfer/flex/create-transfer-task.js
@@ -67,7 +67,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       attributes: newAttributes,
       priority,
       timeout,
-      attempts: 0,
     });
 
     const {
@@ -88,7 +87,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           context,
           taskSid,
           channelSid,
-          attempts: 0,
         });
     } catch (error) {
       console.error('Error updating chat channel with task sid created for it');

--- a/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
+++ b/serverless-functions/src/functions/features/chat-transfer/studio/add-task-to-chat-channel-data.protected.js
@@ -15,7 +15,6 @@ exports.handler = prepareStudioFunction(requiredParameters, async (context, even
       context,
       taskSid,
       channelSid,
-      attempts: 0,
     });
 
     response.setStatusCode(result.status);

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -125,7 +125,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
       interactionSid: flexInteractionSid,
       channelSid: flexInteractionChannelSid,
       context,
-      attempts: 0,
     };
 
     const {
@@ -147,7 +146,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
         channelSid: flexInteractionChannelSid,
         participantSid: removeFlexInteractionParticipantSid,
         context,
-        attempts: 0,
       });
 
     console.log(

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
@@ -51,7 +51,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
       channelSid: flexInteractionChannelSid,
       participantSid: flexInteractionParticipantSid,
       context,
-      attempts: 0,
     });
 
     response.setStatusCode(201);

--- a/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
+++ b/serverless-functions/src/functions/features/dual-channel-recording/flex/create-recording.js
@@ -15,7 +15,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       params: {
         recordingChannels: 'dual',
       },
-      attempts: 0,
     });
 
     const { recording, status } = result;

--- a/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
+++ b/serverless-functions/src/functions/features/hang-up-by/flex/fetch-conference-participant.js
@@ -16,7 +16,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       context,
       conference,
       participant,
-      attempts: 0,
     });
 
     const { participantsResponse, status } = result;

--- a/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
+++ b/serverless-functions/src/functions/features/internal-call/common/call-outbound-join.protected.js
@@ -15,7 +15,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
       const fetchTaskResult = await TaskOperations.fetchTask({
         context,
         taskSid,
-        attempts: 0,
       });
 
       const { task } = fetchTaskResult;
@@ -51,7 +50,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
             },
             workflowSid: process.env.TWILIO_FLEX_INTERNAL_CALL_WORKFLOW_SID,
             taskChannel: 'voice',
-            attempts: 0,
           });
 
           newAttributes.conference.participants.taskSid = createTaskResult.task.sid;
@@ -61,7 +59,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
           context,
           taskSid,
           attributesUpdate: JSON.stringify(newAttributes),
-          attempts: 0,
         });
       }
     }
@@ -72,7 +69,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
       const fetchTaskResult = await TaskOperations.fetchTask({
         context,
         taskSid,
-        attempts: 0,
       });
 
       const { task } = fetchTaskResult;
@@ -85,7 +81,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
             assignmentStatus: task.assignmentStatus === 'assigned' ? 'wrapping' : 'canceled',
             reason: 'conference is complete',
           },
-          attempts: 0,
         });
       }
 
@@ -95,7 +90,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
         const fetchTargetTaskResult = await TaskOperations.fetchTask({
           context,
           taskSid: targetTaskSid,
-          attempts: 0,
         });
 
         const { task: targetTask } = fetchTargetTaskResult;
@@ -108,7 +102,6 @@ exports.handler = async function callOutboundJoin(context, event, callback) {
               assignmentStatus: targetTask.assignmentStatus === 'assigned' ? 'wrapping' : 'canceled',
               reason: 'conference is complete',
             },
-            attempts: 0,
           });
         }
       }

--- a/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
+++ b/serverless-functions/src/functions/features/internal-call/flex/cleanup-rejected-task.js
@@ -12,7 +12,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       taskSid,
       status: 'in-progress',
       limit: 20,
-      attempts: 0,
     });
 
     if (!conferencesResponse.success) {
@@ -25,7 +24,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
           context,
           conference: conference.sid,
           updateParams: { status: 'completed' },
-          attempts: 0,
         });
       }),
     );

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-call-recording.js
@@ -17,7 +17,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         status: 'paused',
         pauseBehavior: pauseBehavior ?? 'silence',
       },
-      attempts: 0,
     });
 
     const { recording, status } = result;

--- a/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/pause-conference-recording.js
@@ -17,7 +17,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         status: 'paused',
         pauseBehavior: pauseBehavior ?? 'silence',
       },
-      attempts: 0,
     });
 
     const { recording, status } = result;

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-call-recording.js
@@ -19,7 +19,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       params: {
         status: 'in-progress',
       },
-      attempts: 0,
     });
 
     const { recording, status } = result;

--- a/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
+++ b/serverless-functions/src/functions/features/pause-recording/flex/resume-conference-recording.js
@@ -19,7 +19,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       params: {
         status: 'in-progress',
       },
-      attempts: 0,
     });
 
     const { recording, status } = result;

--- a/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
+++ b/serverless-functions/src/functions/features/supervisor-barge-coach/flex/participant-mute-and-coach.js
@@ -32,7 +32,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         agentSid,
         muted,
         coaching,
-        attempts: 0,
       });
       response.setStatusCode(result.status);
       response.setBody({
@@ -47,7 +46,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
         conferenceSid,
         participantSid,
         muted,
-        attempts: 0,
       });
 
       const { status, conferenceSid: conference } = result;

--- a/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
+++ b/serverless-functions/src/functions/features/supervisor-complete-reservation/flex/update-reservation.js
@@ -29,7 +29,6 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     const { taskSid, reservationSid, status: taskStatus } = event;
 
     const result = await TaskOperations.updateReservation({
-      attempts: 0,
       context,
       taskSid,
       reservationSid,


### PR DESCRIPTION
### Summary

A few reasons for this:
- It's unnecessary
- Depending on how the wrapper was written, nothing fails until the retry handler is hit, which makes this wicked easy to overlook (see review comments in #200 for an example)

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
