### PR TITLE
Making variables available for terraform studio functions

### DIFF
--- a/.github/actions/terraform_state_artifact/action.yml
+++ b/.github/actions/terraform_state_artifact/action.yml
@@ -74,21 +74,33 @@ runs:
         ### SERVERLESS DOMAINS: ALWAYS REQUIRED INPUT VARIABLES ###
         $services = twilio api:serverless:v1:services:list -o json | ConvertFrom-Json
 
-        $tf_severless_sid_custom_flex = $services | where {$_.uniqueName -eq 'custom-flex-extensions-serverless'} | Select -property sid -ExpandProperty sid
-        $tf_severless_sid_schedule_manager = $services | where {$_.uniqueName -eq 'schedule-manager'} | Select -property sid -ExpandProperty sid
+        $env:TF_VAR_SERVERLESS_SID = $services | where {$_.uniqueName -eq 'custom-flex-extensions-serverless'} | Select -property sid -ExpandProperty sid
+        $env:TF_VAR_SCHEDULE_MANAGER_SID = $services | where {$_.uniqueName -eq 'schedule-manager'} | Select -property sid -ExpandProperty sid
 
-        $env:TF_VAR_SERVERLESS_DOMAIN_CUSTOM_FLEX = twilio api:serverless:v1:services:environments:list --service-sid $tf_severless_sid_custom_flex -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property domainName -ExpandProperty domainName
-        $env:TF_VAR_SERVERLESS_DOMAIN_SCHEDULE_MANAGER = twilio api:serverless:v1:services:environments:list --service-sid $tf_severless_sid_schedule_manager -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property domainName -ExpandProperty domainName
+        $env:TF_VAR_SERVERLESS_DOMAIN = twilio api:serverless:v1:services:environments:list --service-sid $env:TF_VAR_SERVERLESS_SID -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property domainName -ExpandProperty domainName
+        $env:TF_VAR_SERVERLESS_ENV_SID = twilio api:serverless:v1:services:environments:list --service-sid $env:TF_VAR_SERVERLESS_SID -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property sid -ExpandProperty sid
+        $env:TF_VAR_SCHEDULE_MANAGER_DOMAIN = twilio api:serverless:v1:services:environments:list --service-sid $env:TF_VAR_SCHEDULE_MANAGER_SID -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property domainName -ExpandProperty domainName
+        $env:TF_VAR_SCHEDULE_MANAGER_ENV_SID = twilio api:serverless:v1:services:environments:list --service-sid $env:TF_VAR_SCHEDULE_MANAGER_SID -o json | ConvertFrom-Json | where {$_.uniqueName -eq 'dev-environment'} | Select -property sid -ExpandProperty sid
 
-        $temp1 = $env:TF_VAR_SERVERLESS_DOMAIN_CUSTOM_FLEX
-        $temp2 = $env:TF_VAR_SERVERLESS_DOMAIN_SCHEDULE_MANAGER
+        ### FUNCTIONS
+        $serverless_functions = twilio api:serverless:v1:services:functions:list --service-sid $env:TF_VAR_SERVERLESS_SID -o json | ConvertFrom-Json
+        $schedule_manager_functions = twilio api:serverless:v1:services:functions:list --service-sid $env:TF_VAR_SCHEDULE_MANAGER_SID -o json | ConvertFrom-Json
+
+        ### SERVERLESS FUNCTIONS
+        $env:TF_VAR_FUNCTION_CREATE_CALLBACK = $serverless_functions | where {$_.friendlyName -eq '/features/callback-and-voicemail/studio/create-callback'} | Select -property sid -ExpandProperty sid
+        ### SCHEDULE MANAGER FUNCTIONS
+        $env:TF_VAR_FUNCTION_CHECK_SCHEDULE_SID = $schedule_manager_functions | where {$_.friendlyName -eq '/check-schedule'} | Select -property sid -ExpandProperty sid
+
+
+        $temp1 = $env:TF_VAR_SERVERLESS_DOMAIN
+        $temp2 = $env:TF_VAR_SCHEDULE_MANAGER_DOMAIN
         echo " - *Discovering Serverless Backends* " >> $env:GITHUB_STEP_SUMMARY
