### PR TITLE
Pin some dependencies to fix TR SDK types issue

### DIFF
--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -38,7 +38,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-private-methods": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
-    "@twilio/flex-ui": "^2",
+    "@twilio/flex-ui": "2.3.3",
     "@types/jest": "^29.5.0",
     "@types/luxon": "^3.1.0",
     "@types/react-redux": "^7.1.1",
@@ -50,6 +50,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^16.0.0",
     "react-test-renderer": "17.0.2",
+    "twilio-taskrouter": "0.8.2",
     "typescript": "^5"
   },
   "jest": {


### PR DESCRIPTION
### Summary

TR SDK 0.8.3 changed type definitions in a way that broke how they were referenced by flex-ui. Pinning TR SDK to 0.8.2 in our package.json is enough to fix the issue. I also pinned flex-ui to 2.3.3 for now, so that we don't break again when the next release presumably fixes this. Once fixed I will return these dependencies to normal.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
