### PR TITLE
Add uninstall script option

### DIFF
--- a/docs/docs/building/template-utilities/configuration.md
+++ b/docs/docs/building/template-utilities/configuration.md
@@ -227,6 +227,15 @@ Normally the script will run `npm install` for each package. However, if you onl
 npm run postinstall -- --skip-install
 ```
 
+### uninstall
+If you would like to completely remove the installed npm dependencies:
+
+```bash
+npm run postinstall -- --uninstall
+```
+
+This will remove `node_modules` and `package-lock.json` within each package before dependencies are installed (unless `--skip-install` is also specified, in which case dependencies would be removed but not reinstalled).
+
 ### env
 By default, the script will assume you are running locally and not deploying to a specific environment. When running in CI, the `ENVIRONMENT` env var is set, which the script uses to determine the environment being deployed. However, you can override this behavior by specifying an environment manually as follows:
 

--- a/scripts/common/install-packages.mjs
+++ b/scripts/common/install-packages.mjs
@@ -1,10 +1,20 @@
 import shell from "shelljs";
 
-export default (packageDir) => {
+export default (packageDir, skipInstall, uninstall) => {
   if (packageDir && shell.test('-d', packageDir)) {
-    console.log(`Installing package ${packageDir}...`);
-    shell.cd(`./${packageDir}`)
-    shell.exec("npm install", {silent:true});
+    shell.cd(`./${packageDir}`);
+    
+    if (uninstall) {
+      console.log(`Uninstalling package ${packageDir}...`);
+      shell.rm('-rf', 'node_modules');
+      shell.rm('-f', 'package-lock.json');
+    }
+    
+    if (!skipInstall) {
+      console.log(`Installing package ${packageDir}...`);
+      shell.exec("npm install", {silent:true});
+    }
+    
     const dirDepth = packageDir.split("/").length;
     for (let i = 0; i < dirDepth; i++) {
       shell.cd("..");

--- a/scripts/setup-environment.mjs
+++ b/scripts/setup-environment.mjs
@@ -11,6 +11,7 @@ import * as constants from "./common/constants.mjs";
 
 let skipInstallStep = false;
 let overwrite = false;
+let uninstall = false;
 let environment = process.env.ENVIRONMENT;
 let overridePackages = [];
 
@@ -24,6 +25,8 @@ for (let i = 2; i < process.argv.length; i++) {
     overridePackages = process.argv[i].slice(11).split(',');
   } else if (process.argv[i].startsWith('--overwrite')) {
     overwrite = true;
+  } else if (process.argv[i].startsWith('--uninstall')) {
+    uninstall = true;
   }
 }
 
@@ -89,12 +92,12 @@ const execute = async () => {
     saveAppConfig(overwrite);
   }
   
-  if (!skipInstallStep) {
+  if (!skipInstallStep || uninstall) {
     if (!overridePackages.length) {
-      installNpmPackage(getPluginDirs().pluginDir);
+      installNpmPackage(getPluginDirs().pluginDir, skipInstallStep, uninstall);
     }
     for (const path of packages) {
-      installNpmPackage(path);
+      installNpmPackage(path, skipInstallStep, uninstall);
     }
   }
   


### PR DESCRIPTION
### Summary

Adds an `--uninstall` flag to the setup script. This removes npm dependencies from each package before installing them. This is useful in several scenarios:
- Broken node dependencies, and "annihilation" is easier than fixing them
- Ensuring all packages are the latest version, such as flex-ui
- Easier to test package dependency changes

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
