### PR TITLE
Fix changing views while WorkerDirectory is open

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/WorkerDirectory.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/WorkerDirectory.tsx
@@ -6,6 +6,6 @@ export const componentName = FlexComponent.WorkerDirectory;
 export const componentHook = function removeDialpadForConvTransfer(flex: typeof Flex, _manager: Flex.Manager) {
   // remove existing dialpad tab
   flex.WorkerDirectory.Tabs.Content.remove('directory', {
-    if: ({ task }) => Flex.TaskHelper.isCBMTask(task),
+    if: ({ task }) => task && Flex.TaskHelper.isCBMTask(task),
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueItem.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueItem.tsx
@@ -43,8 +43,9 @@ export const QueueItem = (props: QueueItemProps) => {
   const callWarmTransferEnabled =
     Manager.getInstance().store.getState().flex.featureFlags.features['flex-warm-transfers']?.enabled;
 
-  const isWarmTransferEnabled = TaskHelper.isCBMTask(task) ? isCbmWarmTransferEnabled() : callWarmTransferEnabled;
-  const isColdTransferEnabled = TaskHelper.isCBMTask(task) ? isCbmColdTransferEnabled() : true;
+  const isWarmTransferEnabled =
+    task && TaskHelper.isCBMTask(task) ? isCbmWarmTransferEnabled() : callWarmTransferEnabled;
+  const isColdTransferEnabled = task && TaskHelper.isCBMTask(task) ? isCbmColdTransferEnabled() : true;
 
   return (
     <Flex
@@ -86,7 +87,7 @@ export const QueueItem = (props: QueueItemProps) => {
               size="circle"
               onClick={onWarmTransferClick}
             >
-              {TaskHelper.isChatBasedTask(task) ? (
+              {task && TaskHelper.isChatBasedTask(task) ? (
                 <ChatIcon key={`queue-item-warm-transfer-icon-${queue.sid}`} decorative={false} title="" />
               ) : (
                 <CallTransferIcon key={`queue-item-warm-transfer-icon-${queue.sid}`} decorative={false} title="" />
@@ -109,7 +110,7 @@ export const QueueItem = (props: QueueItemProps) => {
               size="circle"
               onClick={onColdTransferClick}
             >
-              {TaskHelper.isChatBasedTask(task) ? (
+              {task && TaskHelper.isChatBasedTask(task) ? (
                 <SendIcon key={`queue-item-cold-transfer-icon-${queue.sid}`} decorative={false} title="" />
               ) : (
                 <CallOutgoingIcon key={`queue-item-cold-transfer-icon-${queue.sid}`} decorative={false} title="" />


### PR DESCRIPTION
### Summary

It seems some TaskHelper functions do not like being passed a null task.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
