### PR TITLE
Use node 18 for all jobs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install packages
         run: |
           npm install --ignore-scripts
@@ -71,7 +71,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install packages
         working-directory: ./plugin-flex-ts-template-v2
         run: npm install

--- a/.github/workflows/docs_checks.yaml
+++ b/.github/workflows/docs_checks.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install packages
         working-directory: ./docs
         run: npm install

--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: set github environment variables
         env:
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
@@ -161,7 +161,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: set github environment variables
         env:
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
@@ -194,7 +194,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: install twilio cli
         run: npm install --ignore-scripts


### PR DESCRIPTION
### Summary

Since the serverless toolkit requires Node 18 now, and the Flex plugin CLI now works with 18 as well, switch everything over to use it.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
