### PR TITLE
Teams view filters fixes

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilter/SelectFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { styled, templates } from '@twilio/flex-ui';
 import { Select, Option } from '@twilio-paste/core/select';
@@ -31,24 +31,29 @@ export const MultiSelectFilter = (props: OwnProps) => {
   const pillState = useFormPillState();
   const dispatch = useDispatch();
   const [selectedItems, setSelectedItems] = useState([] as string[]);
+  const userChange = useRef(false);
 
   const { selectedQueue } = useSelector(
     (state: AppState) => state[reduxNamespace].queueNoWorkerDataFilter as QueueNoWorkerDataFilterState,
   );
 
   useEffect(() => {
-    if (props.handleChange) {
+    if (userChange.current && props.handleChange) {
       props.handleChange(selectedItems);
+      userChange.current = false;
     }
   }, [selectedItems]);
 
   useEffect(() => {
-    if (!props.currentValue) {
+    if (props.currentValue) {
+      setSelectedItems(props.currentValue);
+    } else {
       // This is a bit of a hack to enable the queueNoWorkerDataFilter to render the currently filtered queue accurately.
       // Because that filter actually applies skill filters instead via logic in beforeApplyTeamsViewFilters,
       // our component's value is 'reset' by Flex. The beforeApplyTeamsViewFilters logic saves and resets the selected queue
       // in state, so we can rely on that to know when to persist the selected queue versus when to actually reset.
       // The name 'queue' is unique to the queueNoWorkerDataFilter (queueWorkerDataFilter uses the name 'queues' instead).
+      userChange.current = true;
       if (props.name === 'queue' && selectedQueue !== '' && selectedQueue !== ResetQueuePlaceholder) {
         setSelectedItems([selectedQueue]);
         return;
@@ -65,6 +70,7 @@ export const MultiSelectFilter = (props: OwnProps) => {
     // queue to equal ResetQueuePlaceholder, which is a bespoke value we catch here to trigger the reset.
     // Here, we then change state again, so that if an invalid queue is selected again, there is a state change to trigger reset.
     if (props.name === 'queue' && selectedQueue === ResetQueuePlaceholder) {
+      userChange.current = true;
       setSelectedItems([]);
       dispatch(selectQueue(''));
     }
@@ -74,6 +80,7 @@ export const MultiSelectFilter = (props: OwnProps) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (!e.target.value) return;
+    userChange.current = true;
 
     if (props.IsMulti) {
       setSelectedItems((selectedItems) => [...selectedItems, e.target.value]);
@@ -83,6 +90,7 @@ export const MultiSelectFilter = (props: OwnProps) => {
   };
 
   const deselectItem = (item: FilterDefinitionOption) => {
+    userChange.current = true;
     setSelectedItems((selectedItems) => [...selectedItems.filter((i) => i !== item.value)]);
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilterLabel/SelectFilterLabel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/custom-components/SelectFilterLabel/SelectFilterLabel.tsx
@@ -4,12 +4,13 @@ import { StringTemplates } from '../../flex-hooks/strings/TeamViewQueueFilter';
 
 export type OwnProps = {
   currentValue?: string[];
+  activeOption?: any;
 };
 
 export const SelectFilterLabel = (props: OwnProps) => {
   let label = templates.FilterItemAny();
   if (props.currentValue && props.currentValue.length === 1) {
-    label = templates[StringTemplates.FilterOnly]({ selected: props.currentValue[0] });
+    label = templates[StringTemplates.FilterOnly]({ selected: props.activeOption?.label ?? props.currentValue[0] });
   }
   if (props.currentValue && props.currentValue.length > 1) {
     label = templates.FilterItemAmountSelected({ amount: props.currentValue.length });

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/agentSkillsFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/agentSkillsFilter.tsx
@@ -1,4 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
+import { sortBy } from 'lodash';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';
@@ -26,7 +27,7 @@ export const agentSkillsFilter = () =>
     id: 'data.attributes.routing.skills',
     title: (Manager.getInstance().strings as any)[StringTemplates.AgentSkills],
     fieldName: 'skills',
-    options: skillsArray ? skillsArray : [],
+    options: skillsArray ? sortBy(skillsArray, ['label']) : [],
     customStructure: {
       field: <SelectFilter IsMulti={true} />,
       label: <SelectFilterLabel />,

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
@@ -1,4 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
+import { sortBy } from 'lodash';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';
@@ -47,7 +48,7 @@ export const queueNoWorkerDataFilter = async () => {
       label: <SelectFilterLabel />,
       field: <SelectFilter IsMulti={false} />,
     },
-    options,
+    options: sortBy(options, ['label']),
     condition: 'IN',
   } as FilterDefinition;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
@@ -1,4 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
+import { sortBy } from 'lodash';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';
@@ -36,7 +37,7 @@ export const queueWorkerDataFilter = async () => {
       label: <SelectFilterLabel />,
       field: <SelectFilter IsMulti={true} />,
     },
-    options,
+    options: sortBy(options, ['label']),
     condition: 'IN',
   } as FilterDefinition;
 };

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/teams-filters.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/teams-filters.ts
@@ -18,6 +18,19 @@ export const init = async (flex: typeof Flex, manager: Flex.Manager) => {
   }
 
   flex.TeamsView.defaultProps.filters = customFilters;
+
+  // Because some filters may be async, the default filters will not apply automatically.
+  const defaultFilters = customFilters
+    .filter((filter) => filter.options && filter.options.filter((option) => option.default).length)
+    .map((filter) => ({
+      name: filter.id,
+      condition: (filter.condition as Flex.FilterConditions) || Flex.FilterConditions.IN,
+      values: filter.options?.filter((option) => option.default).map((option) => option.value) || [],
+    }));
+  if (!defaultFilters.length) return;
+  Flex.Actions.invokeAction('ApplyTeamsViewFilters', {
+    filters: defaultFilters,
+  });
 };
 
 export const addHook = (flex: typeof Flex, manager: Flex.Manager, feature: string, hook: any) => {


### PR DESCRIPTION
### Summary

- Fixed async filters breaking automatic applying of default filter options
  - Note: tested that the ApplyTeamsViewFilters action is harmless with only an agent role
- Fixed the multiselect component's handling of default options
- Fixed the multiselect component forgetting its state when the filters panel is closed then reopened
- Sorted the queues and skills filters

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
