### PR TITLE
Add input select option to device-manager

### DIFF
--- a/docs/docs/feature-library/device-manager.md
+++ b/docs/docs/feature-library/device-manager.md
@@ -21,20 +21,11 @@ After selecting an audio device, a `Toast notification` is shown to indicate the
 
 There are no additional dependencies for setup beyond ensuring the flag is enabled within the `flex-config` attributes.
 
-To enable the `Device Manager` feature, under the `flex-config` attributes set the `device_manager` `enabled` flag to `true`:
+To enable the `Device Manager` feature, under the `flex-config` attributes set the `device_manager` `enabled` flag to `true`. You may also separate the output and input device selection by setting `input_select` to `true`.
 
 ```json
 "device_manager": {
-    "enabled": true
+    "enabled": true,
+    "input_select": true
 }
 ```
-
----
-
-## Changelog
-
-### 1.0
-
-**October 5, 2022**
-
-- Upgraded [original plugin code](https://github.com/jhunter-twilio/plugin-select-audio-device) to template structure & Flex 2.0 with Twilio Paste.

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -78,7 +78,8 @@
         "default_max_capacity": 2
       },
       "device_manager": {
-        "enabled": true
+        "enabled": true,
+        "input_select": false
       },
       "dual_channel_recording": {
         "enabled": false,

--- a/plugin-flex-ts-template-v2/src/feature-library/device-manager/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/device-manager/config.ts
@@ -1,8 +1,13 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import DeviceManagerConfig from './types/ServiceConfiguration';
 
-const { enabled = false } = (getFeatureFlags()?.features?.device_manager as DeviceManagerConfig) || {};
+const { enabled = false, input_select = false } =
+  (getFeatureFlags()?.features?.device_manager as DeviceManagerConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const isInputSelectEnabled = () => {
+  return input_select;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/device-manager/custom-components/DeviceManager/DeviceManager.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/device-manager/custom-components/DeviceManager/DeviceManager.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Manager, templates } from '@twilio/flex-ui';
+import { Device } from '@twilio/voice-sdk';
 import { Flex, MenuButton, MenuGroup, useMenuState, Menu, MenuItem, useToaster, Toaster } from '@twilio-paste/core';
+import { MicrophoneOnIcon } from '@twilio-paste/icons/esm/MicrophoneOnIcon';
 import { VolumeOnIcon } from '@twilio-paste/icons/esm/VolumeOnIcon';
 import { AgentIcon } from '@twilio-paste/icons/esm/AgentIcon';
 
+import { isInputSelectEnabled } from '../../config';
 import { SecondDevice } from '../../../multi-call/helpers/MultiCallHelper';
 import { isFeatureEnabled as isMultiCallEnabled } from '../../../multi-call/config';
 import { StringTemplates } from '../../flex-hooks/strings';
@@ -19,27 +22,32 @@ const DeviceManager: React.FunctionComponent = () => {
     });
   }
 
