### PR TITLE
Allow override of default task channels without console errors

### DIFF
--- a/docs/docs/how-it-works/04_plugin-flex-ts-template-v2.md
+++ b/docs/docs/how-it-works/04_plugin-flex-ts-template-v2.md
@@ -222,6 +222,43 @@ export const channelHook = function createCallbackChannel(
 };
 ```
 
+Alternatively, you can use a channels hook to modify an existing task channel definition.
+
+```ts
+import * as Flex from '@twilio/flex-ui';
+
+import CustomerAvatarObject from '../../custom-components/CustomerAvatarObject';
+
+export const channelHook = function overrideCallChannelToUseCustomerAttribute(
+  flex: typeof Flex,
+  _manager: Flex.Manager,
+) {
+  const channelDefinition = flex.DefaultTaskChannels.Call;
+  const { templates, icons } = channelDefinition;
+
+  channelDefinition.templates = {
+    ...templates,
+    TaskListItem: {
+      ...flex.DefaultTaskChannels.Call.templates?.TaskListItem,
+      firstLine: (task: Flex.ITask) => `(${task.attributes.customer}) ${task.defaultFrom}`,
+    },
+    TaskCanvasHeader: {
+      ...flex.DefaultTaskChannels.Call.templates?.TaskCanvasHeader,
+      title: (task: Flex.ITask) => `(${task.attributes.customer}) ${task.defaultFrom}`,
+    },
+  };
+
+  channelDefinition.icons = {
+    ...icons,
+    list: <CustomerAvatarObject key="task-list-customer-avatar" />,
+    main: <CustomerAvatarObject key="main-customer-avatar" />,
+    active: <CustomerAvatarObject key="active-customer-avatar" />,
+  };
+
+  // Nothing to return from hook, since we are overriding the default Call channel versus adding a new channel
+};
+```
+
 ### chat-orchestrator
 
 Use a chat orchestrator hook to modify chat orchestration via `ChatOrchestrator.setOrchestrations`.

--- a/plugin-flex-ts-template-v2/README.md
+++ b/plugin-flex-ts-template-v2/README.md
@@ -205,6 +205,43 @@ export const channelHook = function createCallbackChannel(flex: typeof Flex, man
 };
 ```
 
+Alternatively, you can use a channels hook to modify an existing task channel definition.
+
+```ts
+import * as Flex from '@twilio/flex-ui';
+
+import CustomerAvatarObject from '../../custom-components/CustomerAvatarObject';
+
+export const channelHook = function overrideCallChannelToUseCustomerAttribute(
+  flex: typeof Flex,
+  _manager: Flex.Manager,
+) {
+  const channelDefinition = flex.DefaultTaskChannels.Call;
+  const { templates, icons } = channelDefinition;
+
+  channelDefinition.templates = {
+    ...templates,
+    TaskListItem: {
+      ...flex.DefaultTaskChannels.Call.templates?.TaskListItem,
+      firstLine: (task: Flex.ITask) => `(${task.attributes.customer}) ${task.defaultFrom}`,
+    },
+    TaskCanvasHeader: {
+      ...flex.DefaultTaskChannels.Call.templates?.TaskCanvasHeader,
+      title: (task: Flex.ITask) => `(${task.attributes.customer}) ${task.defaultFrom}`,
+    },
+  };
+
+  channelDefinition.icons = {
+    ...icons,
+    list: <CustomerAvatarObject key="task-list-customer-avatar" />,
+    main: <CustomerAvatarObject key="main-customer-avatar" />,
+    active: <CustomerAvatarObject key="active-customer-avatar" />,
+  };
+
+  // Nothing to return from hook, since we are overriding the default Call channel versus adding a new channel
+};
+```
+
 ### chat-orchestrator
 
 Use a chat orchestrator hook to modify chat orchestration via `ChatOrchestrator.setOrchestrations`.

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/channels.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/channels.ts
@@ -2,7 +2,10 @@ import * as Flex from '@twilio/flex-ui';
 
 export const addHook = (flex: typeof Flex, manager: Flex.Manager, feature: string, hook: any) => {
   console.info(`Feature ${feature} registered channel hook: %c${hook.channelHook.name}`, 'font-weight:bold');
-  // returns a task channel to register
+  // returns a task channel to register (or not - if it's overriding a default channel)
   const channel = hook.channelHook(flex, manager);
-  flex.TaskChannels.register(channel);
+  if (channel) {
+    // Must be a new channel, so register it
+    flex.TaskChannels.register(channel);
+  }
 };


### PR DESCRIPTION
### Summary

Small null check to allow a channels hook to **not** return a ChannelDefinition instance - to cater to use cases where we want to override default task channels definitions. Example included in docs/README.

### Checklist

- [x] Tested changes end to end
- [x] Updated README
- [ ] Added PR Label "ready-for-review"
- [ ] Requested one or more reviewers for the PR
