### PR TITLE
Make activity-skill-filter happy in Flex UI 2.2.0

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapperComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapperComponent.tsx
@@ -1,3 +1,6 @@
+// @ts-nocheck
+// The Flex.Activity component has an incompatible interface between Flex UI 2.1.x and Flex UI 2.2.0.
+// Disable type checking in this file to enable usage across different Flex UI versions.
 import * as Flex from '@twilio/flex-ui';
 import React, { useEffect } from 'react';
 import AppState from 'types/manager/AppState';
@@ -17,7 +20,7 @@ function ActivityWrapperComponent() {
   // Mostly because there isn't a way to hook into the native component
   return (
     <ActivityWrapper activitiesConfig={AgentActivities.getCSSConfig()}>
-      <Flex.Activity />
+      <Flex.Activity disabled={false} />
     </ActivityWrapper>
   );
 }


### PR DESCRIPTION
### Summary

Flex.Activity requires the `disabled` prop in 2.2.0. However, 2.1.1 and earlier do not define that prop in the type interface. Add the prop and disable type checking for the file to allow usage across versions in spite of the incompatible interface.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
