### PR TITLE
Fix cold external transfer for outbound tasks

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
@@ -40,7 +40,11 @@ export const registerStartExternalColdTransfer = async () => {
       }
 
       try {
-        await CustomTransferDirectoryService.startColdTransfer(task.attributes.call_sid, phoneNumber, callerId);
+        await CustomTransferDirectoryService.startColdTransfer(
+          task?.attributes?.call_sid ?? task.attributes.conference.participants.customer,
+          phoneNumber,
+          callerId,
+        );
       } catch (error: any) {
         console.error('Error executing startColdTransfer', error);
         Notifications.showNotification(CustomTransferDirectoryNotification.ErrorExecutingColdTransfer, {


### PR DESCRIPTION
### Summary

The `call_sid` task attribute is not set for outbound tasks. Fixes #335

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
