### PR TITLE
Update conversation-transfer functions to reduce boilerplate

### DIFF
--- a/serverless-functions/.boiler-plate-function
+++ b/serverless-functions/.boiler-plate-function
@@ -1,20 +1,19 @@
-const { prepareFlexFunction, extractStandardResponse } = require(Runtime.getFunctions()["common/helpers/function-helper"].path);
-const PhoneNumbers = require(Runtime.getFunctions()[
-  "common/twilio-wrappers/phone-numbers"
+const { prepareFlexFunction, extractStandardResponse } = require(Runtime.getFunctions()[
+  'common/helpers/function-helper'
 ].path);
+const PhoneNumbers = require(Runtime.getFunctions()['common/twilio-wrappers/phone-numbers'].path);
 
 const requiredParameters = [
-  { key: "requiredParamOneName", purpose: "parameter description" },
-  { key: "requiredParamTwoName", purpose: "parameter description" },
+  { key: 'requiredParamOneName', purpose: 'parameter description' },
+  { key: 'requiredParamTwoName', purpose: 'parameter description' },
 ];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-   
     // perform action: the following is an example of using a twilio-wrapper function
     // and extracting the standard response along with the desired phone numbers
     // object
-    
+
     /* 
     const result = await PhoneNumbers.listPhoneNumbers({
       context,
@@ -25,8 +24,8 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
     response.setBody({ phoneNumbers, ...extractStandardResponse(result) });
     */
 
-    callback(null, response);
+    return callback(null, response);
   } catch (error) {
-    handleError(error);
+    return handleError(error);
   }
 });

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -64,13 +64,6 @@ const getRoutingParams = (
   };
 };
 
-const sendErrorReply = (callback, response, scriptName, status, message) => {
-  console.error(`Unexpected error occurred in ${scriptName}: ${message}`);
-  response.setStatusCode(status);
-  response.setBody({ success: false, message });
-  return callback(null, response);
-};
-
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   if (!context.TWILIO_FLEX_WORKSPACE_SID || !context.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID) {
     response.setStatusCode(400);
@@ -111,14 +104,13 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     const {
       success,
-      status,
       message = '',
       participantInvite = null,
     } = await InteractionsOperations.participantCreateInvite(participantCreateInviteParams);
 
     // if this failed bail out so we don't remove the agent from the conversation and no one else joins
     if (!success) {
-      return sendErrorReply(callback, response, scriptName, status, message);
+      return handleError(message);
     }
 
     if (removeFlexInteractionParticipantSid)

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -1,41 +1,37 @@
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
-
-const FunctionHelper = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
 const InteractionsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/interactions'].path);
 
-const getRequiredParameters = () => {
-  return [
-    {
-      key: 'taskSid',
-      purpose: 'task sid of transferring task',
-    },
-    {
-      key: 'conversationId',
-      purpose: 'for linking transfer task in insights (CHxxx or WTxxx sid)',
-    },
-    {
-      key: 'jsonAttributes',
-      purpose: 'string representation of transferring task',
-    },
-    {
-      key: 'transferTargetSid',
-      purpose: 'worker or queue sid',
-    },
-    {
-      key: 'workersToIgnore',
-      purpose:
-        "json object with key indicating task attribute to set as an array of workers to ignore. eg {'workersToIgnore':['Alice','Bob']}. This gets copied to task attributes.",
-    },
-    {
-      key: 'flexInteractionSid',
-      purpose: 'KDxxx sid for inteactions API',
-    },
-    {
-      key: 'flexInteractionChannelSid',
-      purpose: 'UOxxx sid for interactions API',
-    },
-  ];
-};
+const requiredParameters = [
+  {
+    key: 'taskSid',
+    purpose: 'task sid of transferring task',
+  },
+  {
+    key: 'conversationId',
+    purpose: 'for linking transfer task in insights (CHxxx or WTxxx sid)',
+  },
+  {
+    key: 'jsonAttributes',
+    purpose: 'string representation of transferring task',
+  },
+  {
+    key: 'transferTargetSid',
+    purpose: 'worker or queue sid',
+  },
+  {
+    key: 'workersToIgnore',
+    purpose:
+      "json object with key indicating task attribute to set as an array of workers to ignore. eg {'workersToIgnore':['Alice','Bob']}. This gets copied to task attributes.",
+  },
+  {
+    key: 'flexInteractionSid',
+    purpose: 'KDxxx sid for inteactions API',
+  },
+  {
+    key: 'flexInteractionChannelSid',
+    purpose: 'UOxxx sid for interactions API',
+  },
+];
 
 const getRoutingParams = (
   context,
@@ -68,34 +64,20 @@ const getRoutingParams = (
   };
 };
 
-exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, event, callback) {
-  const response = new Twilio.Response();
+const sendErrorReply = (callback, response, scriptName, status, message) => {
+  console.error(`Unexpected error occurred in ${scriptName}: ${message}`);
+  response.setStatusCode(status);
+  response.setBody({ success: false, message });
+  return callback(null, response);
+};
 
-  const requiredParameters = getRequiredParameters();
-  const parameterError = FunctionHelper.validateParameters(context.PATH, event, requiredParameters);
-
-  response.appendHeader('Access-Control-Allow-Origin', '*');
-  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-  response.appendHeader('Content-Type', 'application/json');
-  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-
-  if (Object.keys(event).length === 0) {
-    console.log('Empty event object, likely an OPTIONS request');
-    return callback(null, response);
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   if (!context.TWILIO_FLEX_WORKSPACE_SID || !context.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID) {
     response.setStatusCode(400);
     response.setBody({
       data: null,
       message: 'TWILIO_FLEX_WORKSPACE_SID and TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID required enviroment variables',
     });
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
     return callback(null, response);
   }
 
@@ -165,16 +147,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
     });
     return callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({ success: false, message: error });
