### PR TITLE
Fix scrolling in the tasks canvas when small

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/ParticipantsTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/ParticipantsTab.tsx
@@ -18,6 +18,7 @@ const ParticipantsTabContainer = styled.div`
   padding-right: 3%;
   padding-top: 3%;
   width: 100%;
+  overflow-y: scroll;
 `;
 
 interface ParticipantsTabProps {

--- a/plugin-flex-ts-template-v2/src/feature-library/dispositions/custom-components/DispositionTab/DispositionTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/dispositions/custom-components/DispositionTab/DispositionTab.tsx
@@ -91,7 +91,7 @@ const DispositionTab = (props: OwnProps) => {
   }, [props.task?.status]);
 
   return (
-    <Box padding="space80">
+    <Box padding="space80" overflowY="scroll">
       <Stack orientation="vertical" spacing="space80">
         {getDispositionsForQueue(props.task?.queueSid ?? '').length > 0 && (
           <RadioGroup


### PR DESCRIPTION
### Summary
The conversation-transfer participants tab, and the dispositions tab, did not properly handle their overflow, so the entire tasks canvas was scrolling. This fixes those tabs to properly scroll.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
