### PR TITLE
Retry upon common network errors

### DIFF
--- a/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/ApiService/index.ts
@@ -63,8 +63,15 @@ export default abstract class ApiService {
         // https://gist.github.com/odewahn/5a5eeb23279eed6a80d7798fdb47fe91
         try {
           // Generic retry when calls return a 'too many requests' response
+          // or when Fetch API returns a TypeError due to a network error
           // request is delayed by a random number which grows with the number of retries
-          if (error.status === 429 && attempts < MAX_ATTEMPTS) {
+          if (
+            ((error instanceof TypeError &&
+              (error.message === 'Failed to fetch' ||
+                error.message === 'NetworkError when attempting to fetch resource.')) ||
+              error.status === 429) &&
+            attempts < MAX_ATTEMPTS
+          ) {
             // Calculate the exponential backoff delay
             const backoffDelay = Math.min(MAX_RETRY_DELAY, RETRY_INTERVAL * Math.pow(2, attempts));
             // Apply full jitter to the delay; reduces load


### PR DESCRIPTION
### Summary

While testing in a challenged network environment, I ran into some retry-able errors not being retried. Added logic to both the serverless and plugin fetch handlers to retry network errors, not just HTTP errors.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