-    return callback(null, response);
+    return handleError(error);
   }
 });
-
-const sendErrorReply = (callback, response, scriptName, status, message) => {
-  console.error(`Unexpected error occurred in ${scriptName}: ${message}`);
-  response.setStatusCode(status);
-  response.setBody({ success: false, message });
-  return callback(null, response);
-};

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/remove-participant.js
@@ -1,48 +1,23 @@
-const TokenValidator = require('twilio-flex-token-validator').functionValidator;
-
-const FunctionHelper = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
 const ConversationsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/conversations'].path);
 const InteractionsOperations = require(Runtime.getFunctions()['common/twilio-wrappers/interactions'].path);
 
-const getRequiredParameters = () => {
-  return [
-    {
-      key: 'flexInteractionSid',
-      purpose: 'KDxxx sid for inteactions API',
-    },
-    {
-      key: 'flexInteractionChannelSid',
-      purpose: 'UOxxx sid for interactions API',
-    },
-    {
-      key: 'flexInteractionParticipantSid',
-      purpose: 'UTxxx sid for interactions API',
-    },
-  ];
-};
+const requiredParameters = [
+  {
+    key: 'flexInteractionSid',
+    purpose: 'KDxxx sid for inteactions API',
+  },
+  {
+    key: 'flexInteractionChannelSid',
+    purpose: 'UOxxx sid for interactions API',
+  },
+  {
+    key: 'flexInteractionParticipantSid',
+    purpose: 'UTxxx sid for interactions API',
+  },
+];
 
-exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, event, callback) {
-  const response = new Twilio.Response();
-
-  const requiredParameters = getRequiredParameters();
-  const parameterError = FunctionHelper.validateParameters(context.PATH, event, requiredParameters);
-
-  response.appendHeader('Access-Control-Allow-Origin', '*');
-  response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-  response.appendHeader('Content-Type', 'application/json');
-  response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
-
-  if (Object.keys(event).length === 0) {
-    console.log('Empty event object, likely an OPTIONS request');
-    return callback(null, response);
-  }
-
-  if (parameterError) {
-    response.setStatusCode(400);
-    response.setBody({ data: null, message: parameterError });
-    return callback(null, response);
-  }
-
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
     const { flexInteractionSid, flexInteractionChannelSid, flexInteractionParticipantSid, conversationSid } = event;
 
@@ -81,9 +56,6 @@ exports.handler = TokenValidator(async function chat_transfer_v2_cbm(context, ev
     });
     return callback(null, response);
   } catch (error) {
-    console.error(`Unexpected error occurred in ${scriptName}: ${error}`);
-    response.setStatusCode(500);
-    response.setBody({ success: false, message: error });
-    return callback(null, response);
+    return handleError(error);
   }
 });


### PR DESCRIPTION
### Summary

These somehow slipped through the cracks during the Great Function De-boilerplate-ification a few months ago. This should not change any behavior. Some error handling may be different, but no callers are using it currently anyway.

### Checklist
- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
