### PR TITLE
Adding check for non-existent object

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -190,7 +190,7 @@ const AdminView = () => {
                   <FeatureCard
                     feature={feature}
                     configureFor={configureFor}
-                    isUserModified={configureFor === 'user' && userConfig?.features[feature] !== undefined}
+                    isUserModified={configureFor === 'user' && userConfig?.features && userConfig?.features[feature] !== undefined}
                     config={config?.features[feature]}
                     handleSave={handleSave}
                     key={feature}

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -190,7 +190,9 @@ const AdminView = () => {
                   <FeatureCard
                     feature={feature}
                     configureFor={configureFor}
-                    isUserModified={configureFor === 'user' && userConfig?.features && userConfig?.features[feature] !== undefined}
+                    isUserModified={
+                      configureFor === 'user' && userConfig?.features && userConfig?.features[feature] !== undefined
+                    }
                     config={config?.features[feature]}
                     handleSave={handleSave}
                     key={feature}


### PR DESCRIPTION
### Summary

When a worker has no features object, like a fresh install, the admin-ui was bombing out.

A simple check to for whether any features object exists on the worker corrects this issue.
