### PR TITLE
Reduce size of lodash and Paste

### DIFF
--- a/plugin-flex-ts-template-v2/.eslintrc.js
+++ b/plugin-flex-ts-template-v2/.eslintrc.js
@@ -20,6 +20,23 @@ module.exports = {
     'no-console': 'off',
     'no-duplicate-imports': 'off',
     'no-nested-ternary': 'off',
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@twilio-paste/core',
+            message:
+              'Importing Paste this way bloats plugin size. Instead, use specific imports such as `@twilio-paste/core/button`.',
+          },
+          {
+            name: 'lodash',
+            message:
+              'Importing lodash this way bloats plugin size. Instead, use specific imports such as `lodash/sortBy`.',
+          },
+        ],
+      },
+    ],
     'prefer-destructuring': 'off',
     'prefer-named-capture-group': 'off',
     'prefer-promise-reject-errors': 'off',

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/ActivityHandlerAdmin/ActivityHandlerAdmin.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/ActivityHandlerAdmin/ActivityHandlerAdmin.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useFlexSelector } from '@twilio/flex-ui';
-import { FormControl, Label, Select, Option, Paragraph } from '@twilio-paste/core';
+import { FormControl } from '@twilio-paste/core/form';
+import { Label } from '@twilio-paste/core/label';
+import { Select, Option } from '@twilio-paste/core/select';
+import { Paragraph } from '@twilio-paste/core/paragraph';
 
 import AppState from '../../../../types/manager/AppState';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/custom-components/pending-activity/PendingActivityComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Flex, Text } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Text } from '@twilio-paste/core/text';
 import { Template, templates, useFlexSelector } from '@twilio/flex-ui';
 import { useSelector } from 'react-redux';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/utils/AgentActivities.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/utils/AgentActivities.ts
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 import AppState from 'types/manager/AppState';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 import { Activity } from 'types/task-router';
 
 import { ActivitySkillFilterRules } from '../types/ServiceConfiguration';

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useState } from 'react';
 import { Manager, Notifications, Template, templates } from '@twilio/flex-ui';
-import {
-  Heading,
-  Flex,
-  Label,
-  Box,
-  RadioButtonGroup,
-  RadioButton,
-  Input,
-  Spinner,
-  AlertDialog,
-} from '@twilio-paste/core';
+import { AlertDialog } from '@twilio-paste/core/alert-dialog';
+import { Box } from '@twilio-paste/core/box';
+import { Flex } from '@twilio-paste/core/flex';
+import { Heading } from '@twilio-paste/core/heading';
+import { Input } from '@twilio-paste/core/input';
+import { Label } from '@twilio-paste/core/label';
+import { RadioButton, RadioButtonGroup } from '@twilio-paste/core/radio-button-group';
+import { Spinner } from '@twilio-paste/core/spinner';
 import { UserIcon } from '@twilio-paste/icons/esm/UserIcon';
 import { ProductFlexIcon } from '@twilio-paste/icons/esm/ProductFlexIcon';
 import { SearchIcon } from '@twilio-paste/icons/esm/SearchIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -14,7 +14,7 @@ import {
 import { UserIcon } from '@twilio-paste/icons/esm/UserIcon';
 import { ProductFlexIcon } from '@twilio-paste/icons/esm/ProductFlexIcon';
 import { SearchIcon } from '@twilio-paste/icons/esm/SearchIcon';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 import { StringTemplates } from '../../flex-hooks/strings';
 import { AdminViewWrapper, FeatureCardWrapper } from './AdminView.Styles';

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureCard/FeatureCard.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureCard/FeatureCard.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react';
 import { Manager, Template, templates } from '@twilio/flex-ui';
