### PR TITLE
Clear old config when submitting global config updates

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -88,7 +88,7 @@ const AdminView = () => {
     setUserConfig(featuresUser);
   };
 
-  const handleSave = async (feature: string, config: any): Promise<boolean> => {
+  const handleSave = async (feature: string, config: any, mergeFeature: boolean): Promise<boolean> => {
     if (configureFor === 'user') {
       const saveResult = await saveUserConfig(feature, config);
 
@@ -102,7 +102,7 @@ const AdminView = () => {
         return false;
       }
 
-      const saveResult = await saveGlobalConfig(feature, config);
+      const saveResult = await saveGlobalConfig(feature, config, mergeFeature);
 
       if (saveResult) {
         publishMessage({ event: streamEvent });

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureCard/FeatureCard.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureCard/FeatureCard.tsx
@@ -13,7 +13,7 @@ interface Props {
   configureFor: string;
   isUserModified?: boolean;
   config: any;
-  handleSave: (feature: string, config: any) => Promise<boolean>;
+  handleSave: (feature: string, config: any, mergeFeature: boolean) => Promise<boolean>;
 }
 
 const FeatureCard = ({ feature, configureFor, isUserModified, config, handleSave }: Props) => {
@@ -24,13 +24,13 @@ const FeatureCard = ({ feature, configureFor, isUserModified, config, handleSave
 
   const handleReset = async () => {
     setIsSaving(true);
-    await handleSave(feature, undefined);
+    await handleSave(feature, undefined, true);
     setIsSaving(false);
   };
 
   const handleEnabledChanged = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsSaving(true);
-    await handleSave(feature, { enabled: e.target.checked });
+    await handleSave(feature, { enabled: e.target.checked }, true);
     setIsSaving(false);
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureModal/FeatureModal.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureModal/FeatureModal.tsx
@@ -16,7 +16,7 @@ interface Props {
   config: any;
   isOpen: boolean;
   handleClose: () => void;
-  handleSave: (feature: string, config: any) => Promise<boolean>;
+  handleSave: (feature: string, config: any, mergeFeature: boolean) => Promise<boolean>;
 }
 
 interface CustomComponentPayload {
@@ -103,7 +103,7 @@ const FeatureModal = ({ feature, configureFor, isUserModified, config, isOpen, h
       }
     });
 
-    if (await handleSave(feature, modifiedConfig)) {
+    if (await handleSave(feature, modifiedConfig, false)) {
       handleClose();
     } else {
       setHasFailure(true);
@@ -114,7 +114,7 @@ const FeatureModal = ({ feature, configureFor, isUserModified, config, isOpen, h
   const reset = async () => {
     setHasFailure(false);
     setIsResetting(true);
-    if (await handleSave(feature, undefined)) {
+    if (await handleSave(feature, undefined, true)) {
       handleClose();
     } else {
       setHasFailure(true);

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/AdminUiService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/AdminUiService.ts
@@ -30,11 +30,12 @@ class AdminUiService extends ApiService {
     });
   };
 
-  updateUiAttributes = async (attributesUpdate: string): Promise<AdminUiServiceReponse> => {
+  updateUiAttributes = async (attributesUpdate: string, mergeFeature: boolean): Promise<AdminUiServiceReponse> => {
     return new Promise((resolve, reject) => {
       const encodedParams: EncodedParams = {
         Token: encodeURIComponent(this.manager.store.getState().flex.session.ssoTokenPayload.token),
         attributesUpdate: encodeURIComponent(attributesUpdate),
+        mergeFeature: encodeURIComponent(mergeFeature),
       };
 
       this.fetchJsonWithReject<AdminUiServiceReponse>(

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/helpers.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/helpers.ts
@@ -96,7 +96,7 @@ export const saveUserConfig = async (feature: string, config: any): Promise<bool
   return true;
 };
 
-export const saveGlobalConfig = async (feature: string, config: any): Promise<any> => {
+export const saveGlobalConfig = async (feature: string, config: any, mergeFeature: boolean): Promise<any> => {
   let returnVal = false;
   try {
     const updateResponse = await AdminUiService.updateUiAttributes(
@@ -107,6 +107,7 @@ export const saveGlobalConfig = async (feature: string, config: any): Promise<an
           },
         },
       }),
+      mergeFeature,
     );
     if (updateResponse?.configuration?.custom_data?.features) {
       returnVal = updateResponse.configuration.custom_data.features;

--- a/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
+++ b/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
@@ -7,7 +7,7 @@ const requiredParameters = [{ key: 'attributesUpdate', purpose: 'ui_attributes t
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
-    const { attributesUpdate, TokenResult } = event;
+    const { attributesUpdate, mergeFeature, TokenResult } = event;
 
     if (TokenResult.roles.indexOf('admin') < 0) {
       response.setStatusCode(403);
@@ -17,6 +17,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
 
     const result = await Configuration.updateUiAttributes({
       attributesUpdate,
+      mergeFeature,
       context,
     });
 


### PR DESCRIPTION
### Summary

Prevents deep merges within a feature’s config. Example: When configuring activity-skill-filter, if you wanted to remove an activity, the deep merge would've prevented that prior to this PR, and now it respects the user's input.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
