### PR TITLE
Replace ticker with Redux for pending activity

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
@@ -1,25 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Flex, Text } from '@twilio-paste/core';
 import { Manager, Template, templates } from '@twilio/flex-ui';
+import { useSelector } from 'react-redux';
 
-import ActivityManager from '../../helper/ActivityManager';
 import { StringTemplates } from '../../flex-hooks/strings/ActivityReservationHandler';
+import AppState from '../../../../types/manager/AppState';
+import { reduxNamespace } from '../../../../utils/state';
+import { ActivityReservationHandlerState } from '../../flex-hooks/reducers/ActivityReservationHandler';
 
 const PendingActivity = () => {
-  const [clock, setClock] = useState(true);
-  const [pendingActivity, setPendingActivity] = useState(ActivityManager.getPendingActivity());
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setClock((currentClock) => !currentClock);
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  useEffect(() => {
-    setPendingActivity(ActivityManager.getPendingActivity());
-  }, [clock]);
+  const { pendingActivity } = useSelector(
+    (state: AppState) => state[reduxNamespace].activityReservationHandler as ActivityReservationHandlerState,
+  );
 
   return (
     <>

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, Text } from '@twilio-paste/core';
-import { Manager, Template, templates } from '@twilio/flex-ui';
+import { Template, templates, useFlexSelector } from '@twilio/flex-ui';
 import { useSelector } from 'react-redux';
 
 import { StringTemplates } from '../../flex-hooks/strings/ActivityReservationHandler';
@@ -12,10 +12,11 @@ const PendingActivity = () => {
   const { pendingActivity } = useSelector(
     (state: AppState) => state[reduxNamespace].activityReservationHandler as ActivityReservationHandlerState,
   );
+  const { activity: currentActivity } = useFlexSelector((state: AppState) => state.flex.worker);
 
   return (
     <>
-      {pendingActivity && pendingActivity.name !== Manager.getInstance().workerClient?.activity.name && (
+      {pendingActivity && pendingActivity.name !== currentActivity.name && (
         <Flex vertical marginRight="space20" hAlignContent="center">
           <Text as="p" color="colorTextInverse" fontSize="fontSize20" fontWeight="fontWeightBold">
             <Template source={templates[StringTemplates.PendingActivity]} />

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/reducers/ActivityReservationHandler.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/flex-hooks/reducers/ActivityReservationHandler.ts
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+import { PendingActivity } from '../../types/ActivityManager';
+
+export interface ActivityReservationHandlerState {
+  pendingActivity: PendingActivity | null;
+}
+
+const initialState = {
+  pendingActivity: null,
+} as ActivityReservationHandlerState;
+
+const activityReservationHandlerSlice = createSlice({
+  name: 'activityReservationHandler',
+  initialState,
+  reducers: {
+    updatePendingActivity(state, action: PayloadAction<PendingActivity | null>) {
+      state.pendingActivity = action.payload;
+    },
+  },
+});
+
+export const { updatePendingActivity } = activityReservationHandlerSlice.actions;
+export const reducerHook = () => ({ activityReservationHandler: activityReservationHandlerSlice.reducer });

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/types/ActivityManager.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/types/ActivityManager.ts
@@ -1,0 +1,9 @@
+export interface PendingActivity {
+  name: string;
+}
+
+export interface CallbackPromise {
+  resolve: any;
+  reject: any;
+  available?: boolean;
+}


### PR DESCRIPTION
### Summary

Previously, the pending activity component would run a ticker to check the pending activity from local storage every second. This was quite inefficient (and could lag up to one second after a change); now instead we use Redux and `useSelector`.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