-import { Heading, Flex, Box, Stack, Card, Switch, Button, Anchor } from '@twilio-paste/core';
+import { Heading } from '@twilio-paste/core/heading';
+import { Box } from '@twilio-paste/core/box';
+import { Flex } from '@twilio-paste/core/flex';
+import { Anchor } from '@twilio-paste/core/anchor';
+import { Stack } from '@twilio-paste/core/stack';
+import { Switch } from '@twilio-paste/core/switch';
+import { Button } from '@twilio-paste/core/button';
+import { Card } from '@twilio-paste/core/card';
 import { SkipBackIcon } from '@twilio-paste/icons/esm/SkipBackIcon';
 import { ProductSettingsIcon } from '@twilio-paste/icons/esm/ProductSettingsIcon';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureModal/FeatureModal.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/FeatureModal/FeatureModal.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 import { Actions, Template, templates } from '@twilio/flex-ui';
-import { Alert, Box, TextArea, Anchor, Label, Switch, Button, Input, HelpText } from '@twilio-paste/core';
+import { Alert } from '@twilio-paste/core/alert';
+import { Box } from '@twilio-paste/core/box';
+import { TextArea } from '@twilio-paste/core/textarea';
+import { Anchor } from '@twilio-paste/core/anchor';
+import { Label } from '@twilio-paste/core/label';
+import { Switch } from '@twilio-paste/core/switch';
+import { Button } from '@twilio-paste/core/button';
+import { Input } from '@twilio-paste/core/input';
+import { HelpText } from '@twilio-paste/core/help-text';
 import { Form, FormControl } from '@twilio-paste/core/form';
 import { useUID, useUIDSeed } from '@twilio-paste/core/uid-library';
 import { Modal, ModalBody, ModalFooter, ModalFooterActions, ModalHeader, ModalHeading } from '@twilio-paste/core/modal';

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/custom-components/CallbackAndVoicemail/CallbackAndVoicemail.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/custom-components/CallbackAndVoicemail/CallbackAndVoicemail.tsx
@@ -2,7 +2,13 @@ import { ITask, useFlexSelector, Manager, Template, templates } from '@twilio/fl
 import React, { useEffect, useState } from 'react';
 import { DateTime } from 'luxon';
 import { TaskAttributes } from 'types/task-router/Task';
-import { Button, Box, Heading, Text, Flex, Stack, HelpText } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
+import { Box } from '@twilio-paste/core/box';
+import { Heading } from '@twilio-paste/core/heading';
+import { Text } from '@twilio-paste/core/text';
+import { Flex } from '@twilio-paste/core/flex';
+import { Stack } from '@twilio-paste/core/stack';
+import { HelpText } from '@twilio-paste/core/help-text';
 import { InformationIcon } from '@twilio-paste/icons/esm/InformationIcon';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/VideoRoom/VideoRoom.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/chat-to-video-escalation/custom-components/VideoRoom/VideoRoom.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ITask, Manager, Template, templates } from '@twilio/flex-ui';
-import { Flex } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
 
 import { iframeStyle } from './styles';
 import { StringTemplates } from '../../flex-hooks/strings/ChatToVideo';

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantTabLabel/ParticipantTabLabel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantTabLabel/ParticipantTabLabel.tsx
@@ -1,5 +1,6 @@
 import { TaskContext, Template, templates } from '@twilio/flex-ui';
-import { Stack, Badge } from '@twilio-paste/core';
+import { Badge } from '@twilio-paste/core/badge';
+import { Stack } from '@twilio-paste/core/stack';
 
 import { StringTemplates } from '../../flex-hooks/strings/ChatTransferStrings';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipant/InvitedParticipant.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipant/InvitedParticipant.tsx
@@ -1,4 +1,6 @@
-import { Flex as FlexBox, Box, Button } from '@twilio-paste/core';
+import { Flex as FlexBox } from '@twilio-paste/core/flex';
+import { Box } from '@twilio-paste/core/box';
+import { Button } from '@twilio-paste/core/button';
 import { ChatIcon } from '@twilio-paste/icons/esm/ChatIcon';
 import { AgentIcon } from '@twilio-paste/icons/esm/AgentIcon';
 import { CloseIcon } from '@twilio-paste/icons/esm/CloseIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipants.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/InvitedParticipants/InvitedParticipants.tsx
