### PR TITLE
Fix error with empty sync doc

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/sync/Sync.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/sync/Sync.ts
@@ -69,7 +69,7 @@ class SyncDocClass {
     let supervisorsArray: Array<any> = [];
     this.getSyncDoc(docToUpdate)
       .then((doc: any) => {
-        if (doc.data.supervisors !== null) {
+        if (doc.data.supervisors) {
           supervisorsArray = [...doc.data.supervisors];
         }
         if (updateStatus === 'add') {


### PR DESCRIPTION
### Summary

Fixes errors when supervisor-barge-coach has not been used before. The reason is this value is `undefined` rather than `null`, which is what was being checked before.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
