### PR TITLE
updating broken links for docs site

### DIFF
--- a/docs/docs/how-it-works/04_plugin-flex-ts-template-v2.md
+++ b/docs/docs/how-it-works/04_plugin-flex-ts-template-v2.md
@@ -6,4 +6,4 @@ title: plugin-flex-ts-template-v2
 
 This is the Twilio Professional Services Flex Plugin that accompanies the Flex Project Template.
 
-This plugin defines a package structure to make distributed development easier when augmenting Flex with custom features and behaviors. For walkthroughs on building with this template, check out the documentation [over here](/setup-guides/building-with-template).
+This plugin defines a package structure to make distributed development easier when augmenting Flex with custom features and behaviors. For walkthroughs on building with this template, check out the documentation [over here](/how-it-works/building-with-template).

--- a/docs/docs/setup-guides/00_local-setup-and-use.md
+++ b/docs/docs/setup-guides/00_local-setup-and-use.md
@@ -46,7 +46,7 @@ npm start
 
 ### development notes
 
-When developing locally, Flex config is overridden by anything in your [appConfig.js](/plugin-flex-ts-template-v2/public/appConfig.example.js). Note: appConfig is only applicable when running the plugin locally, so you can edit this file to toggle features on and off for your locally running web server. You can also tweak the api endpoint for your serverless functions if you need to.
+When developing locally, Flex config is overridden by anything in your `plugin-flex-ts-template-v2/public/appConfig.js`. Note: appConfig is only applicable when running the plugin locally, so you can edit this file to toggle features on and off for your locally running web server. You can also tweak the api endpoint for your serverless functions if you need to.
 
 When running the plugin locally, this template has been set up to pair the plugin with the serverless functions also running locally on localhost:3001. The serverless functions can be debugged by attaching your debugger to the node instance. The following is a sample entry for ".vscode/launch.json" to connect vscode for debugging
 


### PR DESCRIPTION
### Summary

fixed some broken links in the docs after the terraform PR was merged to main



