### PR TITLE
Fix activity-skill-filter in 2.4.0

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapper.ts
@@ -11,6 +11,7 @@ export type Props = OwnProps;
 const buildActivityCss = (config: ActivityCssConfig) => {
   const { idx, display, order } = config;
   // NOTE: idx/order are 0-based, CSS order and nth-of-type are 1-based
+  // Flex UI 2.4.0 changed data-test to data-testid; we support both versions
   return `
     & > div.Twilio-MainHeader > div.Twilio-MainHeader-end > div > div[data-test="activity-menu"],
     & > div.Twilio-MainHeader > div.Twilio-MainHeader-end > div > div[data-testid="activity-menu"] {

--- a/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-skill-filter/custom-components/activity-wrapper/ActivityWrapper.ts
@@ -12,7 +12,8 @@ const buildActivityCss = (config: ActivityCssConfig) => {
   const { idx, display, order } = config;
   // NOTE: idx/order are 0-based, CSS order and nth-of-type are 1-based
   return `
-    & > div.Twilio-MainHeader > div.Twilio-MainHeader-end > div > div[data-test="activity-menu"] {
+    & > div.Twilio-MainHeader > div.Twilio-MainHeader-end > div > div[data-test="activity-menu"],
+    & > div.Twilio-MainHeader > div.Twilio-MainHeader-end > div > div[data-testid="activity-menu"] {
       display: flex;
       flex-direction: column;
       > button:nth-of-type(${idx + 1}) {


### PR DESCRIPTION
### Summary

The `data-test` tag got changed to `data-testid`, which broke the CSS selector. This fix supports both the old and new versions.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
