### PR TITLE
Remove material icons to reduce bundle size

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Callback.tsx
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 import React from 'react';
-import PhoneCallbackIcon from '@material-ui/icons/PhoneCallback';
+import { CallOutgoingIcon } from '@twilio-paste/icons/esm/CallOutgoingIcon';
 
 import { TaskAttributes } from '../../../../types/task-router/Task';
 import { StringTemplates } from '../strings/Callback';
@@ -58,9 +58,9 @@ export const channelHook = function createCallbackChannel(flex: typeof Flex, man
       },
     },
     icons: {
-      active: <PhoneCallbackIcon key="active-callback-icon" />,
-      list: <PhoneCallbackIcon key="list-callback-icon" />,
-      main: <PhoneCallbackIcon key="main-callback-icon" />,
+      active: <CallOutgoingIcon element="C_AND_V_ICON" decorative={true} key="active-callback-icon" />,
+      list: <CallOutgoingIcon element="C_AND_V_ICON" decorative={true} key="list-callback-icon" />,
+      main: <CallOutgoingIcon element="C_AND_V_ICON" decorative={true} key="main-callback-icon" />,
     },
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/channels/Voicemail.tsx
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 import React from 'react';
-import VoicemailIcon from '@material-ui/icons/Voicemail';
+import { VoicemailIcon } from '@twilio-paste/icons/esm/VoicemailIcon';
 
 import { TaskAttributes } from '../../../../types/task-router/Task';
 import { StringTemplates } from '../strings/Callback';
@@ -58,9 +58,9 @@ export const channelHook = function createVoicemailChannel(flex: typeof Flex, ma
       },
     },
     icons: {
-      active: <VoicemailIcon key="active-voicemail-icon" />,
-      list: <VoicemailIcon key="list-voicemail-icon" />,
-      main: <VoicemailIcon key="main-voicemail-icon" />,
+      active: <VoicemailIcon element="C_AND_V_ICON" decorative={true} key="active-voicemail-icon" />,
+      list: <VoicemailIcon element="C_AND_V_ICON" decorative={true} key="list-voicemail-icon" />,
+      main: <VoicemailIcon element="C_AND_V_ICON" decorative={true} key="main-voicemail-icon" />,
     },
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/paste-elements/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/flex-hooks/paste-elements/index.ts
@@ -12,4 +12,10 @@ export const pasteElementHook = {
   C_AND_V_CONTENT_HEADING: {
     marginBottom: 'space0',
   },
+  C_AND_V_ICON: {
+    width: '100%',
+    height: '100%',
+    minWidth: 'sizeSquare90',
+    padding: 'space20',
+  },
 } as { [key: string]: PasteCustomCSS };


### PR DESCRIPTION
### Summary

Callbacks and voicemails used icons from material-ui which increased our bundle size. This PR replaces those with Paste icons (and adds the required styling for appropriate sizing).

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
