### PR TITLE
Clarify valid environment names in docs

### DIFF
--- a/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
+++ b/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
@@ -42,7 +42,7 @@ Time to complete: _~8 minutes_
 2. Create a twilio api key and secret for your account follow this [guide](https://www.twilio.com/docs/glossary/what-is-an-api-key#how-can-i-create-api-keys) to setup an API key.
 3. In github, navigate to the repository you created in step 1, click the settings tab -> environments -> "New Environment"
    
-   - For the environment name, do not include spaces or other special characters
+   - For the environment name, do not include spaces or other special characters except hyphens and underscores
    
    - _NOTE_ if you are on the free tier, the repository will need to be public to use environments.  If you are on the free tier and still want to use a private repo you will need to clone the deploy script to have dedicated secrets per environment
 

--- a/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
+++ b/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
@@ -42,6 +42,8 @@ Time to complete: _~8 minutes_
 2. Create a twilio api key and secret for your account follow this [guide](https://www.twilio.com/docs/glossary/what-is-an-api-key#how-can-i-create-api-keys) to setup an API key.
 3. In github, navigate to the repository you created in step 1, click the settings tab -> environments -> "New Environment"
    
+   - For the environment name, do not include spaces or other special characters
+   
    - _NOTE_ if you are on the free tier, the repository will need to be public to use environments.  If you are on the free tier and still want to use a private repo you will need to clone the deploy script to have dedicated secrets per environment
 
    - add the 4 *secrets* for that environment

--- a/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
+++ b/docs/docs/setup-guides/00_deploy-to-hosted-flex.md
@@ -52,7 +52,7 @@ Time to complete: _~8 minutes_
      - `TWILIO_API_SECRET` - the api secret
      - `TF_ENCRYPTION_KEY` this can be any string value you want
 
-   - your environment secrets should look something like this (TF_ENCYPTION_KEY can be a repo or environment secret)
+   - your environment secrets should look something like this (TF_ENCRYPTION_KEY can be a repo or environment secret)
    ![image](/img/guides/github-secrets.png)
 
 4. Login into Flex and make sure in the admin panel, the version of flex you are using meets the minimal version allowed by the plugin (at time of writing, Flex 2.x is minimum allowed)
@@ -63,7 +63,7 @@ Time to complete: _~8 minutes_
    
 7. Run the workflow.
    - this will deploy the assets to your environment with the default features enabled, See [Feature library Information](/feature-library/overview) for further details of whats enabled by default.
-   - envrionment properties will be automatically populated based on the deployed Flex configuration, including service and workflow SIDs. See [override environment properties](/setup-guides/override-environment-properties) for information on how to influence this configuration.
+   - environment properties will be automatically populated based on the deployed Flex configuration, including service and workflow SIDs. See [override environment properties](/setup-guides/override-environment-properties) for information on how to influence this configuration.
  
 
 


### PR DESCRIPTION
### Summary

Including spaces and other special characters can break our scripts, at least in their current state. Since we don't test with those names, let's guide against their usage, even if we may fix this in the future.

### Checklist

- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
