### PR TITLE
Fix hidden cold transfer button when warm transfer is disabled

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/ShowDirectory.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/ShowDirectory.ts
@@ -8,6 +8,10 @@ export const actionName = FlexAction.ShowDirectory;
 export const actionHook = function handleChatTransferShowDirectory(flex: typeof Flex, manager: Flex.Manager) {
   if (isMultiParticipantEnabled()) return;
 
+  // If warm transfers are disabled within Flex, the button is already removed.
+  // Warm transfers are enabled by default now, so check for the explicit disabled value.
+  if (!manager.store.getState().flex.featureFlags.features['flex-warm-transfers']?.enabled) return;
+
   flex.Actions.addListener(`${actionEvent}${actionName}`, (_payload: any, _abortFunction: any) => {
     let display = 'flex';
     const taskSid = manager.store.getState().flex.view.selectedTaskSid;

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/ShowDirectory.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/ShowDirectory.ts
@@ -9,7 +9,6 @@ export const actionHook = function handleChatTransferShowDirectory(flex: typeof 
   if (isMultiParticipantEnabled()) return;
 
   // If warm transfers are disabled within Flex, the button is already removed.
-  // Warm transfers are enabled by default now, so check for the explicit disabled value.
   if (!manager.store.getState().flex.featureFlags.features['flex-warm-transfers']?.enabled) return;
 
   flex.Actions.addListener(`${actionEvent}${actionName}`, (_payload: any, _abortFunction: any) => {


### PR DESCRIPTION
### Summary
If the warm transfers Flex feature flag is disabled, then the warm transfer button is hidden from the transfer panel. If warm transfer is disabled in the conversation-transfer feature, we remove the last button from the transfer panel. This means that if both warm transfer settings are disabled, then the cold transfer button is the last button, and gets removed. The change in this PR checks the feature flag before doing anything.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
