### PR TITLE
Automatically set env vars from GitHub

### DIFF
--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -60,15 +60,17 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       ENVIRONMENT: ${{ inputs.environment }}
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
-      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
     steps:
       - uses: actions/checkout@v3
       - name: setup node.js
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+      - name: set github environment variables
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
+        run: scripts/github-set-env.sh
       - name: install top-level packages
         run: |
           echo "### Job summary" >> $GITHUB_STEP_SUMMARY
@@ -125,9 +127,6 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       ENVIRONMENT: ${{ inputs.environment }}
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
-      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
     needs: [deploy-terraform]
     steps:
       - uses: actions/checkout@v3
@@ -135,6 +134,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+      - name: set github environment variables
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
+        run: scripts/github-set-env.sh
       - name: install npm and apply missing environment variables
         id: initial-env
         run: |
@@ -167,9 +171,6 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       ENVIRONMENT: ${{ inputs.environment }}
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
-      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
     needs: [deploy-terraform]
     steps:
       - uses: actions/checkout@v3
@@ -177,6 +178,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+      - name: set github environment variables
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
+        run: scripts/github-set-env.sh
       - name: install top-level packages
         run: |
           echo "### Job summary" >> $GITHUB_STEP_SUMMARY
@@ -200,9 +206,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENVIRONMENT: ${{ inputs.environment }}
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
-      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
       OVERWRITE_CONFIG: ${{ inputs.initial_release == true || inputs.overwrite_config == true }}
     needs:
       - deploy-serverless
@@ -215,6 +218,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+      - name: set github environment variables
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
+        run: scripts/github-set-env.sh
       - name: install root npm
         run: |
           echo "### Job summary" >> $GITHUB_STEP_SUMMARY

--- a/scripts/github-set-env.sh
+++ b/scripts/github-set-env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Simple solution for extracting secrets and vars from the GitHub environment
+# and setting them all as environment variables for the setup scripts to use
+# This allows passing of secrets to env files as defined in .env.example
+# https://stackoverflow.com/a/75789640
+
+# Create string to use as a delimiter
+EOF=_PS_TEMPLATE_VAR_EOF_
+
+# Outputs the name/value pairs in the required format for multiline strings
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+to_envs() { jq -r "to_entries[] | \"\(.key)<<$EOF\n\(.value)\n$EOF\n\""; }
+
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+echo "$VARS_CONTEXT" | to_envs >> $GITHUB_ENV
+echo "$SECRETS_CONTEXT" | to_envs >> $GITHUB_ENV


### PR DESCRIPTION
### Summary

When building on the template, there are some use cases where the default set of environment vars should be overridden:
- Creating integrations that require access token / service account details as secrets
  - The developer would add a placeholder for the var in `.env.example`, then the scripting takes care of the rest
- Manually setting a value that was not automatically fetched
  - For example when the mappings file was not updated for a name change
- Temporarily overriding a value for testing purposes

This change essentially passes through the environment secrets and variables defined in GitHub into the runner's environment, causing our existing setup scripts to use them for creating the environment files. The setup script prefers a locally-defined environment var and will skip fetching that var from the API if it would have otherwise.

### Checklist

- [x] Tested changes end to end
- [ ] Updated documentation
- [x] Requested one or more reviewers
