### PR TITLE
Updated Barge Coach to remove strings reference in Sync + enhance monitor panel for localization

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
@@ -86,14 +86,16 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
         // If agent_coaching_panel is true (enabled), proceed
         // otherwise we will not update to the Sync Doc
         if (agent_coaching_panel && !privateMode) {
+          const supervisorStatus = 'coaching';
+          const updateStatus = 'update';
           // Updating the Sync Doc to reflect that we are no longer barging and back into Monitoring
           SyncDoc.initSyncDocSupervisors(
             agentWorkerSID,
             conferenceSid,
             myWorkerSID,
             supervisorFN,
-            'is Coaching',
-            'update',
+            supervisorStatus,
+            updateStatus,
           );
         }
       } else {
@@ -106,14 +108,16 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
         // If agent_coaching_panel is true (enabled), proceed
         // otherwise we will not update to the Sync Doc
         if (agent_coaching_panel && !privateMode) {
+          const supervisorStatus = 'barge';
+          const updateStatus = 'update';
           // Updating the Sync Doc to reflect that we are no longer barging and back into Monitoring
           SyncDoc.initSyncDocSupervisors(
             agentWorkerSID,
             conferenceSid,
             myWorkerSID,
             supervisorFN,
-            'has Joined',
-            'update',
+            supervisorStatus,
+            updateStatus,
           );
         }
       }
