### PR TITLE
Work around Flex bug with parking

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/actions/ParkInteraction.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/actions/ParkInteraction.ts
@@ -45,7 +45,8 @@ export const parkInteraction = async (payload: ParkInteractionPayload) => {
     Notifications.dismissNotificationById(ParkInteractionNotification.ParkError);
 
     setTimeout(() => {
-      console.log('after 2 sec');
+      // Work around a Flex bug where a CONVERSATION_UPDATE happens after CONVERSATION_UNLOAD,
+      // which results in the conversation not loading until Flex UI is reloaded
       Manager.getInstance().store.dispatch({
         type: 'CONVERSATION_UNLOAD',
         payload: {},

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/actions/ParkInteraction.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/actions/ParkInteraction.ts
@@ -1,4 +1,4 @@
-import { TaskHelper, Notifications, templates } from '@twilio/flex-ui';
+import { TaskHelper, Notifications, templates, Manager } from '@twilio/flex-ui';
 
 import { ParkInteractionNotification } from '../flex-hooks/notifications';
 import { StringTemplates } from '../flex-hooks/strings';
@@ -43,6 +43,19 @@ export const parkInteraction = async (payload: ParkInteractionPayload) => {
     );
 
     Notifications.dismissNotificationById(ParkInteractionNotification.ParkError);
+
+    setTimeout(() => {
+      console.log('after 2 sec');
+      Manager.getInstance().store.dispatch({
+        type: 'CONVERSATION_UNLOAD',
+        payload: {},
+        meta: {
+          conversationSid: agent.mediaProperties.conversationSid,
+          channelSid: agent.mediaProperties.conversationSid,
+        },
+      });
+    }, 2000);
+
     return Notifications.showNotification(ParkInteractionNotification.ParkSuccess);
   } catch (error) {
     let message = (error as any)?.message;


### PR DESCRIPTION
### Summary

When parking an interaction in Flex, sometimes a `CONVERSATION_UPDATE` Redux action is emitted after a `CONVERSATION_UNLOAD` action. This results in bad state in Flex UI, which means that if the interaction is un-parked during the same Flex UI session, and the same agent receives the conversation, it will not load properly until Flex UI is reloaded.

This hack works around this bug successfully by emitting `CONVERSATION_UNLOAD` 2 seconds later. It was originally conceived for conversations orchestrated outside the Flex Interactions API, but it turns out it is needed for interactions too.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