@@ -1,4 +1,6 @@
-import { Stack, Card, Heading } from '@twilio-paste/core';
+import { Stack } from '@twilio-paste/core/stack';
+import { Card } from '@twilio-paste/core/card';
+import { Heading } from '@twilio-paste/core/heading';
 import { Template, templates } from '@twilio/flex-ui';
 
 import { InvitedParticipant } from './InvitedParticipant/InvitedParticipant';

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participant/Participant.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participant/Participant.tsx
@@ -1,4 +1,6 @@
-import { Flex as FlexBox, Box, Button } from '@twilio-paste/core';
+import { Flex as FlexBox } from '@twilio-paste/core/flex';
+import { Box } from '@twilio-paste/core/box';
+import { Button } from '@twilio-paste/core/button';
 import { UserIcon } from '@twilio-paste/icons/esm/UserIcon';
 import { AgentIcon } from '@twilio-paste/icons/esm/AgentIcon';
 import { CloseIcon } from '@twilio-paste/icons/esm/CloseIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participants.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/Participants.tsx/Participants.tsx
@@ -1,4 +1,6 @@
-import { Stack, Card, Heading } from '@twilio-paste/core';
+import { Stack } from '@twilio-paste/core/stack';
+import { Card } from '@twilio-paste/core/card';
+import { Heading } from '@twilio-paste/core/heading';
 import { Template, templates } from '@twilio/flex-ui';
 
 import { Participant } from './Participant/Participant';

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/ParticipantsTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/ParticipantsTab.tsx
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 import { useState, useEffect } from 'react';
-import { Stack } from '@twilio-paste/core';
+import { Stack } from '@twilio-paste/core/stack';
 import { ConversationState, styled, Actions } from '@twilio/flex-ui';
 
 import { Participants } from './Participants.tsx/Participants';

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/CommonDirectoryComponents.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/CommonDirectoryComponents.tsx
@@ -1,5 +1,6 @@
 import { Manager, styled, templates } from '@twilio/flex-ui';
-import { Box, Input } from '@twilio-paste/core';
+import { Box } from '@twilio-paste/core/box';
+import { Input } from '@twilio-paste/core/input';
 import { SearchIcon } from '@twilio-paste/icons/esm/SearchIcon';
 import { Ref } from 'react';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalDirectoryTab.tsx
@@ -1,7 +1,7 @@
 import { Flex, Alert } from '@twilio-paste/core';
 import { withTaskContext, ITask, Actions, Manager, useFlexSelector, Template, templates } from '@twilio/flex-ui';
 import { useState, useRef, useEffect } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { SearchBox } from './CommonDirectoryComponents';
 import { getExternalDirectory } from '../config';

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalDirectoryTab.tsx
@@ -1,4 +1,5 @@
-import { Flex, Alert } from '@twilio-paste/core';
+import { Alert } from '@twilio-paste/core/alert';
+import { Flex } from '@twilio-paste/core/flex';
 import { withTaskContext, ITask, Actions, Manager, useFlexSelector, Template, templates } from '@twilio/flex-ui';
 import { useState, useRef, useEffect } from 'react';
 import debounce from 'lodash/debounce';

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalItem.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/ExternalItem.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { ITask, templates } from '@twilio/flex-ui';
-import { ButtonGroup, Button, Flex, Tooltip, Text } from '@twilio-paste/core';
+import { ButtonGroup } from '@twilio-paste/core/button-group';
+import { Button } from '@twilio-paste/core/button';
+import { Flex } from '@twilio-paste/core/flex';
+import { Tooltip } from '@twilio-paste/core/tooltip';
+import { Text } from '@twilio-paste/core/text';
 import { ProductPhoneNumbersIcon } from '@twilio-paste/icons/esm/ProductPhoneNumbersIcon';
 import { CallTransferIcon } from '@twilio-paste/icons/esm/CallTransferIcon';
 import { CallOutgoingIcon } from '@twilio-paste/icons/esm/CallOutgoingIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
