### PR TITLE
Retry using exponential backoff with full jitter

### DIFF
--- a/serverless-functions/src/functions/common/helpers/retry-handler.private.js
+++ b/serverless-functions/src/functions/common/helpers/retry-handler.private.js
@@ -39,6 +39,10 @@ exports.retryHandler = async (error, parameters, callback) => {
   const retryAttemptsMessage = attempts === 1 ? `${attempts} retry attempt` : `${attempts} retry attempts`;
   const message = errorMessage ? errorMessage : error;
 
+  // Perform retries only on retry-able response status codes
+  // 412: Received upon ETag conflict; retry without delay
+  // 429: Rate limited; retry with delay
+  // 503: Internal error; retry with delay
   if (
     (status === 412 || status === 429 || status === 503) &&
     isNumber(attempts) &&


### PR DESCRIPTION
### Summary

Adjusted the included ApiService to use a better retry algorithm when it receives a 429. In most cases this is handled by the retry handler within serverless, but that has limits in place which means we can still receive them client-side. Plus, ApiService can be used to make requests to other services, too. The new algorithm [should drastically reduce](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) the amount of requests made as part of the retry logic.

Also added comment clarifying the response status codes handled within the serverless retry handler.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
