### PR TITLE
Adding contents:write privileges to linting job

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

Previously, starting a repo from the template and setting it to private - the linting action failed at the checkout step, claiming not to see the repository.  This addresses that by granting the appropriate privilege 

