### PR TITLE
Fix kicking the connecting participant

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConnectingParticipants/ConnectingParticipants.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConnectingParticipants/ConnectingParticipants.tsx
@@ -72,7 +72,7 @@ const ConnectingParticipants = (props: OwnProps) => {
         .filter((p) => p.conferenceSid === props.task?.conference?.conferenceSid)
         .map((p) => {
           const fakeParticipant = {
-            participantType: 'external',
+            participantType: 'unknown',
             phoneNumber: p.phoneNumber,
             connecting: true,
             callSid: p.callSid,


### PR DESCRIPTION
### Summary

- Change the connecting participant type to 'unknown', since 'external' is only used with native xwt enabled, and we are intentionally ignoring native xwt participants.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