-  const selectedDevice = (selectedDevice: MediaDeviceInfo) => {
-    try {
-      const { voiceClient } = Manager.getInstance();
-
+  const setSelectedDevice = (selectedDevice: MediaDeviceInfo, voiceClient: Device) => {
+    if (selectedDevice.kind === 'audiooutput') {
       voiceClient?.audio?.speakerDevices.set(selectedDevice.deviceId);
+    } else {
+      voiceClient?.audio?.setInputDevice(selectedDevice.deviceId);
+    }
 
+    // If user-selected inputs are disabled, automatically select the corresponding input device, if present.
+    if (!isInputSelectEnabled()) {
       devices?.forEach((device: MediaDeviceInfo) => {
         if (device.groupId === selectedDevice.groupId && device.kind === 'audioinput') {
           voiceClient?.audio?.setInputDevice(device.deviceId);
         }
       });
+    }
+  };
+
+  const selectedDevice = (selectedDevice: MediaDeviceInfo) => {
+    try {
+      const { voiceClient } = Manager.getInstance();
+
+      setSelectedDevice(selectedDevice, voiceClient);
 
       // set SecondDevice options if multi-call feature is enabled
-      if (isMultiCallEnabled()) {
-        SecondDevice?.audio?.speakerDevices.set(selectedDevice.deviceId);
-
-        devices?.forEach((device: MediaDeviceInfo) => {
-          if (device.groupId === selectedDevice.groupId && device.kind === 'audioinput') {
-            SecondDevice?.audio?.setInputDevice(device.deviceId);
-          }
-        });
+      if (isMultiCallEnabled() && SecondDevice) {
+        setSelectedDevice(selectedDevice, SecondDevice);
       }
 
       menu.hide();
@@ -73,7 +81,14 @@ const DeviceManager: React.FunctionComponent = () => {
           <AgentIcon decorative={false} title={templates[StringTemplates.SelectAudioDevice]()} />
         </MenuButton>
         <Menu {...menu} aria-label="Actions">
-          <MenuGroup label={templates[StringTemplates.SelectAudioDevice]()} icon={<VolumeOnIcon decorative />}>
+          <MenuGroup
+            label={
+              isInputSelectEnabled()
+                ? templates[StringTemplates.SelectOutputDevice]()
+                : templates[StringTemplates.SelectAudioDevice]()
+            }
+            icon={<VolumeOnIcon decorative />}
+          >
             {devices
               .filter((device) => device.kind === 'audiooutput')
               .map((device) => (
@@ -82,6 +97,17 @@ const DeviceManager: React.FunctionComponent = () => {
                 </MenuItem>
               ))}
           </MenuGroup>
+          {isInputSelectEnabled() && (
+            <MenuGroup label={templates[StringTemplates.SelectInputDevice]()} icon={<MicrophoneOnIcon decorative />}>
+              {devices
+                .filter((device) => device.kind === 'audioinput')
+                .map((device) => (
+                  <MenuItem {...menu} onClick={() => selectedDevice(device)} key={device.deviceId}>
+                    {device.label}
+                  </MenuItem>
+                ))}
+            </MenuGroup>
+          )}
         </Menu>
         <Toaster {...toaster} />
       </Flex>

--- a/plugin-flex-ts-template-v2/src/feature-library/device-manager/flex-hooks/strings/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/device-manager/flex-hooks/strings/index.ts
@@ -9,6 +9,8 @@ export enum StringTemplates {
   SelectAudioDevice = 'PSDeviceMgrSelectAudioDevice',
   SetDeviceSuccess = 'PSDeviceMgrSetDeviceSuccess',
   SetDeviceError = 'PSDeviceMgrSetDeviceError',
+  SelectOutputDevice = 'PSDeviceMgrSelectOutputDevice',
+  SelectInputDevice = 'PSDeviceMgrSelectInputDevice',
 }
 
 export const stringHook = () => ({
@@ -16,6 +18,8 @@ export const stringHook = () => ({
     [StringTemplates.SelectAudioDevice]: 'Select an audio device',
     [StringTemplates.SetDeviceSuccess]: 'Set {{selectedDevice}} as your audio device.',
     [StringTemplates.SetDeviceError]: 'There was an error attempting to set {{selectedDevice}} as your audio device.',
+    [StringTemplates.SelectOutputDevice]: 'Select an output device',
+    [StringTemplates.SelectInputDevice]: 'Select an input device',
   },
   'es-MX': esMX,
   'pt-BR': ptBR,

--- a/plugin-flex-ts-template-v2/src/feature-library/device-manager/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/device-manager/types/ServiceConfiguration.ts
@@ -1,3 +1,4 @@
 export default interface DeviceManagerConfig {
   enabled: boolean;
+  input_select: boolean;
 }


### PR DESCRIPTION
### Summary

Adds configurable option to separate the input and output selections in device-manager. The current behavior remains the default.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
