### PR TITLE
Add example workflow for auto deploys

### DIFF
--- a/.github/actions/terraform_state_artifact/action.yml
+++ b/.github/actions/terraform_state_artifact/action.yml
@@ -22,13 +22,13 @@ inputs:
     required: false
     default: ''
   environment:
-    description: 'Envirnoment associated with the state file'
+    description: 'Environment associated with the state file'
     required: true
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: hashicorp/setup-terraform@v2
     - id: terraform
       working-directory: ${{ inputs.path }}

--- a/.github/examples/merge_deploy.yaml
+++ b/.github/examples/merge_deploy.yaml
@@ -1,0 +1,27 @@
+name: Deploy Flex on Merge
+
+# This is an example workflow for automatically triggered deployments
+# Copy this file to the workflows directory to use it
+
+on:
+  push:
+    branches:
+      # Change the branches below to match your desired configuration
+      # These should be protected branches
+      - develop
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/flex_deploy.yaml
+    with:
+      # Change inputs below to match your desired configuration
+      # Uses the 'production' env when pushing to the main branch, or 'dev' env when pushing to the develop branch
+      environment: ${{ github.ref_name == 'main' && 'production' || 'dev' }}
+      deploy_terraform: true
+      overwrite_config: false
+    secrets:
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
+      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
+      TF_ENCRYPTION_KEY: ${{ secrets.TF_ENCRYPTION_KEY }}

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -1,12 +1,28 @@
 name: Deploy Flex
 
 on:
-  # Run on merge to main
-  #push:
-  #  branches:
-  #  - main
-
-  # Enable running this workflow manually from the Actions tab
+  # To run this workflow via automated triggers, see the .github/examples directory.
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      deploy_terraform:
+        required: true
+        type: boolean
+      overwrite_config:
+        required: true
+        type: boolean
+    secrets:
+      TWILIO_ACCOUNT_SID:
+        required: true
+      TWILIO_API_KEY:
+        required: true
+      TWILIO_API_SECRET:
+        required: true
+      TF_ENCRYPTION_KEY:
+        required: true
+  # Enables running this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       environment:
@@ -36,12 +52,12 @@ jobs:
   # the domain name can be pulled in for the terraform deploy
   perform-initial-serverless-release:
     if: |
-      (github.event.inputs.initial_release == 'true' && 
-       github.event.inputs.deploy_terraform == 'true')
+      (inputs.initial_release == true && 
+       inputs.deploy_terraform == true)
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     env:
-      ENVIRONMENT: ${{ github.event.inputs.environment }}
+      ENVIRONMENT: ${{ inputs.environment }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
@@ -75,11 +91,11 @@ jobs:
       always() &&
         !contains(needs.*.result, 'failure') &&
         !contains(needs.*.result, 'cancelled') &&
-      github.event.inputs.deploy_terraform == 'true'
+      inputs.deploy_terraform == true
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     env:
-      ENVIRONMENT: ${{ github.event.inputs.environment }}
+      ENVIRONMENT: ${{ inputs.environment }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
@@ -88,12 +104,12 @@ jobs:
       TF_VAR_TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
     needs: [perform-initial-serverless-release]
     steps:
-      - uses: actions/checkout@v1 
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/terraform_state_artifact
         with:
           encryptionkey: ${{ secrets.TF_ENCRYPTION_KEY }}
           path: ./infra-as-code/terraform/environments/default
-          environment: ${{ github.event.inputs.environment }}
+          environment: ${{ inputs.environment }}
 
 
   deploy-serverless:
@@ -102,9 +118,9 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     env:
-      ENVIRONMENT: ${{ github.event.inputs.environment }}
+      ENVIRONMENT: ${{ inputs.environment }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
@@ -140,9 +156,9 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     env:
-      ENVIRONMENT: ${{ github.event.inputs.environment }}
+      ENVIRONMENT: ${{ inputs.environment }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
@@ -171,14 +187,14 @@ jobs:
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     env:
-      ENVIRONMENT:  ${{ github.event.inputs.environment }}
+      ENVIRONMENT: ${{ inputs.environment }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
-      OVERWRITE_CONFIG: ${{ github.event.inputs.initial_release == 'true' || github.event.inputs.overwrite_config == 'true' }}
+      OVERWRITE_CONFIG: ${{ inputs.initial_release == true || inputs.overwrite_config == true }}
     needs: [deploy-serverless, deploy-schedule-manager]
     steps:
       - uses: actions/checkout@v3
@@ -200,7 +216,7 @@ jobs:
 
   deploy-release-plugin:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     env:
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
@@ -219,7 +235,7 @@ jobs:
       - name: deploy and release flex-plugin
         run: |
           echo "### Job summary" >> $GITHUB_STEP_SUMMARY
-          echo " - Environment: ${{ github.event.inputs.environment }}"  >> $GITHUB_STEP_SUMMARY
+          echo " - Environment: ${{ inputs.environment }}"  >> $GITHUB_STEP_SUMMARY
           echo " - Plugin Folder: ${{ env.PLUGIN_FOLDER }}"  >> $GITHUB_STEP_SUMMARY
           cd $PLUGIN_FOLDER
           npm install


### PR DESCRIPTION
### Summary

Currently we offer an example solution only for manual deployments (the `workflow_dispatch` trigger). However, development organizations using the template likely want to automatically perform deployments to various environments based on automated triggers, such as a push to a certain branch.

The existing workflow uses trigger inputs for various decisions, which are not available for push triggers and other automatic triggers. This PR adds the plumbing required to support both manual and automated triggers. To support both use cases without duplicating a substantial amount of code, we call the `flex_deploy` workflow as a _nested_ workflow (via the `workflow_call` trigger).

An example `merge_deploy.yaml` workflow is included that deploys to an environment based on a push to a branch.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
