### PR TITLE
Use serverless to fetch voicemail with HTTP auth

### DIFF
--- a/docs/docs/feature-library/flex-v2/03_callback-and-voicemail.md
+++ b/docs/docs/feature-library/flex-v2/03_callback-and-voicemail.md
@@ -14,6 +14,7 @@ The feature is inspired by the work in the [Queued Callback and Voicemail](https
 - Callbacks and voicemails use a shared set of components and functions, as voicemails are effectively callbacks with a voicemail recording (and possibly a transcription) attached.
 - The callback or voicemail task can be automatically selected after the outbound call back to the contact ends, allowing for a smoother call wrapup process.
 - A robust wait experience (aka `waitUrl` endpoint) is provided - which uses a more robust Task API query to find the task associated with the Call SID. This addresses the documented scalability issue of the solution library approach - which uses `EvaluateTaskAttributes` for getting the pending task SID (an API that's strictly rate limited to 3 requests per second).
+- Voicemail retrieval works with recording media HTTP authentication enabled or disabled
 
 # Flex User Experience
 
@@ -38,6 +39,8 @@ When the channel is registered, it renders custom components based on the task a
 There are two associated serverless functions called _create-callback_.
 
 The only difference between these functions is one is intended to be called from Flex, the other from anywhere else, but typically Studio (could also be from a TwiML app). The difference is the security model for each function but both do the same thing, taking in task attributes and generating a new callback (or voicemail) task (via a common utility). The Flex interface is used for the re-queueing feature.
+
+When retrieving voicemail, the `fetch-voicemail` function is invoked. This fetches the recording media using HTTP authentication and returns it base64-encoded to Flex UI.
 
 # Setup and Dependencies
 

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
@@ -16,6 +16,8 @@ export enum StringTemplates {
   RetryLater = 'PSCallbackRetryLater',
   SystemTime = 'PSCallbackSystemTime',
   VoicemailLoading = 'PSCallbackVoicemailLoading',
+  VoicemailError = 'PSCallbackVoicemailError',
+  VoicemailTryAgain = 'PSCallbackVoicemailTryAgain',
 }
 
 export const stringHook = () => ({
@@ -37,5 +39,7 @@ export const stringHook = () => ({
     [StringTemplates.RetryLater]: 'Retry Later',
     [StringTemplates.SystemTime]: 'System time: {{systemTime}}',
     [StringTemplates.VoicemailLoading]: 'Loading voicemail...',
+    [StringTemplates.VoicemailError]: 'Error loading voicemail.',
+    [StringTemplates.VoicemailTryAgain]: 'Try again',
   },
 });

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
@@ -15,6 +15,7 @@ export enum StringTemplates {
   PlaceCallNow = 'PSCallbackPlaceCallNow',
   RetryLater = 'PSCallbackRetryLater',
   SystemTime = 'PSCallbackSystemTime',
+  VoicemailLoading = 'PSCallbackVoicemailLoading',
 }
 
 export const stringHook = () => ({
@@ -35,5 +36,6 @@ export const stringHook = () => ({
     [StringTemplates.PlaceCallNow]: 'Place Call Now To {{phoneNumber}}',
     [StringTemplates.RetryLater]: 'Retry Later',
     [StringTemplates.SystemTime]: 'System time: {{systemTime}}',
+    [StringTemplates.VoicemailLoading]: 'Loading voicemail...',
   },
 });

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
@@ -31,7 +31,16 @@ export interface CreateCallbackRequest {
   isDeleted?: boolean;
 }
 
+export interface FetchVoicemailResponse {
+  type: string;
+  recording: string;
+}
+
 class CallbackService extends ApiService {
+  async fetchVoicemail(recordingSid: string): Promise<FetchVoicemailResponse> {
+    return this.#fetchVoicemail(recordingSid);
+  }
+
   async callCustomerBack(task: Flex.ITask, attempts: number): Promise<Flex.ITask> {
     // Check to see if outbound dialing is enabled on the account
     // as outbound calls won't work unless it is
@@ -145,6 +154,22 @@ class CallbackService extends ApiService {
 
     return this.fetchJsonWithReject<CreateCallbackResponse>(
       `${this.serverlessProtocol}://${this.serverlessDomain}/features/callback-and-voicemail/flex/create-callback`,
+      {
+        method: 'post',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: this.buildBody(encodedParams),
+      },
+    );
+  };
+
+  #fetchVoicemail = async (recordingSid: string): Promise<FetchVoicemailResponse> => {
+    const encodedParams: EncodedParams = {
+      Token: encodeURIComponent(this.manager.user.token),
+      recordingSid: encodeURIComponent(recordingSid),
+    };
+
+    return this.fetchJsonWithReject<FetchVoicemailResponse>(
+      `${this.serverlessProtocol}://${this.serverlessDomain}/features/callback-and-voicemail/flex/fetch-voicemail`,
       {
         method: 'post',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -1,4 +1,5 @@
 const { isString, isObject } = require('lodash');
+const axios = require('axios');
 
 const retryHandler = require(Runtime.getFunctions()['common/helpers/retry-handler'].path).retryHandler;
 
@@ -204,5 +205,67 @@ exports.fetchVoiceQueue = async (parameters) => {
     return { success: true, queueProperties, status: 200 };
   } catch (error) {
     return retryHandler(error, parameters, exports.fetchVoiceQueue);
+  }
+};
+
+/**
+ * @param {object} parameters the parameters for the function
+ * @param {number} parameters.attempts the number of retry attempts performed
+ * @param {object} parameters.context the context from calling lambda function
+ * @param {string} parameters.recordingSid the unique recording SID to fetch
+ * @returns {Map} The given recording's properties
+ * @description fetches the given recording SID's properties
+ */
+exports.fetchRecording = async (parameters) => {
+  const { context, recordingSid } = parameters;
+
+  if (!isObject(context)) throw new Error('Invalid parameters object passed. Parameters must contain context object');
+  if (!isString(recordingSid))
+    throw new Error('Invalid parameters object passed. Parameters must contain recordingSid string');
+
+  try {
+    const client = context.getTwilioClient();
+
+    const recordingProperties = await client.recordings(recordingSid).fetch();
+
+    return { success: true, recordingProperties, status: 200 };
+  } catch (error) {
+    return retryHandler(error, parameters, exports.fetchRecording);
+  }
+};
+
+/**
+ * @param {object} parameters the parameters for the function
+ * @param {number} parameters.attempts the number of retry attempts performed
+ * @param {object} parameters.context the context from calling lambda function
+ * @param {string} parameters.recordingUrl the recording url to fetch
+ * @returns {object} the recording audio file encoded as base64
+ * @description fetches recording by url
+ */
+exports.fetchRecordingMedia = async function fetchConfiguration(parameters) {
+  const { recordingUrl } = parameters;
+
+  if (!isString(recordingUrl))
+    throw new Error('Invalid parameters object passed. Parameters must contain recordingUrl string');
+
+  try {
+    const config = {
+      auth: {
+        username: process.env.ACCOUNT_SID,
+        password: process.env.AUTH_TOKEN,
+      },
+      responseType: 'arraybuffer',
+    };
+
+    const getResponse = await axios.get(`${recordingUrl}.mp3`, config);
+
+    return {
+      success: true,
+      status: 200,
+      recording: getResponse?.data.toString('base64' ?? ''),
+      type: getResponse?.headers['content-type'],
+    };
+  } catch (error) {
+    return retryHandler(error, parameters, exports.fetchRecordingMedia);
   }
 };

--- a/serverless-functions/src/functions/features/callback-and-voicemail/flex/fetch-voicemail.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/flex/fetch-voicemail.js
@@ -1,0 +1,32 @@
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+const VoiceOperations = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
+
+const requiredParameters = [{ key: 'recordingSid', purpose: 'recording sid to fetch' }];
+
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  const { recordingSid } = event;
+
+  try {
+    const recordingResult = await VoiceOperations.fetchRecording({
+      context,
+      recordingSid,
+    });
+
+    if (!recordingResult.recordingProperties.mediaUrl) {
+      return handleError('Missing mediaUrl for provided recording sid');
+    }
+
+    const result = await VoiceOperations.fetchRecordingMedia({
+      context,
+      recordingUrl: recordingResult.recordingProperties.mediaUrl,
+    });
+
+    const { recording, status, type } = result;
+    response.setStatusCode(status);
+    response.setBody({ recording, type });
+
+    return callback(null, response);
+  } catch (error) {
+    return handleError(error);
+  }
+});


### PR DESCRIPTION
### Summary

Given recording media will [require HTTP auth beginning July 31](https://www.twilio.com/en-us/changelog/upcoming-security-changes-enforcing-http-authentication-for-media), we need to support it for retrieving voicemail recordings. This PR adds a new serverless function that will fetch recording media using the recording SID, returning it to the client as base64-encoded data.

The recordingUrl task attribute is no longer used after this change, but I kept it in the docs since it could be useful for other uses. We don't send the recordingUrl to the serverless function because we don't want to allow that function to hit any arbitrary URL using the account SID and auth token, which would be a security risk.

I was concerned about performance, but a request for a 2.5 minute voicemail completes in about 400ms. The serverless function requests the mp3 version of the recording, which is much smaller than the wav version.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
