### PR TITLE
Define concurrency group to queue workflow runs

### DIFF
--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -48,7 +48,7 @@ on:
         description: Overwrite config set by Admin UI Panel?
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ github.ref }}
 
 jobs:
 

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -47,6 +47,9 @@ on:
         default: false
         description: Overwrite config set by Admin UI Panel?
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
 
   # When performing an initial release

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -48,7 +48,7 @@ on:
         description: Overwrite config set by Admin UI Panel?
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.environment || github.event.inputs.environment }}-${{ github.ref }}
 
 jobs:
 

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -48,7 +48,7 @@ on:
         description: Overwrite config set by Admin UI Panel?
 
 concurrency:
-  group: flex-deploy-${{ inputs.environment || github.event.inputs.environment }}-${{ github.ref }}
+  group: flex-deploy-${{ inputs.environment || github.event.inputs.environment }}
 
 jobs:
 

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -48,7 +48,7 @@ on:
         description: Overwrite config set by Admin UI Panel?
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.environment || github.event.inputs.environment }}-${{ github.ref }}
+  group: flex-deploy-${{ inputs.environment || github.event.inputs.environment }}-${{ github.ref }}
 
 jobs:
 


### PR DESCRIPTION
### Summary

Plugin deployments can race while multiple workflow executions run concurrently. This can result in a plugin release with a previous commits plugin code. This change uses the built-in queuing mechanism to single-thread the deployments per environment.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
