### PR TITLE
Enhancements to caller-id feature

### DIFF
--- a/docs/docs/feature-library/caller-id.md
+++ b/docs/docs/feature-library/caller-id.md
@@ -15,7 +15,16 @@ the vanilla feature without any further customizations will look like this
 
 ## Enabling the feature
 
-There are no settings for caller-id, only enabling the feature in the flex-config asset for your environment.
+There are no additional dependencies for setup beyond ensuring the flag is enabled within the `flex-config` attributes.
+
+There is an optional configuration property (`include_outgoing_only_numbers`) controlling whether or not outgoing-only caller IDs (i.e. verified non-Twilio phone numbers) are displayed in the dropdown. This is enabled by default, but can be disabled to hide these numbers.
+
+```json
+"caller_id": {
+    "enabled": true,
+    "include_outgoing_only_numbers": false
+}
+```
 
 ## Outbound Call Configuration
 

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -39,7 +39,8 @@
         "auto_select_task": true
       },
       "caller_id": {
-        "enabled": true
+        "enabled": true,
+        "include_outgoing_only_numbers": true
       },
       "conversation_transfer": {
         "enabled": true,

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/config.ts
@@ -1,8 +1,13 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import CallerIdConfig from './types/ServiceConfiguration';
 
-const { enabled = false } = (getFeatureFlags()?.features?.caller_id as CallerIdConfig) || {};
+const { enabled = false, include_outgoing_only_numbers = true } =
+  (getFeatureFlags()?.features?.caller_id as CallerIdConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const isOutgoingOnlyNumbersEnabled = () => {
+  return include_outgoing_only_numbers;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/custom-components/OutboundCallerIDSelector/OutboundCallerIDSelectorComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/custom-components/OutboundCallerIDSelector/OutboundCallerIDSelectorComponent.tsx
@@ -4,7 +4,7 @@ import { Box } from '@twilio-paste/core/box';
 import { HelpText } from '@twilio-paste/core/help-text';
 import { Label } from '@twilio-paste/core/label';
 import { Select, Option } from '@twilio-paste/core/select';
-import { Template, templates } from '@twilio/flex-ui';
+import { Manager, Template, templates } from '@twilio/flex-ui';
 
 import { PhoneNumberItem } from '../../../../utils/serverless/PhoneNumbers/PhoneNumberService';
 import AppState from '../../../../types/manager/AppState';
@@ -43,9 +43,21 @@ const OutboundCallerIDSelectorComponent = () => {
       ]);
       setHelpText('');
 
-      // initialize state to the first number, which is what the Select control will display
-      if (!selectedCallerId && phoneNumbers.length > 0) {
-        dispatch(Actions.setCallerId(phoneNumbers[0].phoneNumber));
+      if (
+        phoneNumbers.length > 0 &&
+        (!selectedCallerId || !phoneNumbers.find((number) => number.phoneNumber === selectedCallerId))
+      ) {
+        // Either we have never chosen a number or our selection is no longer valid
+
+        const defaultFromNumber = Manager.getInstance().serviceConfiguration.outbound_call_flows.default.caller_id;
+
+        if (phoneNumbers.find((number) => number.phoneNumber === defaultFromNumber)) {
+          // Use the configured default if present
+          dispatch(Actions.setCallerId(defaultFromNumber));
+        } else {
+          // Fall back to the first number
+          dispatch(Actions.setCallerId(phoneNumbers[0].phoneNumber));
+        }
       }
     }
   }, [isFetchingPhoneNumbers, fetchingPhoneNumbersFailed]);

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/states/OutboundCallerIDSelector/actions.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/flex-hooks/states/OutboundCallerIDSelector/actions.ts
@@ -3,6 +3,7 @@ import { Manager } from '@twilio/flex-ui';
 import { Action } from '../../../../../types/manager';
 import PhoneNumberService from '../../../../../utils/serverless/PhoneNumbers/PhoneNumberService';
 import { FETCH_PHONE_NUMBERS, SET_CALLER_ID } from './types';
