### PR TITLE
Auto detect native external warm transfer within conference feature

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -29,7 +29,6 @@
       },
       "conference": {
         "enabled": true,
-        "add_button": true,
         "hold_workaround": false
       },
       "enhanced_crm_container": {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/README.md
@@ -1,6 +1,8 @@
 # conference
 
-When in a call, a "plus" icon is added to the call canvas where you can add an external number to the call.
+When in a call, and the beta native external warm transfer functionality is not enabled, a "plus" icon is added to the call canvas where you can add an external number to the call.
+
+If the beta native external warm transfer functionality is enabled, this feature still adds the ability for a caller to hang up without ending the conference, as well as the ability to kick the customer participant.
 
 This feature is based on [the dialpad addon plugin](https://github.com/twilio-professional-services/flex-dialpad-addon-plugin).
 
@@ -15,7 +17,6 @@ This feature is based on [the dialpad addon plugin](https://github.com/twilio-pr
 Within your `ui_attributes` file, the `conference` feature has 3 settings you may modify:
 
 - `enable` - whether any functionality from this feature is enabled
-- `add_button` - disabling the "add" button is intended for Flex accounts using the External Warm Transfer feature, allowing you to benefit from features in this plugin (such as the ability for a caller to hang up without ending the conference, or the ability to kick the customer participant) without introducing conflicting functions
 - `hold_workaround` - without the hold workaround, after a third participant is added to the conference while the caller is on hold, the entire conference will end if the caller hangs up. when the workaround is enabled, the customer will be taken off hold briefly when the third participant is added, then placed back on hold. This workaround allows the caller to later disconnect without ending the entire conference.
 
 ## Outbound Call Configuration

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
@@ -6,13 +6,14 @@ import ConferenceConfig from './types/ServiceConfiguration';
 const { enabled = false, hold_workaround = false } =
   (getFeatureFlags()?.features?.conference as ConferenceConfig) || {};
 
+const nativeXwtEnabled =
+  Flex.Manager.getInstance().store.getState().flex.featureFlags.features['external-warm-transfers']?.enabled === true;
+
 export const isFeatureEnabled = () => {
   return enabled;
 };
 
 export const isAddButtonEnabled = () => {
-  const nativeXwtEnabled =
-    Flex.Manager.getInstance().store.getState().flex.featureFlags.features['external-warm-transfers']?.enabled === true;
   return enabled && !nativeXwtEnabled;
 };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/config.ts
@@ -1,18 +1,19 @@
+import * as Flex from '@twilio/flex-ui';
+
 import { getFeatureFlags } from '../../utils/configuration';
 import ConferenceConfig from './types/ServiceConfiguration';
 
-const {
-  enabled = false,
-  add_button = false,
-  hold_workaround = false,
-} = (getFeatureFlags()?.features?.conference as ConferenceConfig) || {};
+const { enabled = false, hold_workaround = false } =
+  (getFeatureFlags()?.features?.conference as ConferenceConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
 };
 
 export const isAddButtonEnabled = () => {
-  return enabled && add_button;
+  const nativeXwtEnabled =
+    Flex.Manager.getInstance().store.getState().flex.featureFlags.features['external-warm-transfers']?.enabled === true;
+  return enabled && !nativeXwtEnabled;
 };
 
 export const isHoldWorkaroundEnabled = () => {

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/types/ServiceConfiguration.ts
@@ -1,5 +1,4 @@
 export default interface ConferenceConfig {
   enabled: boolean;
-  add_button: boolean;
   hold_workaround: boolean;
 }


### PR DESCRIPTION
### Summary

Basically this removes the `add_button` setting and replaces it with an automatic detection of the native external warm transfer feature.

### Checklist
- [x] Tested changes end to end
- [x] Any config changes added to all environment files
- [x] Completed README template for new features
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
