### PR TITLE
Conditionally deploy docs site

### DIFF
--- a/.github/workflows/deploy_docs_gh_pages.yml
+++ b/.github/workflows/deploy_docs_gh_pages.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    if: ${{ vars.DEPLOY_DOCS == 'true' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Summary

Uses the repo var `DEPLOY_DOCS` == `true` to determine if the docs site should be deployed. This prevents failures when forking/creating based on this repo.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
