### PR TITLE
Adjust overwrite to clear existing custom_data

### DIFF
--- a/flex-config/index.js
+++ b/flex-config/index.js
@@ -81,6 +81,8 @@ async function deployConfigurationData({ auth, environment, overwrite }) {
     console.log("Merging current configuraton with new configuration...");
     let uiAttributesMerged;
     if (overwrite && overwrite.toLowerCase() === "true") {
+      // when overwriting, clear out the existing custom_data object to remove obsolete values
+      delete uiAttributesCurrent.custom_data;
       uiAttributesMerged = _.merge(uiAttributesCurrent, uiAttributesCommon, uiAttributesOverrides);
     } else {
       uiAttributesMerged = _.merge({}, uiAttributesCommon, uiAttributesOverrides, uiAttributesCurrent);


### PR DESCRIPTION
### Summary

When using the option to overwrite config when performing deployment, while this overwrites existing data, old obsolete data may remain. Clear out custom_data before merging in existing config to fix this.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
