### PR TITLE
Fix for repeated terraform deploys

### DIFF
--- a/.github/workflows/terraform_deploy.yaml
+++ b/.github/workflows/terraform_deploy.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Import Internal State
         run: |
           ./import_internal_state.sh
-        if: steps.pull-state.outputs.JOB_FAILED == 'true'
+        if: steps.pull-state.outputs.JOB_FAILED == 'false'
         working-directory: ./infra-as-code/state
         id: import_internal_state
       - name: Export State

--- a/.github/workflows/terraform_deploy.yaml
+++ b/.github/workflows/terraform_deploy.yaml
@@ -25,7 +25,7 @@ jobs:
   terraform_deploy:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    name: Deploy Terraform
+    name: Terraform
     env:
       ENCRYPTION_KEY: ${{ secrets.TF_ENCRYPTION_KEY }}
       TF_STATE_FILES: ".terraform.lock.hcl|terraform.tfstate"

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -76,7 +76,6 @@ importInternalState() {
 	import_resource "$flows" "Messaging Flow" "module.studio.twilio_studio_flows_v2.messaging" "friendlyName" false
 	import_resource "$flows" "Chat Flow" "module.studio.twilio_studio_flows_v2.chat" "friendlyName" false
 	echo "   - :white_check_mark: Studio - Flows" >>$GITHUB_STEP_SUMMARY
-	echo "   - :white_check_mark: Studio - Flows" >>$GITHUB_STEP_SUMMARY
 
 }
 

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -124,6 +124,7 @@ export TF_VAR_SERVERLESS_SID TF_VAR_SCHEDULE_MANAGER_SID TF_VAR_SERVERLESS_DOMAI
 ### only if existing state file does not exist
 ### do we want to import the internal state
 if ! [ -f ./terraform.tfstate.enc ]; then
+  echo "   - Importing existing Twilio state to a new terraform state file" >>$GITHUB_STEP_SUMMARY
   importInternalState
 fi
 

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -120,7 +120,12 @@ fi
 
 export TF_VAR_SERVERLESS_SID TF_VAR_SCHEDULE_MANAGER_SID TF_VAR_SERVERLESS_DOMAIN TF_VAR_SERVERLESS_ENV_SID TF_VAR_SCHEDULE_MANAGER_DOMAIN TF_VAR_SCHEDULE_MANAGER_ENV_SID TF_VAR_FUNCTION_CREATE_CALLBACK TF_VAR_FUNCTION_CHECK_SCHEDULE_SID
 
-importInternalState
+
+### only if existing state file does not exist
+### do we want to import the internal state
+if ! [ -f ./terraform.tfstate.enc ]; then
+  importInternalState
+fi
 
 terraform -chdir="../terraform/environments/default" apply -input=false -auto-approve
 echo "JOB_FAILED=false" >>"$GITHUB_OUTPUT"

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -123,7 +123,7 @@ export TF_VAR_SERVERLESS_SID TF_VAR_SCHEDULE_MANAGER_SID TF_VAR_SERVERLESS_DOMAI
 
 ### only if existing state file does not exist
 ### do we want to import the internal state
