### PR TITLE
Gracefully handle get-queues failures

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
@@ -43,7 +43,14 @@ const _getAgentsWorkerSidArray = (participants: any) => {
 };
 
 const _queueNameFromSid = async (transferTargetSid: string) => {
-  const queues = await TaskService.getQueues();
+  let queues;
+
+  try {
+    queues = await TaskService.getQueues();
+  } catch (error) {
+    console.error('conversation-transfer: Unable to get queues', error);
+  }
+
   const queueResult = queues
     ? queues.find((queue) => {
         return queue.sid === transferTargetSid;

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
@@ -22,7 +22,14 @@ import TaskRouterService from '../../../utils/serverless/TaskRouter/TaskRouterSe
 */
 
 export const queueNoWorkerDataFilter = async () => {
-  const queueOptions = await TaskRouterService.getQueues();
+  let queueOptions;
+
+  try {
+    queueOptions = await TaskRouterService.getQueues();
+  } catch (error) {
+    console.error('teams-view-filters: Unable to get queues', error);
+  }
+
   const options = queueOptions
     ? queueOptions.map((queue: any) => ({
         value: queue.friendlyName,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
@@ -11,7 +11,14 @@ import TaskRouterService from '../../../utils/serverless/TaskRouter/TaskRouterSe
 */
 
 export const queueWorkerDataFilter = async () => {
-  const queueOptions = await TaskRouterService.getQueues();
+  let queueOptions;
+
+  try {
+    queueOptions = await TaskRouterService.getQueues();
+  } catch (error) {
+    console.error('teams-view-filters: Unable to get queues', error);
+  }
+
   const options = queueOptions
     ? queueOptions.map((queue: any) => ({
         value: queue.sid,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/actions/beforeApplyTeamsViewFilters.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/flex-hooks/actions/beforeApplyTeamsViewFilters.ts
@@ -77,12 +77,18 @@ function replaceQueueFiltersForTeamView(flex: typeof Flex, manager: Flex.Manager
 
       // now find the queue for the replaced filter
       // and get the queue eligibility expression
+      let queue;
       const queueFiltersArray: Array<AppliedFilter> = [];
-      const fetchedQueues = await TaskRouterService.getQueues();
-      const queues = fetchedQueues ? fetchedQueues : [];
-      const queue = queues.find((queue) => {
-        return queue.friendlyName === queueEligibilityFilter?.values[0];
-      });
+
+      try {
+        const fetchedQueues = await TaskRouterService.getQueues();
+        const queues = fetchedQueues ? fetchedQueues : [];
+        queue = queues.find((queue) => {
+          return queue.friendlyName === queueEligibilityFilter?.values[0];
+        });
+      } catch (error) {
+        console.error('teams-view-filters: Unable to get queues', error);
+      }
 
       // if there is no queue found notify user
       if (!queue) {


### PR DESCRIPTION
### Summary

I noticed that when the serverless function fails, Flex freezes when the teams view filters are loaded. This fixes that.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
