### PR TITLE
Require admin role to update global config

### DIFF
--- a/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
+++ b/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
@@ -7,7 +7,14 @@ const requiredParameters = [{ key: 'attributesUpdate', purpose: 'ui_attributes t
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-    const { attributesUpdate } = event;
+    const { attributesUpdate, TokenResult } = event;
+
+    if (TokenResult.roles.indexOf('admin') < 0) {
+      response.setStatusCode(403);
+      response.setBody('Not authorized');
+      return callback(null, response);
+    }
+
     const result = await Configuration.updateUiAttributes({
       attributesUpdate,
       context,


### PR DESCRIPTION
### Summary

The admin-ui feature is only available to users with the admin role. This adds protection to the update-config serverless function so that malicious agents cannot use it.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
