### PR TITLE
Rename logFilters config setting

### DIFF
--- a/docs/docs/feature-library/flex-v2/26_teams-view-filters.md
+++ b/docs/docs/feature-library/flex-v2/26_teams-view-filters.md
@@ -46,7 +46,7 @@ To use the sample features, most of the filters can simply be toggled on in the 
 ```json
 "teams_view_filters": {
         "enabled": true,
-        "logFilters": true,
+        "log_filters": false,
         "applied_filters": {
           "email": true,
           "department" : true,

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -79,7 +79,7 @@
       },
       "teams_view_filters": {
         "enabled": true,
-        "logFilters": true,
+        "log_filters": false,
         "applied_filters": {
           "email": true,
           "department": true,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/config.ts
@@ -3,7 +3,7 @@ import TeamViewFiltersConfig from './types/ServiceConfiguration';
 
 const {
   enabled = false,
-  logFilters = false,
+  log_filters = false,
   department_options = [],
   team_options = [],
 } = (getFeatureFlags().features?.teams_view_filters as TeamViewFiltersConfig) || {};
@@ -21,7 +21,7 @@ export const isFeatureEnabled = () => {
 };
 
 export const shouldLogFilters = () => {
-  return enabled && logFilters;
+  return enabled && log_filters;
 };
 
 export const isEmailFilterEnabled = () => {

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/types/ServiceConfiguration.ts
@@ -1,6 +1,6 @@
 export default interface TeamViewFiltersConfig {
   enabled: boolean;
-  logFilters: boolean;
+  log_filters: boolean;
   applied_filters: {
     email: boolean;
     department: boolean;


### PR DESCRIPTION
### Summary

The teams-view-filters feature has a debug option named `logFilters`. This is the only setting that does not use an underscore to denote a space. This changes the setting to `log_filters` to make it consistent, and disables it by default, as it is a debugging feature.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
