### PR TITLE
Teams view task card highlighting

### DIFF
--- a/docs/docs/feature-library/teams-view-enhancements.md
+++ b/docs/docs/feature-library/teams-view-enhancements.md
@@ -10,3 +10,5 @@ The Teams View can be modified by adding and removing columns in the [WorkersDat
 ![TeamsViewColumns](/img/features/teams-view-enhancements/teams-view-columns.png)
 
 The workers skills array can be re-formatted and shown in an additional column in the WorksDataTable of the Teams View.  This gives Supervisors a quicker way to review worker skills. Additionally, extra columns can be added to display worker attributes such as `team_name`, `department_name`, `location` or other custom attributes.
+
+We can highlight tasks that have a long handle time by adding a colored border around the Task Card based on the task age. For example, if the task is older than 3 minutes (180 seconds) we can show a yellow border. And if the task age exceeds 5 minutes (300 seconds) we can show red border. These thresholds are configurable in the Admin panel. This task highlighting may assist supervisors with observing how agents are performing, or if they are having challenges completing tasks within expected handling time ranges.  

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -230,6 +230,10 @@
       },
       "teams_view_enhancements": {
         "enabled": true,
+        "highlight_handle_time": true,
+        "handle_time_warning_threshold": 180,
+        "handle_time_exceeded_threshold": 300,
+        "display_task_queue_name": true,
         "columns": {
           "team": true,
           "department": false,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/config.ts
@@ -1,11 +1,17 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import TeamsViewEnhancementsConfig from './types/ServiceConfiguration';
 
-const { enabled = false } = (getFeatureFlags()?.features?.teams_view_enhancements as TeamsViewEnhancementsConfig) || {};
+const {
+  enabled = false,
+  highlight_handle_time = true,
+  handle_time_warning_threshold = 180,
+  handle_time_exceeded_threshold = 300,
+  display_task_queue_name = true,
+} = (getFeatureFlags()?.features?.teams_view_enhancements as TeamsViewEnhancementsConfig) || {};
 
 const {
-  team = true,
-  department = true,
+  team = false,
+  department = false,
   location = false,
   agent_skills = true,
 } = getFeatureFlags().features?.teams_view_enhancements?.columns || {};
@@ -28,4 +34,20 @@ export const isLocationColumnEnabled = () => {
 
 export const isAgentSkillsColumnEnabled = () => {
   return enabled && agent_skills;
+};
+
+export const isHTHighlightEnabled = () => {
+  return enabled && highlight_handle_time;
+};
+
+export const getHTWarningThreshold = () => {
+  return handle_time_warning_threshold;
+};
+
+export const getHTExceededThreshold = () => {
+  return handle_time_exceeded_threshold;
+};
+
+export const isDisplayTaskQueueNameEnabled = () => {
+  return enabled && display_task_queue_name;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/flex-hooks/components/TaskCardWrapper.Styles.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/flex-hooks/components/TaskCardWrapper.Styles.tsx
@@ -1,0 +1,23 @@
+import { styled } from '@twilio/flex-ui';
+
+export interface OwnProps {
+  age: number;
+  redLine: number;
+  yellowLine: number;
+}
+
+const getTaskHighlightColor = (props: OwnProps) => {
+  let color = 'white';
+  const taskAge = props.age;
+  if (taskAge > props.redLine) color = 'red';
+  else if (taskAge > props.yellowLine) color = 'yellow';
+  return color;
+};
+
+export const TaskCardBox = styled('div')<OwnProps>`
+  padding-left: 5px;
+  border-width: 3px;
+  border-radius: 10px;
+  border-style: solid;
+  border-color: ${(props) => getTaskHighlightColor(props)};
+`;

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/flex-hooks/components/TaskCardWrapper.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/flex-hooks/components/TaskCardWrapper.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import * as Flex from '@twilio/flex-ui';
+
+import { FlexComponent } from '../../../../types/feature-loader';
+import { TaskCardBox } from './TaskCardWrapper.Styles';
+import {
+  isHTHighlightEnabled,
+  getHTWarningThreshold,
+  getHTExceededThreshold,
+  isDisplayTaskQueueNameEnabled,
+} from '../../config';
+
+export const componentName = FlexComponent.TeamsView;
+export const componentHook = function addTaskCardWrapper(flex: typeof Flex, manager: Flex.Manager) {
+  if (isDisplayTaskQueueNameEnabled()) {
+    // instead of {{task.defaultFrom}}, show the queue name on the Task Card
+    manager.strings.SupervisorTaskCardHeader = '{{task.queueName}}';
+  }
+  if (isHTHighlightEnabled()) {
+    flex.Supervisor.TaskCard.Content.addWrapper((Original) => (originalProps) => {
+      const now = new Date();
+      const task = originalProps.task;
+      const dateUpdated = task?.dateUpdated;
+      let taskAge = 1;
+      if (dateUpdated) {
+        taskAge = (now.getTime() - dateUpdated?.getTime()) / 1000;
+      }
+      return (
+        <TaskCardBox age={taskAge} redLine={getHTExceededThreshold()} yellowLine={getHTWarningThreshold()}>
+          <Original {...originalProps} />
+        </TaskCardBox>
+      );
+    });
+  }
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/types/ServiceConfiguration.ts
@@ -1,5 +1,9 @@
 export default interface TeamsViewEnhancementsConfig {
   enabled: boolean;
+  highlight_handle_time: boolean;
+  handle_time_warning_threshold: number;
+  handle_time_exceeded_threshold: number;
+  display_task_queue_name: boolean;
   columns: {
     team: boolean;
     department: boolean;


### PR DESCRIPTION
### Summary

Adding a Task Card wrapper to enable highlighting with yellow or red border based on configurable Handle Time thresholds.
Show queue name on the Task Card instead of phone number

### Checklist

- [ ] Tested changes end to end
- [ ] Any config changes added to all environment files
- [ ] Completed README template for new features in `/docs/docs/feature-library/` and added feature row entry into the `/docs/docs/feature-library/00_overview.md` file
  - [ ] Feature summary - _high level summary of what the feature does_
  - [ ] Flex User Experience with animations - _animations with descriptions if necessary of the user experience in Flex_
  - [ ] Setup and dependencies - _description of any setup steps required for this feature_
  - [ ] How does it work? - _description of plumbing supporting feature_
- [ ] Added PR Label "ready-for-review"
- [ ] Requested one or more reviewers for the PR
