### PR TITLE
Auto dispositions

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -150,7 +150,8 @@
         ]
       },
       "supervisor_complete_reservation": {
-        "enabled": true
+        "enabled": true,
+        "outcome": "Completed by supervisor"
       },
       "canned_responses": {
         "enabled": true,

--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/README.md
@@ -23,13 +23,14 @@ To enable the `Agent Automation` feature, under the `flex-config` attributes set
 ```json
 "agent_automation": {
   "enabled": true,
-  "configuration" : [{
+  "configuration": [{
     "channel": "voice",
     "required_attributes": [{"key": "direction", "value": "inbound"}],
     "auto_accept": true,
     "auto_select": true,
     "auto_wrapup": true,
-    "wrapup_time" : 30000
+    "wrapup_time": 30000,
+    "default_outcome": "Automatically completed"
   }]
 },
 ```
@@ -38,4 +39,4 @@ To enable the `Agent Automation` feature, under the `flex-config` attributes set
 
 When enabled, this feature listens for taskReceived events and evaluates whether the tasks matches any configuration sets and if so executes SelectTask & AcceptTask action as configured. This feature also loads a renderless component on the task canvas at wrapup. When the component mounts, if there is a matching task configuration then a timeout is set per the task configuration that triggers a CompleteTask action.
 
-When used in combination with the `dispositions` feature's require disposition setting, that setting will take precedence and prevent auto-wrap-up of the affected task if no disposition is selected.
+When used in combination with the `dispositions` feature's require disposition setting, that setting will take precedence and prevent auto-wrap-up of the affected task if no disposition is selected. If no disposition is required, the optional `default_outcome` setting allows you to configure the value displayed in Flex Insights for the outcome when the wrapup time expires and there is no disposition selected by the agent via the `dispositions` feature (or it is disabled).

--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/config.ts
@@ -18,7 +18,7 @@ export const getMatchingTaskConfiguration = (task: ITask): TaskQualificationConf
   configuration.forEach((config) => {
     let matched_config = true;
     if (config.channel === channel) {
-      config.required_attributes.forEach((required_attribute) => {
+      config.required_attributes?.forEach((required_attribute) => {
         if (attributes[required_attribute.key] !== required_attribute.value) {
           matched_config = false;
         }

--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/custom-components/AutoComplete/AutoComplete.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/custom-components/AutoComplete/AutoComplete.tsx
@@ -1,9 +1,10 @@
 import * as Flex from '@twilio/flex-ui';
 import { ITask } from '@twilio/flex-ui';
 import React from 'react';
-import { TaskQualificationConfig } from 'feature-library/agent-automation/types/ServiceConfiguration';
 
+import { TaskQualificationConfig } from '../../types/ServiceConfiguration';
 import { getMatchingTaskConfiguration } from '../../config';
+import TaskRouterService from '../../../../utils/serverless/TaskRouter/TaskRouterService';
 
 export type Props = {
   task: ITask;
@@ -30,8 +31,15 @@ const autoCompleteTask = async (task: ITask, taskConfig: TaskQualificationConfig
     const currentTime = new Date().getTime();
     const timeout = scheduledTime - currentTime > 0 ? scheduledTime - currentTime : 0;
 
-    setTimeout(() => {
+    setTimeout(async () => {
       if (task && Flex.TaskHelper.isInWrapupMode(task)) {
+        if (taskConfig.default_outcome) {
+          await TaskRouterService.updateTaskAttributes(task.taskSid, {
+            conversations: {
+              outcome: taskConfig.default_outcome,
+            },
+          });
+        }
         Flex.Actions.invokeAction('CompleteTask', { sid });
       }
     }, timeout);

--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/types/ServiceConfiguration.ts
@@ -10,6 +10,7 @@ export interface TaskQualificationConfig {
   auto_wrapup: boolean;
   required_attributes: Array<TaskAttributesQualificationConfig>;
   wrapup_time: number;
+  default_outcome: string;
 }
 
 export default interface AgentAutomationConfig {

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participants.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participants.tsx
@@ -21,6 +21,7 @@ export const Participants = ({ participantDetails, handleKickParticipant }: Part
         name={participantName}
         participantType={participantType}
         allowKick={allowKick}
+        key={`participant-${interactionParticipantSid}`}
         handleKickParticiant={() => handleKickParticipant(interactionParticipantSid)}
       />
     );

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/README.md
@@ -12,16 +12,18 @@ a supervisor remotely completing a task that has been sitting in a wrap up state
 
 There are no additional dependencies for setup beyond ensuring the flag is enabled within the `flex-config` attributes.
 
-To enable the `Supervisor Complete Reservation` feature, under the `flex-config` attributes set the `supervisor_complete_reservation` `enabled` flag to `true`.
+To enable the `Supervisor Complete Reservation` feature, under the `flex-config` attributes set the `supervisor_complete_reservation` `enabled` flag to `true`. You may also configure a custom `outcome` which will be displayed in Flex Insights.
 
 ```json
 "supervisor_complete_reservation": {
-  "enabled": true
+  "enabled": true,
+  "outcome": "Completed by supervisor"
 }
 ```
 
 # how does it work?
 
 When enabled, this feature adds a button to the TaskOverviewCanvas that when clicked opens a dialog to confirm the completion of the task. Upon confirmation two requests are made:
-- First, task attributes are updated to set the conversation outcome displayed Flex Insights to indicate the task was completed by a supervisor
+
+- First, task attributes are updated to set the conversation outcome displayed Flex Insights based on the `outcome` setting
 - Then, a request is made to a twilio function that takes the task sid and reservation id and updates the reservation to the completed state.

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/README.md
@@ -22,4 +22,6 @@ To enable the `Supervisor Complete Reservation` feature, under the `flex-config`
 
 # how does it work?
 
-When enabled, this feature adds a button to the TaskOverviewCanvas that when clicked opens a dialog to confirm the completion of the task. Upon confirmation a request is made to a twilio function that takes the task sid and reservation id and updates the reservation to the completed state.
+When enabled, this feature adds a button to the TaskOverviewCanvas that when clicked opens a dialog to confirm the completion of the task. Upon confirmation two requests are made:
+- First, task attributes are updated to set the conversation outcome displayed Flex Insights to indicate the task was completed by a supervisor
+- Then, a request is made to a twilio function that takes the task sid and reservation id and updates the reservation to the completed state.

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/config.ts
@@ -1,9 +1,13 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import SupervisorCompleteReservation from './types/ServiceConfiguration';
 
-const { enabled = false } =
+const { enabled = false, outcome = 'Completed by supervisor' } =
   (getFeatureFlags()?.features?.supervisor_complete_reservation as SupervisorCompleteReservation) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const getOutcome = () => {
+  return outcome;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';
 import { Actions } from '../../flex-hooks/states/SupervisorCompleteReservation';
+import TaskRouterService from '../../../../utils/serverless/TaskRouter/TaskRouterService';
 
 export interface OwnProps {
   task: ITask;
@@ -25,6 +26,15 @@ const SupervisorCompleteReservation = ({ task }: OwnProps) => {
 
   const completeReservation = async () => {
     setIsOpen(false);
+    await TaskRouterService.updateTaskAttributes(
+      taskSid,
+      {
+        conversations: {
+          outcome: 'Completed by supervisor',
+        },
+      },
+      false,
+    );
     dispatch(Actions.updateReservation(taskSid, reservationSid, 'completed'));
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
@@ -3,6 +3,7 @@ import { AlertDialog, Button, Box } from '@twilio-paste/core';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { getOutcome } from '../../config';
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';
 import { Actions } from '../../flex-hooks/states/SupervisorCompleteReservation';
@@ -30,7 +31,7 @@ const SupervisorCompleteReservation = ({ task }: OwnProps) => {
       taskSid,
       {
         conversations: {
-          outcome: 'Completed by supervisor',
+          outcome: getOutcome(),
         },
       },
       false,

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/types/ServiceConfiguration.ts
@@ -1,3 +1,4 @@
 export default interface SupervisorCompleteReservation {
   enabled: boolean;
+  outcome: string;
 }


### PR DESCRIPTION
### Summary

Now that we have the dispositions feature, other features that complete reservations should also set dispositions to allow for a more holistic reporting of task outcomes.

- agent-automation: adds a new _optional_ default_outcome setting, which is used when the dispositions feature is either not in use or set to not be required, and the auto-wrap timer expires before a disposition has been set.
- supervisor-complete-reservation: adds a new outcome setting, which is used for every supervisor completion.

### Checklist
- [x] Tested changes end to end
- [x] Any config changes added to all environment files
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