@@ -12,7 +12,7 @@ import {
   templates,
 } from '@twilio/flex-ui';
 import { useEffect, useState, useRef } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { SyncMap } from 'twilio-sync';
 
 import { getAllSyncMapItems } from '../../../utils/sdk-clients/sync/SyncClient';

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
@@ -1,4 +1,5 @@
-import { Flex, Alert } from '@twilio-paste/core';
+import { Alert } from '@twilio-paste/core/alert';
+import { Flex } from '@twilio-paste/core/flex';
 import {
   withTaskContext,
   Manager,

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueItem.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueItem.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { TaskHelper, ITask, Manager, templates } from '@twilio/flex-ui';
-import { ButtonGroup, Button, Flex, Tooltip, Text } from '@twilio-paste/core';
+import { ButtonGroup } from '@twilio-paste/core/button-group';
+import { Button } from '@twilio-paste/core/button';
+import { Flex } from '@twilio-paste/core/flex';
+import { Tooltip } from '@twilio-paste/core/tooltip';
+import { Text } from '@twilio-paste/core/text';
 import { ProductContactCenterTeamsIcon } from '@twilio-paste/icons/esm/ProductContactCenterTeamsIcon';
 import { CallTransferIcon } from '@twilio-paste/icons/esm/CallTransferIcon';
 import { CallOutgoingIcon } from '@twilio-paste/icons/esm/CallOutgoingIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/device-manager/custom-components/DeviceManager/DeviceManager.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/device-manager/custom-components/DeviceManager/DeviceManager.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Manager, templates } from '@twilio/flex-ui';
 import { Device } from '@twilio/voice-sdk';
-import { Flex, MenuButton, MenuGroup, useMenuState, Menu, MenuItem, useToaster, Toaster } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { MenuButton, MenuGroup, useMenuState, Menu, MenuItem } from '@twilio-paste/core/menu';
+import { useToaster, Toaster } from '@twilio-paste/core/toast';
 import { MicrophoneOnIcon } from '@twilio-paste/icons/esm/MicrophoneOnIcon';
 import { VolumeOnIcon } from '@twilio-paste/icons/esm/VolumeOnIcon';
 import { AgentIcon } from '@twilio-paste/icons/esm/AgentIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/dispositions/custom-components/DispositionTab/DispositionTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/dispositions/custom-components/DispositionTab/DispositionTab.tsx
@@ -7,7 +7,7 @@ import { TextArea } from '@twilio-paste/core/textarea';
 import { Label } from '@twilio-paste/core/label';
 import { HelpText } from '@twilio-paste/core/help-text';
 import { Box } from '@twilio-paste/core/box';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { getDispositionsForQueue, isNotesEnabled, isRequireDispositionEnabledForQueue } from '../../config';
 import AppState from '../../../../types/manager/AppState';

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/custom-components/InternalDialpad/InternalDialpad.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/custom-components/InternalDialpad/InternalDialpad.tsx
@@ -5,7 +5,7 @@ import { Combobox } from '@twilio-paste/core/combobox';
 import { Flex } from '@twilio-paste/core/flex';
 import { Stack } from '@twilio-paste/core/stack';
 import { Text } from '@twilio-paste/core/text';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { Worker as InstantQueryWorker } from 'types/sync/InstantQuery';
 
 import { makeInternalCall } from '../../helpers/internalCall';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/DeleteButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { Button } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
 import { DeleteIcon } from '@twilio-paste/icons/esm/DeleteIcon';
 
 import { ShortcutsObject } from '../../types/types';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/EditButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/EditButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
 import { EditIcon } from '@twilio-paste/icons/esm/EditIcon';
 
 interface EditButtonProps {

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { Template, templates } from '@twilio/flex-ui';
 import { useUID } from '@twilio-paste/core/uid-library';
-import { useTabState, Box, Heading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@twilio-paste/core';
+import { useTabState, Tab, Tabs, TabList, TabPanel, TabPanels } from '@twilio-paste/core/tabs';
+import { Box } from '@twilio-paste/core/box';
+import { Heading } from '@twilio-paste/core/heading';
 import { useToaster, Toaster } from '@twilio-paste/core/toast';
 
 import { StringTemplates } from '../../flex-hooks/strings';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/ModalWindow.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/ModalWindow.tsx
@@ -1,28 +1,15 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useUID } from '@twilio-paste/core/uid-library';
-import {
-  Grid,
-  Column,
-  HelpText,
-  ModalHeading,
-  ModalFooterActions,
-  Box,
-  Button,
-  Label,
-  Input,
-  Separator,
-  Table,
-  THead,
-  Tr,
-  Th,
-  Td,
-  TBody,
-  Stack,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-} from '@twilio-paste/core';
+import { Table, THead, Tr, Th, Td, TBody } from '@twilio-paste/core/table';
+import { Box } from '@twilio-paste/core/box';
+import { ModalHeading, ModalFooterActions, Modal, ModalBody, ModalFooter, ModalHeader } from '@twilio-paste/core/modal';
+import { Grid, Column } from '@twilio-paste/core/grid';
+import { HelpText } from '@twilio-paste/core/help-text';
+import { Stack } from '@twilio-paste/core/stack';
+import { Button } from '@twilio-paste/core/button';
+import { Label } from '@twilio-paste/core/label';
+import { Input } from '@twilio-paste/core/input';
+import { Separator } from '@twilio-paste/core/separator';
 import { Template, templates } from '@twilio/flex-ui';
 
 import { StringTemplates } from '../../flex-hooks/strings';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/CustomKeyboardShortcutsView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/CustomKeyboardShortcutsView.tsx
@@ -1,19 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Heading,
-  Paragraph,
-  Card,
-  Tooltip,
-  Text,
-  Stack,
-  Box,
-  Table,
-  THead,
-  Tr,
-  Th,
-  Td,
-  TBody,
-} from '@twilio-paste/core';
+import { Table, THead, Tr, Th, Td, TBody } from '@twilio-paste/core/table';
+import { Box } from '@twilio-paste/core/box';
+import { Card } from '@twilio-paste/core/card';
+import { Heading } from '@twilio-paste/core/heading';
+import { Paragraph } from '@twilio-paste/core/paragraph';
+import { Stack } from '@twilio-paste/core/stack';
+import { Text } from '@twilio-paste/core/text';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 import { Template, templates } from '@twilio/flex-ui';
 import { WarningIcon } from '@twilio-paste/icons/esm/WarningIcon';
 import { InformationIcon } from '@twilio-paste/icons/esm/InformationIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/DefaultKeyboardShortcutsView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/DefaultKeyboardShortcutsView.tsx
@@ -1,19 +1,12 @@
 import { useState, useEffect } from 'react';
-import {
-  Paragraph,
-  Table,
-  THead,
-  Tr,
-  Th,
-  Td,
-  TBody,
-  Box,
-  Tooltip,
-  Text,
-  Heading,
-  Stack,
-  Card,
-} from '@twilio-paste/core';
+import { Table, THead, Tr, Th, Td, TBody } from '@twilio-paste/core/table';
+import { Box } from '@twilio-paste/core/box';
+import { Card } from '@twilio-paste/core/card';
+import { Heading } from '@twilio-paste/core/heading';
+import { Paragraph } from '@twilio-paste/core/paragraph';
+import { Stack } from '@twilio-paste/core/stack';
+import { Text } from '@twilio-paste/core/text';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 import { Template, templates } from '@twilio/flex-ui';
 import { InformationIcon } from '@twilio-paste/icons/esm/InformationIcon';
 import { WarningIcon } from '@twilio-paste/icons/esm/WarningIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/Settings.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/Tabs/Settings.tsx
@@ -1,6 +1,12 @@
 import { Dispatch, SetStateAction, useState, useEffect, useCallback } from 'react';
 import { Template, templates } from '@twilio/flex-ui';
-import { Button, Heading, Stack, Card, Paragraph, Switch, TabPrimitiveInitialState } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
+import { Card } from '@twilio-paste/core/card';
+import { Heading } from '@twilio-paste/core/heading';
+import { Paragraph } from '@twilio-paste/core/paragraph';
+import { Stack } from '@twilio-paste/core/stack';
+import { Switch } from '@twilio-paste/core/switch';
+import { TabPrimitiveInitialState } from '@twilio-paste/core/tabs-primitive';
 import { useToaster, Toaster } from '@twilio-paste/core/toast';
 
 import { StringTemplates } from '../../../flex-hooks/strings';

--- a/plugin-flex-ts-template-v2/src/feature-library/localization/custom-components/LanguageSelector/LanguageSelector.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/localization/custom-components/LanguageSelector/LanguageSelector.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Actions, Template, templates } from '@twilio/flex-ui';
-import { Flex, MenuButton, MenuGroup, useMenuState, Menu, MenuItem, AlertDialog } from '@twilio-paste/core';
+import { MenuButton, MenuGroup, useMenuState, Menu, MenuItem } from '@twilio-paste/core/menu';
+import { AlertDialog } from '@twilio-paste/core/alert-dialog';
+import { Flex } from '@twilio-paste/core/flex';
 import { TranslationIcon } from '@twilio-paste/icons/esm/TranslationIcon';
 
 import languages from '../../languages';

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Box } from '@twilio-paste/core';
+import { Box } from '@twilio-paste/core/box';
 import { Manager, templates } from '@twilio/flex-ui';
 import { Heading } from '@twilio-paste/core/heading';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkViewTable.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkViewTable.tsx
