### PR TITLE
Logger Utility now listens for `flexError` events.

### DIFF
--- a/docs/docs/building/template-utilities/logging.md
+++ b/docs/docs/building/template-utilities/logging.md
@@ -64,6 +64,10 @@ The Flex Project Template will automatically append the workerSid and worker nam
 
 If for some reason this logging utility does not meet your needs - you are free to use `console.log/warn/error` directly.
 
+### Flex Error Integration
+
+The logger will automatically listen for and log with `logger.error()` all [Flex Errors Events](https://www.twilio.com/docs/flex/developer/ui/errors-and-debugging#listening-to-the-flexerror-event) automatically.
+
 ## Destinations
 
 Destinations are an important concept for this logging utility. A destination is where the logs should go. It can be something simple, like the browser console, or something more complex like an external logging aggregator like Datadog.

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/index.ts
@@ -52,7 +52,7 @@ export const initFeatures = (flex: typeof Flex, manager: Flex.Manager) => {
   Logger.addHook(flex, manager, 'built-in logger to browser console', SendLogsToBrowserConsole);
 
   // After all features have initialized, execute deferred hooks
-  Logger.init();
+  Logger.init(manager);
   CssOverrides.init(manager);
   PasteElements.init(flex);
   Reducers.init(manager);

--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/logger.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/logger.ts
@@ -6,7 +6,11 @@ import Destination from '../logger/destination';
 
 const destinations: Destination[] = [];
 
-export const init = () => {
+export const init = (manager: Flex.Manager) => {
+  manager.events.addListener('flexError', (error) => {
+    logger.error('Internal FlexError', error);
+  });
+
   const worker = FlexHelperSingleton.getCurrentWorker();
   if (worker) {
     logger.addMetaData('workerSid', worker.sid);


### PR DESCRIPTION
The Logger Utility will not automatically register a listener on the Flex Manager for `flexError` events and will push them through the logger as errors. These will flow to configured destinations (tested with Datadog).

### Summary

Our standard logger integration now listens for `flexError` events and will push them through our logger.

### Checklist

- [x] Tested changes end to end
- [ ] Updated documentation
- [x] Requested one or more reviewers
