### PR TITLE
Skip docs checks if docs deploy disabled

### DIFF
--- a/.github/workflows/docs_checks.yaml
+++ b/.github/workflows/docs_checks.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    if: ${{ vars.DEPLOY_DOCS == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

Small oversight on my part, there is no point in running the docs checks if docs won't ever be deployed.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
