### PR TITLE
Fix localizability of callback task names

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import PhoneCallbackIcon from '@material-ui/icons/PhoneCallback';
 
 import { TaskAttributes } from '../../../../types/task-router/Task';
+import { StringTemplates } from '../strings/Callback';
 
-export const channelHook = function createCallbackChannel(flex: typeof Flex, _manager: Flex.Manager) {
+export const channelHook = function createCallbackChannel(flex: typeof Flex, manager: Flex.Manager) {
   const channelDefinition = flex.DefaultTaskChannels.createDefaultTaskChannel(
     'callback',
     (task) => {
@@ -16,6 +17,13 @@ export const channelHook = function createCallbackChannel(flex: typeof Flex, _ma
     'palegreen',
   );
 
+  const getTaskName = (task: Flex.ITask, queue: boolean): string => {
+    if (queue) {
+      return `${task.queueName}: ${(manager.strings as any)[StringTemplates.Callback]} (${task.attributes.name})`;
+    }
+    return `${(manager.strings as any)[StringTemplates.Callback]} (${task.attributes.name})`;
+  };
+
   const { templates } = channelDefinition;
   const CallbackChannel: Flex.TaskChannelDefinition = {
     ...channelDefinition,
@@ -23,15 +31,30 @@ export const channelHook = function createCallbackChannel(flex: typeof Flex, _ma
       ...templates,
       TaskListItem: {
         ...templates?.TaskListItem,
-        firstLine: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
+        firstLine: (task: Flex.ITask) => getTaskName(task, true),
       },
       TaskCanvasHeader: {
         ...templates?.TaskCanvasHeader,
-        title: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
+        title: (task: Flex.ITask) => getTaskName(task, true),
       },
       IncomingTaskCanvas: {
         ...templates?.IncomingTaskCanvas,
-        firstLine: (task: Flex.ITask) => task.queueName,
+        firstLine: (task: Flex.ITask) => getTaskName(task, true),
+      },
+      TaskCard: {
+        ...templates?.TaskCard,
+        firstLine: (task: Flex.ITask) => getTaskName(task, false),
+      },
+      Supervisor: {
+        ...templates?.Supervisor,
+        TaskCanvasHeader: {
+          ...templates?.Supervisor?.TaskCanvasHeader,
+          title: (task: Flex.ITask) => getTaskName(task, false),
+        },
+        TaskOverviewCanvas: {
+          ...templates?.Supervisor?.TaskOverviewCanvas,
+          firstLine: (task: Flex.ITask) => getTaskName(task, true),
+        },
       },
     },
     icons: {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import VoicemailIcon from '@material-ui/icons/Voicemail';
 
 import { TaskAttributes } from '../../../../types/task-router/Task';
+import { StringTemplates } from '../strings/Callback';
 
-export const channelHook = function createVoicemailChannel(flex: typeof Flex, _manager: Flex.Manager) {
+export const channelHook = function createVoicemailChannel(flex: typeof Flex, manager: Flex.Manager) {
   const channelDefinition = flex.DefaultTaskChannels.createDefaultTaskChannel(
     'voicemail',
     (task) => {
@@ -16,6 +17,13 @@ export const channelHook = function createVoicemailChannel(flex: typeof Flex, _m
     'deepskyblue',
   );
 
+  const getTaskName = (task: Flex.ITask, queue: boolean): string => {
+    if (queue) {
+      return `${task.queueName}: ${(manager.strings as any)[StringTemplates.Voicemail]} (${task.attributes.name})`;
+    }
+    return `${(manager.strings as any)[StringTemplates.Voicemail]} (${task.attributes.name})`;
+  };
+
   const { templates } = channelDefinition;
   const VoicemailChannel: Flex.TaskChannelDefinition = {
     ...channelDefinition,
@@ -23,15 +31,30 @@ export const channelHook = function createVoicemailChannel(flex: typeof Flex, _m
       ...templates,
       TaskListItem: {
         ...templates?.TaskListItem,
-        firstLine: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
+        firstLine: (task: Flex.ITask) => getTaskName(task, true),
       },
       TaskCanvasHeader: {
         ...templates?.TaskCanvasHeader,
-        title: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
+        title: (task: Flex.ITask) => getTaskName(task, true),
       },
       IncomingTaskCanvas: {
         ...templates?.IncomingTaskCanvas,
-        firstLine: (task: Flex.ITask) => task.queueName,
+        firstLine: (task: Flex.ITask) => getTaskName(task, true),
+      },
+      TaskCard: {
+        ...templates?.TaskCard,
+        firstLine: (task: Flex.ITask) => getTaskName(task, false),
+      },
+      Supervisor: {
+        ...templates?.Supervisor,
+        TaskCanvasHeader: {
+          ...templates?.Supervisor?.TaskCanvasHeader,
+          title: (task: Flex.ITask) => getTaskName(task, false),
+        },
+        TaskOverviewCanvas: {
+          ...templates?.Supervisor?.TaskOverviewCanvas,
+          firstLine: (task: Flex.ITask) => getTaskName(task, true),
+        },
       },
     },
     icons: {

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/strings/Callback.ts
@@ -24,6 +24,8 @@ export enum StringTemplates {
   VoicemailLoading = 'PSCallbackVoicemailLoading',
   VoicemailError = 'PSCallbackVoicemailError',
   VoicemailTryAgain = 'PSCallbackVoicemailTryAgain',
+  Callback = 'PSCallbackCallback',
+  Voicemail = 'PSCallbackVoicemail',
 }
 
 export const stringHook = () => ({
@@ -47,6 +49,8 @@ export const stringHook = () => ({
     [StringTemplates.VoicemailLoading]: 'Loading voicemail...',
     [StringTemplates.VoicemailError]: 'Error loading voicemail.',
     [StringTemplates.VoicemailTryAgain]: 'Try again',
+    [StringTemplates.Callback]: 'Callback',
+    [StringTemplates.Voicemail]: 'Voicemail',
   },
   'es-MX': esMX,
   'pt-BR': ptBR,

--- a/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
@@ -31,7 +31,7 @@ exports.createCallbackTask = async (parameters) => {
   // setup required task attributes for task
   const attributes = {
     taskType: recordingSid ? 'voicemail' : 'callback',
-    name: `${recordingSid ? 'Voicemail' : 'Callback'} (${numberToCall})`,
+    name: numberToCall,
     flow_execution_sid: flexFlowSid,
     message: message || null,
     callBackData: {


### PR DESCRIPTION
### Summary

Moves the callback/voicemail task label to the Flex TaskChannelDefinition instead of the task itself, so we can localize it.

### Checklist

- [x] Tested changes end to end
- [x] Added PR Label "ready-for-review"
- [x] Requested one or more reviewers for the PR
