### PR TITLE
Use virtualStartTime for callback requests

### DIFF
--- a/serverless-functions/package-lock.json
+++ b/serverless-functions/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.0",
         "lodash": "^4.17.21",
         "randomstring": "^1.3.0",
-        "twilio": "^4.11.0",
+        "twilio": "^4.19.0",
         "twilio-flex-token-validator": "^1.5.6"
       },
       "devDependencies": {

--- a/serverless-functions/package.json
+++ b/serverless-functions/package.json
@@ -15,7 +15,7 @@
     "axios": "^1.6.0",
     "lodash": "^4.17.21",
     "randomstring": "^1.3.0",
-    "twilio": "^4.11.0",
+    "twilio": "^4.19.0",
     "twilio-flex-token-validator": "^1.5.6"
   },
   "devDependencies": {

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -222,7 +222,6 @@ exports.createTask = async function createTask(parameters) {
 
   if (virtualStartTime) {
     createParams.virtualStartTime = virtualStartTime;
-    console.log(`Setting virtualStartTime to ${virtualStartTime}`);
   }
 
   try {

--- a/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
+++ b/serverless-functions/src/functions/common/twilio-wrappers/taskrouter.private.js
@@ -184,6 +184,7 @@ exports.updateReservation = async function updateReservation(parameters) {
  * @param {string} parameters.workflowSid the workflow to submit the task
  * @param {string} parameters.taskChannel the task channel to submit the task on
  * @param {object} parameters.attributes the attributes applied to the task
+ * @param {string} parameters.virtualStartTime the start time to use for task ordering
  * @param {number} parameters.priority the priority
  * @param {number} parameters.timeout timeout
  * @returns {object} an object containing the task if successful
@@ -195,6 +196,7 @@ exports.createTask = async function createTask(parameters) {
     workflowSid,
     taskChannel,
     attributes,
+    virtualStartTime,
     priority: overriddenPriority,
     timeout: overriddenTimeout,
   } = parameters;
@@ -210,15 +212,24 @@ exports.createTask = async function createTask(parameters) {
   const timeout = overriddenTimeout || 86400;
   const priority = overriddenPriority || 0;
 
+  const createParams = {
+    attributes: JSON.stringify(attributes),
+    workflowSid,
+    taskChannel,
+    priority,
+    timeout,
+  };
+
+  if (virtualStartTime) {
+    createParams.virtualStartTime = virtualStartTime;
+    console.log(`Setting virtualStartTime to ${virtualStartTime}`);
+  }
+
   try {
     const client = context.getTwilioClient();
-    const task = await client.taskrouter.v1.workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID).tasks.create({
-      attributes: JSON.stringify(attributes),
-      workflowSid,
-      taskChannel,
-      priority,
-      timeout,
-    });
+    const task = await client.taskrouter.v1
+      .workspaces(process.env.TWILIO_FLEX_WORKSPACE_SID)
+      .tasks.create(createParams);
 
     return {
       success: true,

--- a/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/common/callback-operations.private.js
@@ -19,6 +19,7 @@ exports.createCallbackTask = async (parameters) => {
     transcriptText,
     isDeleted,
     overriddenTaskChannel,
+    virtualStartTime,
   } = parameters;
 
   // use assigned values or use defaults
@@ -60,5 +61,6 @@ exports.createCallbackTask = async (parameters) => {
     attributes,
     priority,
     timeout,
+    virtualStartTime,
   });
 };

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
@@ -241,7 +241,7 @@ exports.handler = async (context, event, callback) => {
         numberToCallFrom: event.Called,
       };
 
-      if (options.retainPlaceInQueue) {
+      if (options.retainPlaceInQueue && enqueuedTaskSid) {
         // Get the original task's start time to maintain queue ordering.
         const originalTask = await fetchTask(context, enqueuedTaskSid);
         callbackParams.virtualStartTime = originalTask?.dateCreated;
@@ -279,7 +279,7 @@ exports.handler = async (context, event, callback) => {
       return callback(null, twiml);
 
     case 'submit-voicemail':
-      // Submit the voicemail to Taskrouter (and/or to your backend if you have a voicemail handling solution)
+      // Submit the voicemail to TaskRouter (and/or to your backend if you have a voicemail handling solution)
 
       // Create the Voicemail task
       // Option to pull in a few more things from original task like conversation_id or even the workflowSid
@@ -293,7 +293,7 @@ exports.handler = async (context, event, callback) => {
         transcriptText: event.TranscriptionText,
       };
 
-      if (options.retainPlaceInQueue) {
+      if (options.retainPlaceInQueue && enqueuedTaskSid) {
         // Get the original task's start time to maintain queue ordering.
         const originalTask = await fetchTask(context, enqueuedTaskSid);
         vmParams.virtualStartTime = originalTask?.dateCreated;

--- a/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
+++ b/serverless-functions/src/functions/features/callback-and-voicemail/studio/wait-experience.protected.js
@@ -9,6 +9,7 @@ const CallbackOperations = require(Runtime.getFunctions()['features/callback-and
   .path);
 
 const options = {
+  retainPlaceInQueue: true,
   sayOptions: { voice: 'Polly.Joanna' },
   holdMusicUrl: 'http://com.twilio.music.soft-rock.s3.amazonaws.com/_ghost_-_promo_2_sample_pack.mp3',
   messages: {
@@ -234,11 +235,19 @@ exports.handler = async (context, event, callback) => {
     case 'submit-callback':
       // Create the Callback task
       // Option to pull in a few more things from original task like conversation_id or even the workflowSid
-      await CallbackOperations.createCallbackTask({
+      const callbackParams = {
         context,
         numberToCall: event.Caller,
         numberToCallFrom: event.Called,
-      });
+      };
+
+      if (options.retainPlaceInQueue) {
+        // Get the original task's start time to maintain queue ordering.
+        const originalTask = await fetchTask(context, enqueuedTaskSid);
+        callbackParams.virtualStartTime = originalTask?.dateCreated;
+      }
+
+      await CallbackOperations.createCallbackTask(callbackParams);
 
       // End the interaction. Hangup the call.
       twiml.say(options.sayOptions, options.messages.callbackSubmitted);
@@ -274,8 +283,7 @@ exports.handler = async (context, event, callback) => {
 
       // Create the Voicemail task
       // Option to pull in a few more things from original task like conversation_id or even the workflowSid
-
-      await CallbackOperations.createCallbackTask({
+      const vmParams = {
         context,
         numberToCall: event.Caller,
         numberToCallFrom: event.Called,
@@ -283,7 +291,15 @@ exports.handler = async (context, event, callback) => {
         recordingUrl: event.RecordingUrl,
         transcriptSid: event.TranscriptionSid,
         transcriptText: event.TranscriptionText,
-      });
+      };
+
+      if (options.retainPlaceInQueue) {
+        // Get the original task's start time to maintain queue ordering.
+        const originalTask = await fetchTask(context, enqueuedTaskSid);
+        vmParams.virtualStartTime = originalTask?.dateCreated;
+      }
+
+      await CallbackOperations.createCallbackTask(vmParams);
 
       return callback(null, '');
 


### PR DESCRIPTION
### Summary

Addresses #441 by adding an option to the `wait-experience` logic, which when enabled (it is by default), sets the `virtualStartTime` parameter to the value of the original task's `dateCreated`.

Also updated the Twilio library to a version that supports the parameter.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