@@ -1,4 +1,5 @@
-import { TBody, THead, Table, Td, Th, Tr, Button } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
+import { TBody, THead, Table, Td, Th, Tr } from '@twilio-paste/core/table';
 import { ChatIcon } from '@twilio-paste/icons/esm/ChatIcon';
 import { Actions, Manager, templates } from '@twilio/flex-ui';
 import { useState } from 'react';

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkViewTableBodyWrapper.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkView/ParkViewTableBodyWrapper.tsx
@@ -1,4 +1,5 @@
-import { SkeletonLoader, TBody, Td, Tr } from '@twilio-paste/core';
+import { SkeletonLoader } from '@twilio-paste/core/skeleton-loader';
+import { TBody, Td, Tr } from '@twilio-paste/core/table';
 import { templates } from '@twilio/flex-ui';
 
 import { StringTemplates } from '../../flex-hooks/strings';

--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/custom-components/ScheduleAdmin/ScheduleAdmin.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/custom-components/ScheduleAdmin/ScheduleAdmin.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Actions } from '@twilio/flex-ui';
-import { Button } from '@twilio-paste/core';
+import { Button } from '@twilio-paste/core/button';
 
 interface OwnProps {
   feature: string;

--- a/plugin-flex-ts-template-v2/src/feature-library/send-audio-rec-file/custom-components/AudioRecorderPanel/AudioRecorderPanel.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/send-audio-rec-file/custom-components/AudioRecorderPanel/AudioRecorderPanel.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import * as Flex from '@twilio/flex-ui';
 import { Actions, IconButton, templates } from '@twilio/flex-ui';
 import MicRecorder from 'mic-recorder-to-mp3';
-import { Grid, Card, Text } from '@twilio-paste/core';
+import { Grid } from '@twilio-paste/core/grid';
+import { Card } from '@twilio-paste/core/card';
+import { Text } from '@twilio-paste/core/text';
 import { Spinner } from '@twilio-paste/core/spinner';
 
 import { AudioRecorderWrapper, AudioRecorderPopover } from './AudioRecorderPanel.Styles';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/AgentAssistanceButton/AgentAssistanceButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/AgentAssistanceButton/AgentAssistanceButtonComponent.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { TaskHelper, useFlexSelector, ITask, IconButton, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Tooltip } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 
 import { reduxNamespace } from '../../../../utils/state';
 import { AppState } from '../../../../types/manager';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/AgentAssistanceTeamsIcon/AgentAssistanceTeamsIcon.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/AgentAssistanceTeamsIcon/AgentAssistanceTeamsIcon.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@twilio-paste/core';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 import { ErrorIcon } from '@twilio-paste/icons/esm/ErrorIcon';
 import { useSelector } from 'react-redux';
 import { templates } from '@twilio/flex-ui';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { TaskHelper, useFlexSelector, ITask, IconButton, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Stack } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Stack } from '@twilio-paste/core/stack';
 import { ParticipantTypes } from '@twilio/flex-ui/src/state/Participants/participants.types';
 
 import { AppState } from '../../../../types/manager';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { useFlexSelector, Template, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Stack, Box, Text } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Stack } from '@twilio-paste/core/stack';
