### PR TITLE
Use pluginsInitialized instead of pluginsLoaded

### DIFF
--- a/plugin-flex-ts-template-v2/README.md
+++ b/plugin-flex-ts-template-v2/README.md
@@ -335,7 +335,7 @@ enum FlexEvent {
   taskRescinded = 'taskRescinded',
   taskTimeout = 'taskTimeout',
   taskWrapup = 'taskWrapup',
-  pluginsLoaded = 'pluginsLoaded',
+  pluginsInitialized = 'pluginsInitialized',
   tokenUpdated = 'tokenUpdated',
 }
 ```

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/events/pluginsInitialized.ts
@@ -3,7 +3,7 @@ import * as Flex from '@twilio/flex-ui';
 import { FlexEvent } from '../../../../types/feature-loader';
 import { initialize } from '../../config';
 
-export const eventName = FlexEvent.pluginsLoaded;
+export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = (_flex: typeof Flex, _manager: Flex.Manager) => {
   initialize();
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/events/pluginsInitialized.ts
@@ -5,7 +5,7 @@ import { registerRemoveChatParticipant } from '../../custom-action/removeChatPar
 import { registerCancelChatParticipantInvite } from '../../custom-action/cancelChatParticipantInvite';
 import { FlexEvent } from '../../../../types/feature-loader';
 
-export const eventName = FlexEvent.pluginsLoaded;
+export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = () => {
   const coldTransferEnabled = isColdTransferEnabled();
   const multiParticipantEnabled = isMultiParticipantEnabled();

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/pluginsInitialized.ts
@@ -4,7 +4,7 @@ import { NotificationIds } from '../notifications/DualChannelRecording';
 import { getChannelToRecord } from '../../config';
 import { FlexEvent } from '../../../../types/feature-loader';
 
-export const eventName = FlexEvent.pluginsLoaded;
+export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = () => {
   // Test to make sure the channel config property has been
   // configured correctly. If it has not, throw errors and notifications.

--- a/plugin-flex-ts-template-v2/src/feature-library/hang-up-by/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/hang-up-by/flex-hooks/events/pluginsInitialized.ts
@@ -1,7 +1,7 @@
 import { resetHangUpBy } from '../../helpers/hangUpBy';
 import { FlexEvent } from '../../../../types/feature-loader';
 
-export const eventName = FlexEvent.pluginsLoaded;
+export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = () => {
   resetHangUpBy();
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/flex-hooks/events/pluginsInitialized.ts
@@ -3,7 +3,7 @@ import * as Flex from '@twilio/flex-ui';
 import { NotificationIds } from '../notifications/MultiCall';
 import { FlexEvent } from '../../../../types/feature-loader';
 
-export const eventName = FlexEvent.pluginsLoaded;
+export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = () => {
   // Test to make sure the sdkOptions property has been
   // configured correctly. If it has not, throw errors and notifications.

--- a/plugin-flex-ts-template-v2/src/types/feature-loader/FlexEvent.ts
+++ b/plugin-flex-ts-template-v2/src/types/feature-loader/FlexEvent.ts
@@ -8,6 +8,6 @@ export enum FlexEvent {
   taskRescinded = 'taskRescinded',
   taskTimeout = 'taskTimeout',
   taskWrapup = 'taskWrapup',
-  pluginsLoaded = 'pluginsLoaded',
+  pluginsInitialized = 'pluginsInitialized',
   tokenUpdated = 'tokenUpdated',
 }

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/events.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/events.ts
@@ -32,7 +32,7 @@ export const addHook = (flex: typeof Flex, manager: Flex.Manager, feature: strin
     'font-weight:bold',
   );
 
-  if (event === FlexEvent.pluginsLoaded) {
+  if (event === FlexEvent.pluginsInitialized) {
     manager.events.addListener(event, () => {
       hook.eventHook(flex, manager);
     });


### PR DESCRIPTION
### Summary

See FLXUIAPPIN-607. Basically, pluginsLoaded can be emitted before plugins have actually loaded, so our listeners never are invoked!

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
