### PR TITLE
Remove legacy directories from webpack config

### DIFF
--- a/plugin-flex-ts-template-v2/webpack.config.js
+++ b/plugin-flex-ts-template-v2/webpack.config.js
@@ -10,50 +10,28 @@ module.exports = (config, { isProd, isDev, isTest }) => {
     ...config,
     performance: {
       ...config.performance,
-      hints: false
+      hints: false,
     },
     module: {
       ...config.module,
       rules: [
         ...config.module.rules,
         {
-            test: /index\.ts$/,
-            include: [
-              path.join(__dirname, 'src/feature-library/')
-            ],
-            use: 'import-glob'
+          test: /index\.ts$/,
+          include: [path.join(__dirname, 'src/feature-library/')],
+          use: 'import-glob',
         },
         {
-            test: /\.js$/,
-            include: [
-              path.join(__dirname, 'src/flex-hooks/')
-            ],
-            use: 'import-glob'
+          test: /\.ts$/,
+          include: [path.join(__dirname, 'src/utils/feature-loader/')],
+          use: 'import-glob',
         },
         {
-            test: /\.jsx$/,
-            include: [
-              path.join(__dirname, 'src/flex-hooks/')
-            ],
-            use: 'import-glob'
+          test: /\.tsx$/,
+          include: [path.join(__dirname, 'src/utils/feature-loader/')],
+          use: 'import-glob',
         },
-        {
-            test: /\.ts$/,
-            include: [
-              path.join(__dirname, 'src/flex-hooks/'),
-              path.join(__dirname, 'src/utils/feature-loader/')
-            ],
-            use: 'import-glob'
-        },
-        {
-            test: /\.tsx$/,
-            include: [
-              path.join(__dirname, 'src/flex-hooks/'),
-              path.join(__dirname, 'src/utils/feature-loader/')
-            ],
-            use: 'import-glob'
-        },
-      ]
-    }
+      ],
+    },
   };
-}
+};


### PR DESCRIPTION
### Summary

I thought I cleaned these up before merging the feature-discovery branch, but apparently not. There is no longer a `src/flex-hooks/` directory.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