+import { isOutgoingOnlyNumbersEnabled } from '../../../config';
 
 // Provide task to "pending" action as payload
 // https://github.com/pburtchaell/redux-promise-middleware/blob/main/docs/guides/optimistic-updates.md
@@ -12,7 +13,7 @@ class Actions {
     return {
       type: FETCH_PHONE_NUMBERS,
       payload: {
-        promise: PhoneNumberService.getAccountPhoneNumbers(),
+        promise: PhoneNumberService.getAccountPhoneNumbers(isOutgoingOnlyNumbersEnabled()),
       },
     };
   };

--- a/plugin-flex-ts-template-v2/src/feature-library/caller-id/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/caller-id/types/ServiceConfiguration.ts
@@ -1,3 +1,4 @@
 export default interface CallerIdConfig {
   enabled: boolean;
+  include_outgoing_only_numbers: boolean;
 }

--- a/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
@@ -41,13 +41,19 @@ class PhoneNumberService extends ApiService {
 
   private STORAGE_KEY_FLEX_PHONE_NUMBERS = `FLEX_PHONE_NUMBERS_${this.flex_service_instance_sid}`;
 
+  private STORAGE_KEY_FLEX_PHONE_NUMBERS_WITH_OUTGOING = `FLEX_PHONE_NUMBERS_WITH_OUTGOING_${this.flex_service_instance_sid}`;
+
   private STORAGE_KEY_VALIDATED_NUMBERS = `FLEX_VALIDATED_NUMBERS`;
 
   private EXPIRY = 86400000; // 1 day
 
   async getAccountPhoneNumbers(includeOutgoing: boolean): Promise<ListPhoneNumbersResponse> {
     // look for value in storage first
-    const cachedResult = JSON.parse(localStorage.getItem(this.STORAGE_KEY_FLEX_PHONE_NUMBERS) || '{}');
+    const cachedResult = JSON.parse(
+      localStorage.getItem(
+        includeOutgoing ? this.STORAGE_KEY_FLEX_PHONE_NUMBERS_WITH_OUTGOING : this.STORAGE_KEY_FLEX_PHONE_NUMBERS,
+      ) || '{}',
+    );
     // if storage value has expired, discard
     if (cachedResult.expiry < new Date().getTime()) cachedResult.success = false;
     // if we have a valid storage value use it, otherwise get from backend.
@@ -79,7 +85,7 @@ class PhoneNumberService extends ApiService {
       // if response from service was successful, store it
       if (response.success)
         localStorage.setItem(
-          this.STORAGE_KEY_FLEX_PHONE_NUMBERS,
+          includeOutgoing ? this.STORAGE_KEY_FLEX_PHONE_NUMBERS_WITH_OUTGOING : this.STORAGE_KEY_FLEX_PHONE_NUMBERS,
           JSON.stringify({
             ...response,
             expiry: new Date().getTime() + this.EXPIRY,

--- a/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/PhoneNumbers/PhoneNumberService.ts
@@ -45,13 +45,13 @@ class PhoneNumberService extends ApiService {
 
   private EXPIRY = 86400000; // 1 day
 
-  async getAccountPhoneNumbers(): Promise<ListPhoneNumbersResponse> {
+  async getAccountPhoneNumbers(includeOutgoing: boolean): Promise<ListPhoneNumbersResponse> {
     // look for value in storage first
     const cachedResult = JSON.parse(localStorage.getItem(this.STORAGE_KEY_FLEX_PHONE_NUMBERS) || '{}');
     // if storage value has expired, discard
     if (cachedResult.expiry < new Date().getTime()) cachedResult.success = false;
     // if we have a valid storage value use it, otherwise get from backend.
-    return cachedResult.success ? cachedResult : this.#getAccountPhoneNumbers();
+    return cachedResult.success ? cachedResult : this.#getAccountPhoneNumbers(includeOutgoing);
   }
 
   async validatePhoneNumber(phoneNumber: string): Promise<ValidatePhoneNumberResponse> {
@@ -62,9 +62,10 @@ class PhoneNumberService extends ApiService {
     return cachedResult.success ? cachedResult : this.#validatePhoneNumber(phoneNumber);
   }
 
-  #getAccountPhoneNumbers = async (): Promise<any> => {
+  #getAccountPhoneNumbers = async (includeOutgoing: boolean): Promise<any> => {
     const encodedParams: EncodedParams = {
       Token: encodeURIComponent(this.manager.user.token),
+      IncludeOutgoing: encodeURIComponent(includeOutgoing),
     };
 
     return this.fetchJsonWithReject<ListPhoneNumbersResponse>(

--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -2,22 +2,41 @@ const { prepareFlexFunction, extractStandardResponse } = require(Runtime.getFunc
   'common/helpers/function-helper'
 ].path);
 const PhoneNumberOpertions = require(Runtime.getFunctions()['common/twilio-wrappers/phone-numbers'].path);
+const VoiceOpertions = require(Runtime.getFunctions()['common/twilio-wrappers/programmable-voice'].path);
 
 const requiredParameters = [];
 
 exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
   try {
+    const fetchOutgoingCallerIds = event.IncludeOutgoing === 'true' || false;
+
     const result = await PhoneNumberOpertions.listPhoneNumbers({
       context,
     });
 
     const { phoneNumbers: fullPhoneNumberList } = result;
-    const phoneNumbers = fullPhoneNumberList
+    let phoneNumbers = fullPhoneNumberList
       ? fullPhoneNumberList.map((number) => {
           const { friendlyName, phoneNumber } = number;
           return { friendlyName, phoneNumber };
         })
       : null;
+
+    if (fetchOutgoingCallerIds) {
+      const outgoingResult = await VoiceOpertions.listOutgoingCallerIds({
+        context,
+      });
+
+      if (outgoingResult?.success) {
+        const { callerIds } = outgoingResult;
+        phoneNumbers = phoneNumbers.concat(
+          callerIds.map((number) => {
+            const { friendlyName, phoneNumber } = number;
+            return { friendlyName, phoneNumber };
+          }),
+        );
+      }
+    }
 
     response.setStatusCode(result.status);
     response.setBody({ phoneNumbers, ...extractStandardResponse(result) });

--- a/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/programmable-voice.private.js
@@ -272,3 +272,27 @@ exports.fetchRecordingMedia = async (parameters) => {
     return retryHandler(error, parameters, exports.fetchRecordingMedia);
   }
 };
+
+/**
+ * @param {object} parameters the parameters for the function
+ * @param {number} parameters.attempts the number of retry attempts performed
+ * @param {object} parameters.context the context from calling lambda function
+ * @returns {Array<PhoneNumber>} An array of outbound caller ids for the account
+ * @description the following method is used to robustly retrieve
+ *   the outbound caller ids for the account
+ */
+exports.listOutgoingCallerIds = async function listOutgoingCallerIds(parameters) {
+  if (!isObject(parameters.context))
+    throw new Error('Invalid parameters object passed. Parameters must contain context object');
+
+  try {
+    const client = parameters.context.getTwilioClient();
+    const callerIds = await client.outgoingCallerIds.list({
+      limit: 1000,
+    });
+
+    return { success: true, callerIds, status: 200 };
+  } catch (error) {
+    return retryHandler(error, parameters, exports.listOutgoingCallerIds);
+  }
+};


### PR DESCRIPTION
### Summary

1. Previously the list included only purchased Twilio phone numbers. Added new option (`include_outgoing_only_numbers`, enabled by default) to also fetch and include verified outgoing caller IDs to the list.
2. Previously the default value was the first item in the list. Now it uses the configured Flex dialpad default.
3. Previously if the selected caller ID was no longer a valid caller ID, the dropdown selection (which defaulted to the first item) and the configured value (now invalid) would get out of sync, causing failed dials and confusion. Now the default is used in this scenario.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