-if ! [ -f ./terraform.tfstate ]; then
+if ! [ -f ../terraform/environments/default/terraform.tfstate ]; then
   importInternalState
 fi
 

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -34,7 +34,7 @@ import_resource() {
 }
 
 importInternalState() {
-	echo " - Discovering and importing existing state for known definitions" >>$GITHUB_STEP_SUMMARY
+	echo " - Discovering and importing existing Twilio state for known definitions into a new terraform state file" >>$GITHUB_STEP_SUMMARY
 	workspaces=$(twilio api:taskrouter:v1:workspaces:list --no-limit -o json)
 	TF_WORKSPACE_SID=$(get_value_from_json "$workspaces" "friendlyName" "Flex Task Assignment" "sid")
 	import_resource "$workspaces" "Flex Task Assignment" "module.taskrouter.twilio_taskrouter_workspaces_v1.flex" "friendlyName" false
@@ -123,8 +123,7 @@ export TF_VAR_SERVERLESS_SID TF_VAR_SCHEDULE_MANAGER_SID TF_VAR_SERVERLESS_DOMAI
 
 ### only if existing state file does not exist
 ### do we want to import the internal state
-if ! [ -f ./terraform.tfstate.enc ]; then
-  echo "   - Importing existing Twilio state to a new terraform state file" >>$GITHUB_STEP_SUMMARY
+if ! [ -f ./terraform.tfstate ]; then
   importInternalState
 fi
 

--- a/infra-as-code/state/import_internal_state.sh
+++ b/infra-as-code/state/import_internal_state.sh
@@ -128,4 +128,5 @@ if ! [ -f ../terraform/environments/default/terraform.tfstate ]; then
 fi
 
 terraform -chdir="../terraform/environments/default" apply -input=false -auto-approve
+echo " - Applying terraform configuration complete" >>$GITHUB_STEP_SUMMARY
 echo "JOB_FAILED=false" >>"$GITHUB_OUTPUT"

--- a/infra-as-code/state/pull_state.sh
+++ b/infra-as-code/state/pull_state.sh
@@ -30,6 +30,7 @@ if [ -n "$tfstate_bucket" ]; then
 			openssl enc -d -in "$item.enc" -aes-256-cbc -pbkdf2 -k "$ENCRYPTION_KEY" -out "../terraform/environments/default/$item"
 			rm -f "$full_item_name"
 			rm -f "$item.enc"
+			echo "   - :white_check_mark: Existing terraform state file retrieved" >>$GITHUB_STEP_SUMMARY
 		done
 	else
 		echo "JOB_FAILED=true" >>"$GITHUB_OUTPUT"
@@ -41,4 +42,4 @@ else
 	echo "   - :white_check_mark: Unable to identify an existing terraform state - proceeding without" >>$GITHUB_STEP_SUMMARY
 fi
 echo "JOB_FAILED=false" >>"$GITHUB_OUTPUT"
-echo "   - :white_check_mark: Existing terraform state file retrieved" >>$GITHUB_STEP_SUMMARY
+

--- a/infra-as-code/state/pull_state.sh
+++ b/infra-as-code/state/pull_state.sh
@@ -34,10 +34,11 @@ if [ -n "$tfstate_bucket" ]; then
 	else
 		echo "JOB_FAILED=true" >>"$GITHUB_OUTPUT"
 		echo "$full_link not found" >>"$GITHUB_STEP_SUMMARY"
+		echo "   - :x: Existing Terrform state identified - but unable to retrieve it - if this is in error try removing the tfstate service on your twilio account" >>$GITHUB_STEP_SUMMARY
 		exit 0
 	fi
 else
-	echo "JOB_FAILED=true" >>"$GITHUB_OUTPUT"
-	exit 0
+	echo "   - :white_check_mark: Unable to identify an existing terraform state - proceeding without" >>$GITHUB_STEP_SUMMARY
 fi
+echo "JOB_FAILED=false" >>"$GITHUB_OUTPUT"
 echo "   - :white_check_mark: Terraform imported" >>$GITHUB_STEP_SUMMARY

--- a/infra-as-code/state/pull_state.sh
+++ b/infra-as-code/state/pull_state.sh
@@ -36,7 +36,7 @@ if [ -n "$tfstate_bucket" ]; then
 		echo "JOB_FAILED=true" >>"$GITHUB_OUTPUT"
 		echo "$full_link not found" >>"$GITHUB_STEP_SUMMARY"
 		echo "   - :x: Existing Terrform state identified - but unable to retrieve it - if this is in error try removing the tfstate service on your twilio account" >>$GITHUB_STEP_SUMMARY
-		exit 0
+		exit 1
 	fi
 else
 	echo "   - :white_check_mark: Unable to identify an existing terraform state - proceeding without" >>$GITHUB_STEP_SUMMARY

--- a/infra-as-code/state/pull_state.sh
+++ b/infra-as-code/state/pull_state.sh
@@ -41,4 +41,4 @@ else
 	echo "   - :white_check_mark: Unable to identify an existing terraform state - proceeding without" >>$GITHUB_STEP_SUMMARY
 fi
 echo "JOB_FAILED=false" >>"$GITHUB_OUTPUT"
-echo "   - :white_check_mark: Terraform imported" >>$GITHUB_STEP_SUMMARY
+echo "   - :white_check_mark: Existing terraform state file retrieved" >>$GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Summary

Discovered that when doing subsequent deploys of terraform changes, they would not apply.  This addresses the issue by correctly identifying if a state file exists and whether to import the existing twilio state.  I also updated some of the summary messages to reflect whats happening in the three different scenarios i tested.

1. no state file - import existing twilio state then apply configuration
2. state file - skip importing and apply configuration
3. tfstate service but files inaccessible - skip everything.

### Checklist

- [x] Tested changes end to end
