### PR TITLE
Separate dual channel and pause recording services

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/taskAccepted.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/taskAccepted.ts
@@ -1,7 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 
 import { addCallDataToTask, waitForConferenceParticipants, waitForActiveCall } from '../../helpers/dualChannelHelper';
-import RecordingService from '../../../pause-recording/helpers/RecordingService';
+import DualChannelService from '../../helpers/DualChannelService';
 import { getChannelToRecord } from '../../config';
 import { FlexEvent } from '../../../../types/feature-loader';
 
@@ -66,7 +66,7 @@ export const eventHook = async (flex: typeof Flex, _manager: Flex.Manager, task:
   }
 
   try {
-    const recording = await RecordingService.startDualChannelRecording(callSid);
+    const recording = await DualChannelService.startDualChannelRecording(callSid);
     await addCallDataToTask(task, callSid, recording);
   } catch (error) {
     console.error('Unable to start dual channel recording.', error);

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/DualChannelService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/DualChannelService.ts
@@ -1,0 +1,37 @@
+import ApiService from '../../../utils/serverless/ApiService';
+import { EncodedParams } from '../../../types/serverless';
+import { FetchedRecording } from '../../../types/serverless/twilio-api';
+
+export interface RecordingResponse {
+  success: boolean;
+  recording: FetchedRecording;
+}
+
+class DualChannelService extends ApiService {
+  startDualChannelRecording = async (callSid: string): Promise<FetchedRecording> => {
+    return new Promise((resolve, reject) => {
+      const encodedParams: EncodedParams = {
+        callSid: encodeURIComponent(callSid),
+        Token: encodeURIComponent(this.manager.user.token),
+      };
+
+      this.fetchJsonWithReject<RecordingResponse>(
+        `${this.serverlessProtocol}://${this.serverlessDomain}/features/dual-channel-recording/flex/create-recording`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: this.buildBody(encodedParams),
+        },
+      )
+        .then((resp: RecordingResponse) => {
+          resolve(resp.recording);
+        })
+        .catch((error) => {
+          console.log('Error starting dual channel recording', error);
+          reject(error);
+        });
+    });
+  };
+}
+
+export default new DualChannelService();

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/PauseRecordingService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/PauseRecordingService.ts
@@ -7,32 +7,7 @@ export interface RecordingResponse {
   recording: FetchedRecording;
 }
 
-class RecordingService extends ApiService {
-  startDualChannelRecording = async (callSid: string): Promise<FetchedRecording> => {
-    return new Promise((resolve, reject) => {
-      const encodedParams: EncodedParams = {
-        callSid: encodeURIComponent(callSid),
-        Token: encodeURIComponent(this.manager.user.token),
-      };
-
-      this.fetchJsonWithReject<RecordingResponse>(
-        `${this.serverlessProtocol}://${this.serverlessDomain}/features/dual-channel-recording/flex/create-recording`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: this.buildBody(encodedParams),
-        },
-      )
-        .then((resp: RecordingResponse) => {
-          resolve(resp.recording);
-        })
-        .catch((error) => {
-          console.log('Error starting dual channel recording', error);
-          reject(error);
-        });
-    });
-  };
-
+class PauseRecordingService extends ApiService {
   pauseCallRecording = async (callSid: string, pauseBehavior: string): Promise<FetchedRecording> => {
     return new Promise((resolve, reject) => {
       const encodedParams: EncodedParams = {
@@ -138,4 +113,4 @@ class RecordingService extends ApiService {
   };
 }
 
-export default new RecordingService();
+export default new PauseRecordingService();

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
@@ -1,6 +1,6 @@
 import { ITask, Manager, Notifications } from '@twilio/flex-ui';
 
-import RecordingService from './RecordingService';
+import PauseRecordingService from './PauseRecordingService';
 import { NotificationIds } from '../flex-hooks/notifications/PauseRecording';
 import AppState from '../../../types/manager/AppState';
 import { reduxNamespace } from '../../../utils/state';
@@ -56,7 +56,7 @@ export const pauseRecording = async (task: ITask): Promise<boolean> => {
       const callSid = getDualChannelCallSid(task);
 
       if (callSid) {
-        const recording = await RecordingService.pauseCallRecording(
+        const recording = await PauseRecordingService.pauseCallRecording(
           callSid,
           isIncludeSilenceEnabled() ? 'silence' : 'skip',
         );
@@ -65,7 +65,7 @@ export const pauseRecording = async (task: ITask): Promise<boolean> => {
         console.error('Unable to get call SID to pause recording');
       }
     } else if (task.conference) {
-      const recording = await RecordingService.pauseConferenceRecording(
+      const recording = await PauseRecordingService.pauseConferenceRecording(
         task.conference?.conferenceSid,
         isIncludeSilenceEnabled() ? 'silence' : 'skip',
       );
@@ -110,13 +110,13 @@ export const resumeRecording = async (task: ITask): Promise<boolean> => {
       const callSid = getDualChannelCallSid(task);
 
       if (callSid) {
-        await RecordingService.resumeCallRecording(callSid, recording.recordingSid);
+        await PauseRecordingService.resumeCallRecording(callSid, recording.recordingSid);
         success = true;
       } else {
         console.error('Unable to get call SID to resume recording');
       }
     } else if (task.conference) {
-      await RecordingService.resumeConferenceRecording(task.conference?.conferenceSid, recording.recordingSid);
+      await PauseRecordingService.resumeConferenceRecording(task.conference?.conferenceSid, recording.recordingSid);
       success = true;
     }
 


### PR DESCRIPTION
### Summary

This slipped through the cracks-- the dual-channel-recording feature was using the pause-recording feature for serverless invocation. This splits that out so each feature is responsible for its own (as it is supposed to be!) and adjusts some naming.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