+import { Box } from '@twilio-paste/core/box';
+import { Text } from '@twilio-paste/core/text';
 
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorAlertButton/SupervisorAlertButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorAlertButton/SupervisorAlertButtonComponent.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { IconButton, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Tooltip } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 
 import { reduxNamespace } from '../../../../utils/state';
 import { AppState } from '../../../../types/manager';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { useFlexSelector, Template, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Stack, Box, Text } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Stack } from '@twilio-paste/core/stack';
+import { Box } from '@twilio-paste/core/box';
+import { Text } from '@twilio-paste/core/text';
 
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { TaskHelper, useFlexSelector, ITask, IconButton, templates } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
-import { Flex, Stack } from '@twilio-paste/core';
+import { Flex } from '@twilio-paste/core/flex';
+import { Stack } from '@twilio-paste/core/stack';
 
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-complete-reservation/custom-components/SupervisorCompleteReservation/SupervisorCompleteReservation.tsx
@@ -1,5 +1,7 @@
 import { ITask, Template, templates } from '@twilio/flex-ui';
-import { AlertDialog, Button, Box } from '@twilio-paste/core';
+import { AlertDialog } from '@twilio-paste/core/alert-dialog';
+import { Button } from '@twilio-paste/core/button';
+import { Box } from '@twilio-paste/core/box';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/custom-components/AgentTeamActivityTile/AgentTeamActivityTile.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/custom-components/AgentTeamActivityTile/AgentTeamActivityTile.tsx
@@ -1,6 +1,8 @@
 import { Icon, Template, templates, useFlexSelector } from '@twilio/flex-ui';
 import * as React from 'react';