@@ -190,13 +194,15 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
       // otherwise we will not update to the Sync Doc
       if (agent_coaching_panel && !privateMode) {
         // Updating the Sync Doc to reflect that we are no longer coaching and back into Monitoring
+        const supervisorStatus = 'monitoring';
+        const updateStatus = 'update';
         SyncDoc.initSyncDocSupervisors(
           agentWorkerSID,
           conferenceSid,
           myWorkerSID,
           supervisorFN,
-          'is Monitoring',
-          'update',
+          supervisorStatus,
+          updateStatus,
         );
       }
     } else {
@@ -212,14 +218,16 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
       // If agent_coaching_panel is true (enabled), proceed
       // otherwise we will not update to the Sync Doc
       if (agent_coaching_panel && !privateMode) {
+        const supervisorStatus = 'coaching';
+        const updateStatus = 'update';
         // Updating the Sync Doc to reflect that we are now coaching the agent
         SyncDoc.initSyncDocSupervisors(
           agentWorkerSID,
           conferenceSid,
           myWorkerSID,
           supervisorFN,
-          'is Coaching',
-          'update',
+          supervisorStatus,
+          updateStatus,
         );
       }
     }

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
@@ -33,9 +33,9 @@ export const CoachingStatusPanel = () => {
         if (doc.data.supervisors) {
           supervisorArray = [...doc.data.supervisors];
           // Current verion of this feature will only show the Agent they are being coached
-          // This could be updated by removing the below logic and including Monitoring and Joined (barged)
+          // This could be updated by removing the below logic and including Monitoring and Barge
           for (let i = 0; i < supervisorArray.length; i++) {
-            if (supervisorArray[i].status === 'is Monitoring' || supervisorArray[i].status === 'has Joined') {
+            if (supervisorArray[i].status === 'monitoring' || supervisorArray[i].status === 'barge') {
               supervisorArray.splice(i, 1);
               i -= 1;
             }

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
@@ -27,32 +27,24 @@ export const SupervisorMonitorPanel = (_props: SupervisorMonitorPanelProps) => {
 
   const agentWorkerSID = useFlexSelector((state) => state?.flex?.supervisor?.stickyWorker?.worker?.sid);
 
-  const createSupervisorString = () => {
-    const supervisorString: any = [];
-    supervisorArray.forEach((s) => {
-      switch (s.status) {
-        case 'barge':
-          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelBarge]()}`);
-          break;
-        case 'coaching':
-          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelCoaching]()}`);
-          break;
-        case 'monitoring':
-          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelMonitoring]()}`);
-          break;
-        default:
-          break;
-      }
-    });
-    return supervisorString;
+  const supervisorSwitch = (status: string, supervisor: string) => {
+    switch (status) {
+      case 'barge':
+        return templates[StringTemplates.PanelBarge]({ supervisor });
+      case 'coaching':
+        return templates[StringTemplates.PanelCoaching]({ supervisor });
+      case 'monitoring':
+        return templates[StringTemplates.PanelMonitoring]({ supervisor });
+      default:
+        return null;
+    }
   };
   const supervisorsArray = () => {
-    return createSupervisorString().map((s: string) => (
-      <tr key={s}>
-        <td>{s}</td>
-      </tr>
+    return supervisorArray.map((supervisorArray) => (
+      <li key={`${Math.random()}`}>{supervisorSwitch(supervisorArray.status, supervisorArray.supervisor)}</li>
     ));
   };
+
   const syncUpdates = () => {
     if (agentWorkerSID) {
       // Let's subscribe to the sync doc as an agent/worker and check

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
@@ -27,11 +27,29 @@ export const SupervisorMonitorPanel = (_props: SupervisorMonitorPanelProps) => {
 
   const agentWorkerSID = useFlexSelector((state) => state?.flex?.supervisor?.stickyWorker?.worker?.sid);
 
+  const createSupervisorString = () => {
+    const supervisorString: any = [];
+    supervisorArray.forEach((s) => {
+      switch (s.status) {
+        case 'barge':
+          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelBarge]()}`);
+          break;
+        case 'coaching':
+          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelCoaching]()}`);
+          break;
+        case 'monitoring':
+          supervisorString.push(`${s.supervisor} ${templates[StringTemplates.PanelMonitoring]()}`);
+          break;
+        default:
+          break;
+      }
+    });
+    return supervisorString;
+  };
   const supervisorsArray = () => {
-    return supervisorArray.map((supervisorArray) => (
-      <tr key={supervisorArray.supervisorSID}>
-        <td>{supervisorArray.supervisor}</td>
-        <td style={{ color: 'green' }}>&nbsp;{supervisorArray.status}</td>
+    return createSupervisorString().map((s: string) => (
+      <tr key={s}>
+        <td>{s}</td>
       </tr>
     ));
   };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
@@ -41,17 +41,37 @@ export const SupervisorPrivateToggle = ({ task }: SupervisorPrivateToggleProps) 
         }),
       );
       if (coaching) {
-        SyncDoc.initSyncDocSupervisors(agentWorkerSID, conferenceSID, myWorkerSID, supervisorFN, 'is Coaching', 'add');
-      } else if (barge) {
-        SyncDoc.initSyncDocSupervisors(agentWorkerSID, conferenceSID, myWorkerSID, supervisorFN, 'has Joined', 'add');
-      } else {
+        const supervisorStatus = 'coaching';
+        const updateStatus = 'add';
         SyncDoc.initSyncDocSupervisors(
           agentWorkerSID,
           conferenceSID,
           myWorkerSID,
           supervisorFN,
-          'is Monitoring',
-          'add',
+          supervisorStatus,
+          updateStatus,
+        );
+      } else if (barge) {
+        const supervisorStatus = 'barge';
+        const updateStatus = 'add';
+        SyncDoc.initSyncDocSupervisors(
+          agentWorkerSID,
+          conferenceSID,
+          myWorkerSID,
+          supervisorFN,
+          supervisorStatus,
+          updateStatus,
+        );
+      } else {
+        const supervisorStatus = 'monitoring';
+        const updateStatus = 'add';
+        SyncDoc.initSyncDocSupervisors(
+          agentWorkerSID,
+          conferenceSID,
+          myWorkerSID,
+          supervisorFN,
+          supervisorStatus,
+          updateStatus,
         );
       }
       // If privateMode is false, toggle to true and remove the Supervisor from the Sync Doc

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/actions/MonitorCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/actions/MonitorCall.ts
@@ -31,7 +31,16 @@ export const actionHook = async function enableBargeCoachButtonsUponMonitor(flex
     const agentWorkerSID = manager.store.getState().flex?.supervisor?.stickyWorker?.worker?.sid;
     const supervisorFN = manager.store.getState().flex?.worker?.attributes?.full_name;
     const conferenceSID = payload.task?.conference?.conferenceSid;
+    const supervisorStatus = 'monitoring';
+    const updateStatus = 'add';
 
-    SyncDoc.initSyncDocSupervisors(agentWorkerSID, conferenceSID, myWorkerSID, supervisorFN, 'is Monitoring', 'add');
+    SyncDoc.initSyncDocSupervisors(
+      agentWorkerSID,
+      conferenceSID,
+      myWorkerSID,
+      supervisorFN,
+      supervisorStatus,
+      updateStatus,
+    );
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/BargeCoachAssist.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/BargeCoachAssist.ts
@@ -18,6 +18,9 @@ export enum StringTemplates {
   DisablePrivacy = 'PSBargeCoachDisablePrivacy',
   PrivacyOn = 'PSBargeCoachPrivacyOn',
   PrivacyOff = 'PSBargeCoachPrivacyOff',
+  PanelBarge = 'PSBargeCoachMonitorPanelBarge',
+  PanelCoaching = 'PSBargeCoachMonitorPanelCoaching',
+  PanelMonitoring = 'PSBargeCoachMonitorPanelMonitoring',
 }
 
 export const stringHook = () => ({
@@ -40,5 +43,8 @@ export const stringHook = () => ({
     [StringTemplates.DisablePrivacy]: 'Disable Private Mode',
     [StringTemplates.PrivacyOn]: 'Privacy On',
     [StringTemplates.PrivacyOff]: 'Privacy Off',
+    [StringTemplates.PanelBarge]: 'has joined',
+    [StringTemplates.PanelCoaching]: 'is coaching',
+    [StringTemplates.PanelMonitoring]: 'is monitoring',
   },
 });

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/BargeCoachAssist.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/BargeCoachAssist.ts
@@ -43,8 +43,8 @@ export const stringHook = () => ({
     [StringTemplates.DisablePrivacy]: 'Disable Private Mode',
     [StringTemplates.PrivacyOn]: 'Privacy On',
     [StringTemplates.PrivacyOff]: 'Privacy Off',
-    [StringTemplates.PanelBarge]: 'has joined',
-    [StringTemplates.PanelCoaching]: 'is coaching',
-    [StringTemplates.PanelMonitoring]: 'is monitoring',
+    [StringTemplates.PanelBarge]: '{{supervisor}} has joined',
+    [StringTemplates.PanelCoaching]: '{{supervisor}} is coaching',
+    [StringTemplates.PanelMonitoring]: '{{supervisor}} is monitoring',
   },
 });


### PR DESCRIPTION
### Summary

I've updated the barge coach sync where it was once referencing strings for UI renders.  Along with that enhancement, I've added localization support for the monitor panel feature.

For you to test, have two users logged in.  Have one user take a voice task and the other go into monitor/coach/barge.  You can view the monitor panel to see who has joined/coached/monitored that specific task in the Teams view.

### Checklist

- [ x ] Tested changes end to end
- [ x ] Any config changes added to all environment files
- [ x ] For Flex features added, ensure the feature list on the README on the project root folder is updated
- [ x ] Completed README template for new features in `/docs/docs/feature-library/flex-v2` and added feature row entry into the `/docs/docs/feature-library/00_overview.md` file
  - [ x ] Feature summary - _high level summary of what the feature does_
  - [ x ] Flex User Experience with animations - _animations with descriptions if necessary of the user experience in Flex_
  - [ x ] Setup and dependencies - _description of any setup steps required for this feature_
  - [ x ] How does it work? - _description of plumbing supporting feature_
- [ x ] Added PR Label "ready-for-review"
- [ x ] Requested one or more reviewers for the PR


