### PR TITLE
Allow Windows line endings in Prettier

### DIFF
--- a/plugin-flex-ts-template-v2/.eslintrc.js
+++ b/plugin-flex-ts-template-v2/.eslintrc.js
@@ -23,6 +23,12 @@ module.exports = {
     'prefer-destructuring': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-promise-reject-errors': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-identical-functions': 'off',
     'sonarjs/no-duplicate-string': 'off',

--- a/serverless-functions/.eslintrc.js
+++ b/serverless-functions/.eslintrc.js
@@ -19,6 +19,12 @@ module.exports = {
     'prefer-destructuring': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-promise-reject-errors': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-identical-functions': 'off',
     'sonarjs/no-duplicate-string': 'off',

--- a/serverless-schedule-manager/.eslintrc.js
+++ b/serverless-schedule-manager/.eslintrc.js
@@ -19,6 +19,12 @@ module.exports = {
     'prefer-destructuring': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-promise-reject-errors': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-identical-functions': 'off',
     'sonarjs/no-duplicate-string': 'off',


### PR DESCRIPTION
### Summary

Windows uses CRLF instead of LF; allow it through Prettier since git normalizes to LF by default anyway.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
