### PR TITLE
Fix CSS merge

### DIFF
--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/css-overrides.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/css-overrides.ts
@@ -1,4 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
+import { merge } from 'lodash';
 
 let overrides = {};
 
@@ -15,8 +16,5 @@ export const init = (manager: Flex.Manager) => {
 export const addHook = (flex: typeof Flex, manager: Flex.Manager, feature: string, hook: any) => {
   console.info(`Feature ${feature} registered CSS override hook: %c${hook.cssOverrideHook.name}`, 'font-weight:bold');
   const override = hook.cssOverrideHook(flex, manager);
-  overrides = {
-    ...overrides,
-    ...override,
-  };
+  overrides = merge(overrides, override);
 };


### PR DESCRIPTION
### Summary

Multiple features may use the css-overrides hook to modify the same component (e.g. MainHeader). The previous object spread logic would not properly merge these, so switch to lodash deep merge.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