-import { Box, Table, THead, TBody, Th, Tr, Td, Tooltip } from '@twilio-paste/core';
+import { Box } from '@twilio-paste/core/box';
+import { Table, THead, TBody, Th, Tr, Td } from '@twilio-paste/core/table';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 import { SupervisorWorkerState } from '@twilio/flex-ui/src/state/State.definition';
 import AppState from 'types/manager/AppState';
 import { EmojiIcon } from '@twilio-paste/icons/esm/EmojiIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/custom-components/TaskSummaryTile/TaskSummaryTile.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-enhancements/custom-components/TaskSummaryTile/TaskSummaryTile.tsx
@@ -1,6 +1,8 @@
 import { Icon, Template, templates, useFlexSelector } from '@twilio/flex-ui';
 import * as React from 'react';
-import { Box, Table, THead, TBody, Th, Tr, Td, Tooltip } from '@twilio-paste/core';
+import { Box } from '@twilio-paste/core/box';
+import { Table, THead, TBody, Th, Tr, Td } from '@twilio-paste/core/table';
+import { Tooltip } from '@twilio-paste/core/tooltip';
 import { SupervisorWorkerState } from '@twilio/flex-ui/src/state/State.definition';
 import AppState from 'types/manager/AppState';
 import { CallIncomingIcon } from '@twilio-paste/icons/esm/CallIncomingIcon';

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/agentSkillsFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/agentSkillsFilter.tsx
@@ -1,5 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueNoWorkerDataFilter.tsx
@@ -1,5 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/queueWorkerDataFilter.tsx
@@ -1,5 +1,5 @@
 import { FilterDefinition, Manager } from '@twilio/flex-ui';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 import SelectFilter from '../custom-components/SelectFilter';
 import SelectFilterLabel from '../custom-components/SelectFilterLabel';

