### PR TITLE
correcting missing comma

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -78,7 +78,7 @@
         "enabled": true,
         "url": "{{serverless.url}}/features/enhanced-crm-container/index.html?line1={{task.from}}&line2={{task.direction}}",
         "should_display_url_when_no_tasks": true,
-        "display_url_when_no_tasks": "{{serverless.url}}/features/enhanced-crm-container/index.html"
+        "display_url_when_no_tasks": "{{serverless.url}}/features/enhanced-crm-container/index.html",
         "enable_url_tab": true,
         "url_tab_title": "Web Page"
       },


### PR DESCRIPTION
### Summary

The enhanced crm container modifications missed a comma when updating the ui_attributes which causes installs to fail.