-        if($env:TF_VAR_SERVERLESS_DOMAIN_CUSTOM_FLEX) {
+        if($env:TF_VAR_SERVERLESS_DOMAIN) {
          echo "   - :white_check_mark: serverless backend: $temp1"  >> $env:GITHUB_STEP_SUMMARY
         } else {
           echo "   - :x: serverless backend not found"  >> $env:GITHUB_STEP_SUMMARY
         }
-        if($env:TF_VAR_SERVERLESS_DOMAIN_SCHEDULE_MANAGER) {
+        if($env:TF_VAR_SCHEDULE_MANAGER_DOMAIN) {
           echo "   - :white_check_mark: schedule manager: $temp2"  >> $env:GITHUB_STEP_SUMMARY
         } else {
           echo "   - :x: schedule manager backend not found"  >> $env:GITHUB_STEP_SUMMARY

--- a/infra-as-code/terraform/environments/default/main.tf
+++ b/infra-as-code/terraform/environments/default/main.tf
@@ -25,9 +25,14 @@ module "studio" {
   workflow_sid_internal_call = module.taskrouter.workflow_sid_internal_call
   chat_channel_sid = module.taskrouter.chat_channel_sid
   voice_channel_sid = module.taskrouter.voice_channel_sid
-  domain_custom_flex = var.SERVERLESS_DOMAIN_CUSTOM_FLEX
-  domain_schedule_manager = var.SERVERLESS_DOMAIN_SCHEDULE_MANAGER
-
+  serverless_domain = var.SERVERLESS_DOMAIN
+  serverless_sid = var.SERVERLESS_SID
+  serverless_env_sid = var.SERVERLESS_ENV_SID
+  schedule_manager_domain = var.SCHEDULE_MANAGER_DOMAIN
+  schedule_manager_sid = var.SCHEDULE_MANAGER_SID
+  schedule_manager_env_sid = var.SCHEDULE_MANAGER_ENV_SID
+  function_create_callback = var.FUNCTION_CREATE_CALLBACK
+  function_check_schedule_sid = var.FUNCTION_CHECK_SCHEDULE_SID
 }
 
 module "taskrouter" {

--- a/infra-as-code/terraform/environments/default/variables.tf
+++ b/infra-as-code/terraform/environments/default/variables.tf
@@ -62,7 +62,7 @@ variable "SCHEDULE_MANAGER_DOMAIN" {
 
 variable "SCHEDULE_MANAGER_SID" {
   type        = string
-  description = "serverless sid"
+  description = "schedule manager sid"
   validation {
     condition     = length(var.SCHEDULE_MANAGER_SID) > 2 && substr(var.SCHEDULE_MANAGER_SID, 0, 2) == "ZS"
     error_message = "SCHEDULE_MANAGER_SID expected to start with \"ZS\"."
@@ -80,7 +80,7 @@ variable "SCHEDULE_MANAGER_ENV_SID" {
 
 variable "FUNCTION_CREATE_CALLBACK" {
   type        = string
-  description = "get customer by phone function sid"
+  description = "create callback function sid"
   validation {
     condition     = length(var.FUNCTION_CREATE_CALLBACK) > 2 && substr(var.FUNCTION_CREATE_CALLBACK, 0, 2) == "ZH"
     error_message = "FUNCTION_CREATE_CALLBACK expected to start with \"ZH\"."
@@ -89,7 +89,7 @@ variable "FUNCTION_CREATE_CALLBACK" {
 
 variable "FUNCTION_CHECK_SCHEDULE_SID" {
   type        = string
-  description = "get customer by phone function sid"
+  description = "check schedule function sid"
   validation {
     condition     = length(var.FUNCTION_CHECK_SCHEDULE_SID) > 2 && substr(var.FUNCTION_CHECK_SCHEDULE_SID, 0, 2) == "ZH"
     error_message = "FUNCTION_CHECK_SCHEDULE_SID expected to start with \"ZH\"."

--- a/infra-as-code/terraform/environments/default/variables.tf
+++ b/infra-as-code/terraform/environments/default/variables.tf
@@ -24,22 +24,75 @@ variable "TWILIO_API_SECRET" {
   description = "Twilio API secret"
 }
 
-variable "SERVERLESS_DOMAIN_CUSTOM_FLEX" {
+variable "SERVERLESS_DOMAIN" {
   type        = string
-  description = "serverless domain for flex plugin"
+  description = "serverless domain"
   validation {
-    condition     = length(var.SERVERLESS_DOMAIN_CUSTOM_FLEX) > 34 && substr(var.SERVERLESS_DOMAIN_CUSTOM_FLEX, 0, 34) == "custom-flex-extensions-serverless-"
-    error_message = "SERVERLESS_DOMAIN_CUSTOM_FLEX expected to start with \"custom-flex-extensions-serverless-\"."
+    condition     = length(var.SERVERLESS_DOMAIN) > 34 && substr(var.SERVERLESS_DOMAIN, 0, 34) == "custom-flex-extensions-serverless-"
+    error_message = "SERVERLESS_DOMAIN expected to start with \"custom-flex-extensions-serverless-\"."
   }
 }
 
-variable "SERVERLESS_DOMAIN_SCHEDULE_MANAGER" {
+variable "SERVERLESS_SID" {
   type        = string
-  description = "serverless domain schedule manager for flex plugin"
+  description = "serverless sid"
   validation {
-    condition     = length(var.SERVERLESS_DOMAIN_SCHEDULE_MANAGER) > 17 && substr(var.SERVERLESS_DOMAIN_SCHEDULE_MANAGER, 0, 17) == "schedule-manager-"
-    error_message = "SERVERLESS_DOMAIN_SCHEDULE_MANAGER expected to start with \"schedule-manager-\"."
+    condition     = length(var.SERVERLESS_SID) > 2 && substr(var.SERVERLESS_SID, 0, 2) == "ZS"
+    error_message = "SERVERLESS_SID expected to start with \"ZS\"."
   }
 }
 
+variable "SERVERLESS_ENV_SID" {
+  type        = string
+  description = "serverless env sid"
+  validation {
+    condition     = length(var.SERVERLESS_ENV_SID) > 2 && substr(var.SERVERLESS_ENV_SID, 0, 2) == "ZE"
+    error_message = "SERVERLESS_ENV_SID expected to start with \"ZE\"."
+  }
+}
+
+variable "SCHEDULE_MANAGER_DOMAIN" {
+  type        = string
+  description = "schedule manager domain"
+  validation {
+    condition     = length(var.SCHEDULE_MANAGER_DOMAIN) > 17 && substr(var.SCHEDULE_MANAGER_DOMAIN, 0, 17) == "schedule-manager-"
+    error_message = "SCHEDULE_MANAGER_DOMAIN expected to start with \"schedule-manager-\"."
+  }
+}
+
+variable "SCHEDULE_MANAGER_SID" {
+  type        = string
+  description = "serverless sid"
+  validation {
+    condition     = length(var.SCHEDULE_MANAGER_SID) > 2 && substr(var.SCHEDULE_MANAGER_SID, 0, 2) == "ZS"
+    error_message = "SCHEDULE_MANAGER_SID expected to start with \"ZS\"."
+  }
+}
+
+variable "SCHEDULE_MANAGER_ENV_SID" {
+  type        = string
+  description = "schedule manager env sid"
+  validation {
+    condition     = length(var.SCHEDULE_MANAGER_ENV_SID) > 2 && substr(var.SCHEDULE_MANAGER_ENV_SID, 0, 2) == "ZE"
+    error_message = "SCHEDULE_MANAGER_ENV_SID expected to start with \"ZE\"."
+  }
+}
+
+variable "FUNCTION_CREATE_CALLBACK" {
+  type        = string
+  description = "get customer by phone function sid"
+  validation {
+    condition     = length(var.FUNCTION_CREATE_CALLBACK) > 2 && substr(var.FUNCTION_CREATE_CALLBACK, 0, 2) == "ZH"
+    error_message = "FUNCTION_CREATE_CALLBACK expected to start with \"ZH\"."
+  }
+}
+
+variable "FUNCTION_CHECK_SCHEDULE_SID" {
+  type        = string
+  description = "get customer by phone function sid"
+  validation {
+    condition     = length(var.FUNCTION_CHECK_SCHEDULE_SID) > 2 && substr(var.FUNCTION_CHECK_SCHEDULE_SID, 0, 2) == "ZH"
+    error_message = "FUNCTION_CHECK_SCHEDULE_SID expected to start with \"ZH\"."
+  }
+}
 

--- a/infra-as-code/terraform/modules/studio/main.tf
+++ b/infra-as-code/terraform/modules/studio/main.tf
@@ -28,8 +28,15 @@ resource "twilio_studio_flows_v2" "voice" {
 locals{
   params = {
     "WORKFLOW_SID_ASSIGN_TO_ANYONE" = var.workflow_sid_assign_to_anyone
-    "DOMAIN_CUSTOM_FLEX" = var.domain_custom_flex
-    "DOMAIN_SCHEDULE_MANAGER" = var.domain_schedule_manager
+    "WORKFLOW_SID_INBOUND_CALL" = var.workflow_sid_inbound_call
+    "SERVERLESS_DOMAIN" = var.serverless_domain
+    "SERVERLESS_SID" = var.serverless_sid
+    "SERVERLESS_ENV_SID" = var.serverless_env_sid
+    "SCHEDULE_MANAGER_DOMAIN" = var.schedule_manager_domain
+    "SCHEDULE_MANAGER_SID" = var.schedule_manager_sid
+    "SCHEDULE_MANAGER_ENV_SID" = var.schedule_manager_env_sid
+    "FUNCTION_CHECK_SCHEDULE_SID" = var.function_check_schedule_sid
+    "FUNCTION_CREATE_CALLBACK" = var.function_create_callback
     "CHAT_CHANNEL_SID" = var.chat_channel_sid
     "VOICE_CHANNEL_SID" = var.voice_channel_sid
   }

--- a/infra-as-code/terraform/modules/studio/main.tf
+++ b/infra-as-code/terraform/modules/studio/main.tf
@@ -28,7 +28,6 @@ resource "twilio_studio_flows_v2" "voice" {
 locals{
   params = {
     "WORKFLOW_SID_ASSIGN_TO_ANYONE" = var.workflow_sid_assign_to_anyone
-    "WORKFLOW_SID_INBOUND_CALL" = var.workflow_sid_inbound_call
     "SERVERLESS_DOMAIN" = var.serverless_domain
     "SERVERLESS_SID" = var.serverless_sid
     "SERVERLESS_ENV_SID" = var.serverless_env_sid

--- a/infra-as-code/terraform/modules/studio/variables.tf
+++ b/infra-as-code/terraform/modules/studio/variables.tf
@@ -52,20 +52,74 @@ variable "voice_channel_sid" {
   }
 }
 
-variable "domain_custom_flex" {
+variable "serverless_domain" {
   type        = string
   description = "serverless domain for flex plugin"
   validation {
-    condition     = length(var.domain_custom_flex) > 34 && substr(var.domain_custom_flex, 0, 34) == "custom-flex-extensions-serverless-"
-    error_message = "domain_custom_flex expected to start with \"custom-flex-extensions-serverless-\"."
+    condition     = length(var.serverless_domain) > 34 && substr(var.serverless_domain, 0, 34) == "custom-flex-extensions-serverless-"
+    error_message = "serverless_domain expected to start with \"custom-flex-extensions-serverless-\"."
   }
 }
 
-variable "domain_schedule_manager" {
+variable "serverless_sid" {
+  type        = string
+  description = "serverless sid"
+  validation {
+    condition     = length(var.serverless_sid) > 2 && substr(var.serverless_sid, 0, 2) == "ZS"
+    error_message = "serverless_sid expected to start with \"ZS\"."
+  }
+}
+
+variable "serverless_env_sid" {
+  type        = string
+  description = "serverless env sid"
+  validation {
+    condition     = length(var.serverless_env_sid) > 2 && substr(var.serverless_env_sid, 0, 2) == "ZE"
+    error_message = "serverless_env_sid expected to start with \"ZE\"."
+  }
+}
+
+variable "schedule_manager_domain" {
   type        = string
   description = "serverless domain schedule manager for flex plugin"
   validation {
-    condition     = length(var.domain_schedule_manager) > 17 && substr(var.domain_schedule_manager, 0, 17) == "schedule-manager-"
-    error_message = "domain_schedule_manager expected to start with \"schedule-manager-\"."
+    condition     = length(var.schedule_manager_domain) > 17 && substr(var.schedule_manager_domain, 0, 17) == "schedule-manager-"
+    error_message = "schedule_manager_domain expected to start with \"schedule-manager-\"."
+  }
+}
+
+variable "schedule_manager_sid" {
+  type        = string
+  description = "serverless sid"
+  validation {
+    condition     = length(var.schedule_manager_sid) > 2 && substr(var.schedule_manager_sid, 0, 2) == "ZS"
+    error_message = "schedule_manager_sid expected to start with \"ZS\"."
+  }
+}
+
+variable "schedule_manager_env_sid" {
+  type        = string
+  description = "schedule manager env sid"
+  validation {
+    condition     = length(var.schedule_manager_env_sid) > 2 && substr(var.schedule_manager_env_sid, 0, 2) == "ZE"
+    error_message = "schedule_manager_env_sid expected to start with \"ZE\"."
+  }
+}
+
+variable "function_create_callback" {
+  type        = string
+  description = "create callback function sid"
+  validation {
+    condition     = length(var.function_create_callback) > 2 && substr(var.function_create_callback, 0, 2) == "ZH"
+    error_message = "function_create_callback expected to start with \"ZH\"."
+  }
+}
+
+variable "function_check_schedule_sid" {
+  type        = string
+  description = "get customer by phone function sid"
+  validation {
+    condition     = length(var.function_check_schedule_sid) > 2 && substr(var.function_check_schedule_sid, 0, 2) == "ZH"
+    error_message = "function_check_schedule_sid expected to start with \"ZH\"."
   }
 }

--- a/infra-as-code/terraform/studio/voice-flow.json
+++ b/infra-as-code/terraform/studio/voice-flow.json
@@ -1,57 +1,57 @@
 {
-    "description": "IVR for creating a Flex voice task",
-    "states": [
-      {
-        "name": "Trigger",
-        "type": "trigger",
-        "transitions": [
-          {
-            "event": "incomingMessage"
-          },
-          {
-            "next": "SendCallToAgent",
-            "event": "incomingCall"
-          },
-          {
-            "event": "incomingRequest"
-          }
-        ],
-        "properties": {
-          "offset": {
-            "x": 0,
-            "y": -10
-          }
+  "description": "IVR for creating a Flex voice task",
+  "states": [
+    {
+      "name": "Trigger",
+      "type": "trigger",
+      "transitions": [
+        {
+          "event": "incomingMessage"
+        },
+        {
+          "next": "SendCallToAgent",
+          "event": "incomingCall"
+        },
+        {
+          "event": "incomingRequest"
         }
-      },
-      {
-        "name": "SendCallToAgent",
-        "type": "send-to-flex",
-        "transitions": [
-          {
-            "event": "callComplete"
-          },
-          {
-            "event": "failedToEnqueue"
-          },
-          {
-            "event": "callFailure"
-          }
-        ],
-        "properties": {
-          "offset": {
-            "x": 30,
-            "y": 180
-          },
-          "waitUrlMethod": "POST",
-          "waitUrl": "https://${DOMAIN_CUSTOM_FLEX}/features/callback-and-voicemail/studio/wait-experience?mode=initialize",
-          "workflow": "${WORKFLOW_SID_ASSIGN_TO_ANYONE}",
-          "channel": "${VOICE_CHANNEL_SID}",
-          "attributes": "{ \"type\": \"inbound\", \"name\": \"{{trigger.call.From}}\", \"conversations\": {\"hang_up_by\": \"Customer\"} }"
+      ],
+      "properties": {
+        "offset": {
+          "x": 0,
+          "y": -10
         }
       }
-    ],
-    "initial_state": "Trigger",
-    "flags": {
-      "allow_concurrent_calls": true
+    },
+    {
+      "name": "SendCallToAgent",
+      "type": "send-to-flex",
+      "transitions": [
+        {
+          "event": "callComplete"
+        },
+        {
+          "event": "failedToEnqueue"
+        },
+        {
+          "event": "callFailure"
+        }
+      ],
+      "properties": {
+        "offset": {
+          "x": 30,
+          "y": 180
+        },
+        "waitUrlMethod": "POST",
+        "waitUrl": "https://${SERVERLESS_DOMAIN}/features/callback-and-voicemail/studio/wait-experience?mode=initialize",
+        "workflow": "${WORKFLOW_SID_ASSIGN_TO_ANYONE}",
+        "channel": "${VOICE_CHANNEL_SID}",
+        "attributes": "{ \"type\": \"inbound\", \"name\": \"{{trigger.call.From}}\", \"conversations\": {\"hang_up_by\": \"Customer\"} }"
+      }
     }
+  ],
+  "initial_state": "Trigger",
+  "flags": {
+    "allow_concurrent_calls": true
   }
+}


### PR DESCRIPTION
### Summary

while doing some studio development recently, discovered there was some overhead still in creating references to functions in the studio flows.  Provisioning variables to be used for services along with two common studio function calls

- serverless - create callback
- schedule manager - check schedule 


