### PR TITLE
Fix conversation transfer 'leave chat' race condition

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/README.md
@@ -71,12 +71,3 @@ Note that unlike the default behavior when the agent is removed the Conversation
 This plugin also copies all of the existing task attributes from the original task to the transferring task. The tasks conversations.conversations_id is updated to link the tasks for reporting purposes.
 
 The conversations attributes are used to track outstanding invites. When the invite is created the conversations attributes are updated and when an agent joins the conversation it will remove these attributes.
-
-## Disclaimer and important notes for production use
-
-This is a POC feature that demonstrates how transfers and multiple participants can be implemented with the Interactions API and Conversations Based Messaging in Flex. It is important with conversations that the conversation is closed if all agents are removed and ensuring the same agent doesn't try and join the conversation multiple times.
-In these scenarios you could be left with a customer chatting and the messages not being seen by an agent or for agents to end up with a task that they are unable to accept.
-
-The plugin attempts to avoid these edge cases but there are timing conditions that can't easily be taken into account from the plugin. For example the plugin will change the _end chat_ action to _leave chat_ when there are multiple participants. But there could be a timing window where both agents leave the chat at the same time. This results in the participants being removed but the channel is still active.
-
-To handle these edge cases we would recommend using TaskRouter or Conversations webhooks to a backend platform that could detect any invalid Task or Conversations states and update the chat accordingly. For example in this case marking the channel as inactive so that subsequent messages from the customer create a new conversation.

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/LeaveChatButton/LeaveChatButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/LeaveChatButton/LeaveChatButton.tsx
@@ -8,11 +8,12 @@ interface LeaveChatButtonProps {
 
 const LeaveChatButton = ({ conversation }: LeaveChatButtonProps) => {
   const [buttonDisabled, setButtonDisable] = useState(false);
-  const handleLeaveChatClick = () => {
+  const handleLeaveChatClick = async () => {
     if (conversation) {
       setButtonDisable(true);
       const payload: LeaveChatActionPayload = { conversation };
-      Actions.invokeAction('LeaveChat', payload);
+      await Actions.invokeAction('LeaveChat', payload);
+      setButtonDisable(false);
     }
   };
   return (

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipants.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipants.tsx
@@ -15,6 +15,7 @@ export const InvitedParticipants = ({ invitedParticipantDetails, handleCancelInv
     return (
       <InvitedParticipant
         participantName={participantName}
+        key={invitedParticipantDetail.invitesTaskSid}
         inviteTargetType={inviteTargetType}
         handleCancelInvite={() => handleCancelInvite(invitedParticipantDetail)}
       />

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
@@ -7,6 +7,7 @@ import ApiService from '../../../utils/serverless/ApiService';
 const manager: any | undefined = Manager.getInstance();
 
 export interface RemoveParticipantRESTPayload {
+  conversationSid: string;
   flexInteractionSid: string; // KDxxx sid for inteactions API
   flexInteractionChannelSid: string; // UOxxx sid for interactions API
   flexInteractionParticipantSid: string; // UTxxx sid for interactions API for the transferrring agent to remove
@@ -59,7 +60,7 @@ export const buildRemoveMyPartiticipantAPIPayload = async (
   const task = TaskHelper.getTaskFromConversationSid(conversation.source?.sid);
   if (!task || !TaskHelper.isCBMTask(task)) return null;
 
-  const { flexInteractionSid = '', flexInteractionChannelSid = '' } = task.attributes;
+  const { flexInteractionSid = '', flexInteractionChannelSid = '', conversationSid = '' } = task.attributes;
 
   const participants = await task.getParticipants(flexInteractionChannelSid);
 
@@ -71,13 +72,14 @@ export const buildRemoveMyPartiticipantAPIPayload = async (
     flexInteractionSid,
     flexInteractionChannelSid,
     flexInteractionParticipantSid,
+    conversationSid,
   };
 };
 
 export const buildRemovePartiticipantAPIPayload = (task: ITask, flexInteractionParticipantSid: string) => {
   if (!task || !TaskHelper.isCBMTask(task)) return null;
 
-  const { flexInteractionSid = '', flexInteractionChannelSid = '' } = task.attributes;
+  const { flexInteractionSid = '', flexInteractionChannelSid = '', conversationSid = '' } = task.attributes;
 
   if (!flexInteractionParticipantSid) return null;
 
@@ -85,6 +87,7 @@ export const buildRemovePartiticipantAPIPayload = (task: ITask, flexInteractionP
     flexInteractionSid,
     flexInteractionChannelSid,
     flexInteractionParticipantSid,
+    conversationSid,
   };
 };
 
@@ -187,6 +190,7 @@ class ChatTransferService extends ApiService {
   ): Promise<RemoveParticipantRESTResponse> => {
     const encodedParams: EncodedParams = {
       Token: encodeURIComponent(manager.user.token),
+      conversationSid: encodeURIComponent(requestPayload.conversationSid),
       flexInteractionSid: encodeURIComponent(requestPayload.flexInteractionSid),
       flexInteractionChannelSid: encodeURIComponent(requestPayload.flexInteractionChannelSid),
       flexInteractionParticipantSid: encodeURIComponent(requestPayload.flexInteractionParticipantSid),

--- a/serverless-functions/src/functions/common/twilio-wrappers/conversations.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/conversations.private.js
@@ -1,0 +1,30 @@
+const { isString, isObject, isNumber } = require('lodash');
+
+const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handler'].path).retryHandler;
+
+/**
+ * @param {object} parameters the parameters for the function
+ * @param {number} parameters.attempts the number of retry attempts performed
+ * @param {object} parameters.context the context from calling lambda function
+ * @param {string} parameters.conversationSid the sid for this conversation
+ * @param {number} parameters.limit max number of participants to list
+ * @returns {object} An object containing an array of participants
+ * @description the following method is used to list conversation participants
+ */
+exports.participantList = async function participantList(parameters) {
+  const { context, conversationSid, limit } = parameters;
+
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(conversationSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain conversationSid string value');
+  if (!isNumber(limit)) throw new Error('Invalid parameters object passed. Parameters must contain limit number value');
+
+  try {
+    const client = context.getTwilioClient();
+    const participants = await client.conversations.v1.conversations(conversationSid).participants.list({ limit });
+
+    return { success: true, status: 200, participants };
+  } catch (error) {
+    return retryHandler(error, parameters, exports.participantList);
+  }
+};

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -100,6 +100,6 @@ exports.channelUpdate = async function channelUpdate(parameters) {
 
     return { success: true, status: 200, updatedChannel };
   } catch (error) {
-    return retryHandler(error, parameters, exports.participantUpdate);
+    return retryHandler(error, parameters, exports.channelUpdate);
   }
 };

--- a/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/interactions.private.js
@@ -72,3 +72,34 @@ exports.participantUpdate = async function participantUpdate(parameters) {
     return retryHandler(error, parameters, exports.participantUpdate);
   }
 };
+
+/**
+ * @param {object} parameters the parameters for the function
+ * @param {number} parameters.attempts the number of retry attempts performed
+ * @param {object} parameters.context the context from calling lambda function
+ * @param {string} parameters.interactionSid the Interaction Sid for this channel
+ * @param {string} parameters.channelSid The Channel Sid for this Participant
+ * @param {string} parameters.status the channel status - can be: closed or wrapup
+ * @returns {object} An object containing the modified channel
+ * @description the following method is used to update/modify a channel
+ */
+exports.channelUpdate = async function channelUpdate(parameters) {
+  const { context, interactionSid, channelSid, status } = parameters;
+
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(interactionSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain interactionSid string value');
+  if (!isString(channelSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain channelSid string value');
+  if (!isString(status))
+    throw new Error('Invalid parameters object passed. Parameters must contain status string value');
+
+  try {
+    const client = context.getTwilioClient();
+    const updatedChannel = await client.flexApi.v1.interaction(interactionSid).channels(channelSid).update({ status });
+
+    return { success: true, status: 200, updatedChannel };
+  } catch (error) {
+    return retryHandler(error, parameters, exports.participantUpdate);
+  }
+};

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
@@ -1,6 +1,7 @@
 const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
 const FunctionHelper = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+const ConversationsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conversations'].path);
 const InteractionsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/interactions'].path);
 
 const getRequiredParameters = () => {
@@ -43,7 +44,7 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
   }
 
   try {
-    const { flexInteractionSid, flexInteractionChannelSid, flexInteractionParticipantSid } = event;
+    const { flexInteractionSid, flexInteractionChannelSid, flexInteractionParticipantSid, conversationSid } = event;
 
     await InteractionsOperations.participantUpdate({
       status: 'closed',
@@ -52,6 +53,27 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
       participantSid: flexInteractionParticipantSid,
       context,
     });
+
+    // After leaving, check how many participants are left in the conversation.
+    // Why? There is a race condition where the agents may both leave at the same time, so both
+    // hit this function rather than taking the normal complete task path. That leaves
+    // the interaction open with only one participant--the customer. This is undesirable, because
+    // then the customer's next message won't open a new interaction until it is cleaned up in 180 days!
+    const participants = await ConversationsOperations.participantList({
+      conversationSid,
+      limit: 100,
+      context,
+    });
+
+    if (participants.participants && participants.participants.length <= 1) {
+      // If the customer is alone, close it out.
+      await InteractionsOperations.channelUpdate({
+        status: 'closed',
+        interactionSid: flexInteractionSid,
+        channelSid: flexInteractionChannelSid,
+        context,
+      });
+    }
 
     response.setStatusCode(201);
     response.setBody({


### PR DESCRIPTION
### Summary

Currently, if both agents click 'leave chat' at the same time, they will both leave the conversation, leaving the customer all alone, preventing future messages from that customer creating a new interaction.

![Sad-Pablo-Escobar](https://user-images.githubusercontent.com/7373633/236561329-4573ab46-91d8-406e-82b5-2a412a27bdae.jpg)

This fixes the issue by fetching conversation participants after removing a participant. If only the customer remains, close out the interaction.

Also fixes some other minor bugs:
- If leave chat fails, re-enable the button.
- Fix key warning from React.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
