### PR TITLE
Fix participants tab with worker missing full_name

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/hooks.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/hooks.ts
@@ -88,7 +88,9 @@ export const getUpdatedParticipantDetails = async (
 
     if (intertactionParticipant) {
       const friendlyName =
-        conversationParticipant.friendlyName || intertactionParticipant.mediaProperties?.messagingBinding.address;
+        conversationParticipant.friendlyName ||
+        intertactionParticipant.mediaProperties?.messagingBinding?.address ||
+        intertactionParticipant.mediaProperties?.identity;
       const participantType = intertactionParticipant.type;
       const isMe = conversationParticipant.source.identity === myIdentity;
       const interactionParticipantSid = intertactionParticipant.participantSid;


### PR DESCRIPTION
### Summary

Without this fix, the conversation-transfer participants tab breaks pretty hard if a worker in the participant list has no `full_name`.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