--- a/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
@@ -1,5 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { UIAttributes } from 'types/manager/ServiceConfiguration';
 import { CustomWorkerAttributes } from 'types/task-router/Worker';
 

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/css-overrides.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/css-overrides.ts
@@ -1,5 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 let overrides = {};
 

--- a/plugin-flex-ts-template-v2/src/utils/serverless/TaskRouter/TaskRouterService.ts
+++ b/plugin-flex-ts-template-v2/src/utils/serverless/TaskRouter/TaskRouterService.ts
@@ -1,5 +1,5 @@
 import { TaskAssignmentStatus } from 'types/task-router/Task';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import { TaskHelper } from '@twilio/flex-ui';
 
 import ApiService from '../ApiService';

--- a/plugin-flex-ts-template-v2/test-utils/flex-redux.ts
+++ b/plugin-flex-ts-template-v2/test-utils/flex-redux.ts
@@ -1,5 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
-import { mergeWith, unset } from 'lodash';
+import mergeWith from 'lodash/mergeWith';
+import unset from 'lodash/unset';
 
 import { AppState } from '../src/types/manager';
 import { reduxNamespace } from '../src/utils/state';

--- a/plugin-flex-ts-template-v2/test-utils/flex-service-configuration.ts
+++ b/plugin-flex-ts-template-v2/test-utils/flex-service-configuration.ts
@@ -1,5 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
-import { mergeWith, unset } from 'lodash';
+import mergeWith from 'lodash/mergeWith';
+import unset from 'lodash/unset';
 
 import { UIAttributes } from '../src/types/manager/ServiceConfiguration';
 
@@ -22,8 +23,9 @@ const mockedUiAttributes: UIAttributes = {
     serverless_functions_protocol: 'https',
     serverless_functions_port: '443',
     serverless_functions_domain: 'mockServerlessFunctionsDomain',
-    features: {}
-  }
+    language: 'default',
+    features: {},
+  },
 };
 
 let mockedServiceConfiguration: ServiceConfiguration = {
@@ -40,10 +42,10 @@ let mockedServiceConfiguration: ServiceConfiguration = {
   date_created: new Date().toISOString(),
   date_updated: new Date().toISOString(),
   debugger_integration: {
-    enabled: true
+    enabled: true,
   },
   flex_ui_status_report: {
-    enabled: true
+    enabled: true,
   },
   messaging_service_instance_sid: 'mockMessagingServiceInstanceSid',
   outbound_call_flows: {},
@@ -97,10 +99,10 @@ export const resetServiceConfiguration = () => {
     date_created: new Date().toISOString(),
     date_updated: new Date().toISOString(),
     debugger_integration: {
-      enabled: true
+      enabled: true,
     },
     flex_ui_status_report: {
-      enabled: true
+      enabled: true,
     },
     messaging_service_instance_sid: 'mockMessagingServiceInstanceSid',
     outbound_call_flows: {},


### PR DESCRIPTION
### Summary

Adjusts imports to be more scoped, which allows webpack to greatly reduce the bundle size.

Added eslint rule so that future PRs do not re-introduce these vague imports so that we do not regress size by a large amount.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
