### PR TITLE
Enhanced crm container ext

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -32,7 +32,9 @@
         "hold_workaround": false
       },
       "enhanced_crm_container": {
-        "enabled": false
+        "enabled": false,
+        "should_display_url_when_no_tasks": false,
+        "display_url_when_no_tasks": "https://www.bing.com"
       },
       "internal_call": {
         "enabled": false

--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/config.ts
@@ -1,8 +1,20 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import EnhancedCRMContainerConfig from './types/ServiceConfiguration';
 
-const { enabled = false } = (getFeatureFlags()?.features?.enhanced_crm_container as EnhancedCRMContainerConfig) || {};
+const {
+  enabled = false,
+  should_display_url_when_no_tasks = false,
+  display_url_when_no_tasks = '',
+} = (getFeatureFlags()?.features?.enhanced_crm_container as EnhancedCRMContainerConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const shouldDisplayUrlWhenNoTasks = () => {
+  return should_display_url_when_no_tasks;
+};
+
+export const displayUrlWhenNoTasks = () => {
+  return display_url_when_no_tasks;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
@@ -8,5 +8,8 @@ export const componentHook = function replaceAndSetCustomCRMContainer(flex: type
   const baseUrl = 'https://www.bing.com';
   flex.CRMContainer.Content.replace(<IFrameCRMContainer key="custom-crm-container" baseUrl={baseUrl} />, {
     sortOrder: 1,
+    if: (props) => {
+      return props.task !== undefined;
+    },
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/flex-hooks/components/CRMContainer.tsx
@@ -1,7 +1,9 @@
 import * as Flex from '@twilio/flex-ui';
 
+import { displayUrlWhenNoTasks, shouldDisplayUrlWhenNoTasks } from '../../config';
 import IFrameCRMContainer from '../../custom-components/IFrameCRMContainer';
 import { FlexComponent } from '../../../../types/feature-loader';
+import { frameStyle } from '../../custom-components/IFrameCRMContainer/IFrameWrapper/IFrameWrapperStyles';
 
 export const componentName = FlexComponent.CRMContainer;
 export const componentHook = function replaceAndSetCustomCRMContainer(flex: typeof Flex, _manager: Flex.Manager) {
@@ -12,4 +14,14 @@ export const componentHook = function replaceAndSetCustomCRMContainer(flex: type
       return props.task !== undefined;
     },
   });
+
+  flex.CRMContainer.Content.replace(
+    <iframe key="custom-crm-container" src={displayUrlWhenNoTasks()} style={frameStyle} />,
+    {
+      sortOrder: 1,
+      if: (props) => {
+        return shouldDisplayUrlWhenNoTasks() && props.task === undefined;
+      },
+    },
+  );
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-crm-container/types/ServiceConfiguration.ts
@@ -1,3 +1,5 @@
 export default interface EnhancedCRMContainerConfig {
   enabled: boolean;
+  should_display_url_when_no_tasks: boolean;
+  display_url_when_no_tasks: string;
 }


### PR DESCRIPTION
### Summary

Extends the enhanced crm container feature to allow for setting a url that is iframed when no tasks are available.  Also updated it to show the standard crm container when no tasks are available instead of a blank frame.

Addresses feature behavior in discussion #159

### Checklist
- [x] Tested changes end to end
- [x] Any config changes added to all environment files
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
