### PR TITLE
Revising implementation for worker canvas tabs

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -359,6 +359,9 @@
         "text_attributes": [],
         "boolean_attributes": []
       },
+      "worker_canvas_tabs": {
+        "enabled": true
+      },
       "datadog_log_integration": {
         "enabled": false,
         "log_level": "info",

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -353,7 +353,7 @@
         "enabled": false
       },
       "worker_details": {
-        "enabled": false,
+        "enabled": true,
         "edit_team": true,
         "edit_department": true,
         "text_attributes": [],

--- a/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/config.ts
@@ -4,10 +4,16 @@ import AttributeViewerConfig from './types/ServiceConfiguration';
 const { enabled = false, enabled_for_agents = false } =
   (getFeatureFlags()?.features?.attribute_viewer as AttributeViewerConfig) || {};
 
+const { enabled: workerCanvasTabsEnabled = false } = getFeatureFlags()?.features?.worker_canvas_tabs || {};
+
 export const isFeatureEnabled = () => {
   return enabled;
 };
 
 export const isEnabledForAgents = () => {
   return enabled_for_agents;
+};
+
+export const isWorkerCanvasTabsEnabled = () => {
+  return workerCanvasTabsEnabled;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/custom-components/WorkerAttributes/WorkerAttributes.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/custom-components/WorkerAttributes/WorkerAttributes.tsx
@@ -3,6 +3,7 @@ import { CodeBlock } from '@twilio-paste/core/code-block';
 
 import { SectionHeader } from './WorkerAttributes.Styles';
 import { StringTemplates } from '../../flex-hooks/strings';
+import { isWorkerCanvasTabsEnabled } from '../../config';
 
 interface Props {
   worker?: IWorker;
@@ -11,9 +12,11 @@ interface Props {
 const WorkerAttributes = ({ worker }: Props) => {
   return (
     <>
-      <SectionHeader>
-        <Template source={templates[StringTemplates.WorkerAttributesHeader]} />
-      </SectionHeader>
+      {isWorkerCanvasTabsEnabled() ? null : (
+        <SectionHeader>
+          <Template source={templates[StringTemplates.WorkerAttributesHeader]} />
+        </SectionHeader>
+      )}
       <CodeBlock variant="multi-line" language="json" code={JSON.stringify(worker?.attributes, null, 2)} />
     </>
   );

--- a/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/flex-hooks/components/WorkerCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/attribute-viewer/flex-hooks/components/WorkerCanvas.tsx
@@ -1,11 +1,18 @@
-// import * as Flex from '@twilio/flex-ui';
+import * as Flex from '@twilio/flex-ui';
+import { ContentFragmentProps } from '@twilio/flex-ui';
 
-// import WorkerAttributes from '../../custom-components/WorkerAttributes';
+import WorkerAttributes from '../../custom-components/WorkerAttributes';
 import { FlexComponent } from '../../../../types/feature-loader';
+import { StringTemplates } from '../strings';
+
+interface TabbedContentFragmentProps extends ContentFragmentProps {
+  tabTitle: string;
+}
 
 export const componentName = FlexComponent.WorkerCanvas;
 export const componentHook = function addAttributesToWorkerCanvas() {
-  // flex.WorkerCanvas.Content.add(<WorkerAttributes key="worker-attributes" />, {
-  //   sortOrder: 1000,
-  // });
+  Flex.WorkerCanvas.Content.add(<WorkerAttributes key="worker-attributes" />, {
+    tabTitle: StringTemplates.WorkerAttributesHeader,
+    sortOrder: 1000,
+  } as TabbedContentFragmentProps);
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/config.ts
@@ -3,10 +3,16 @@ import SupervisorCapacityConfig from './types/ServiceConfiguration';
 
 const { enabled = false, rules } = (getFeatureFlags()?.features?.supervisor_capacity as SupervisorCapacityConfig) || {};
 
+const { enabled: workerCanvasTabsEnabled = false } = getFeatureFlags()?.features?.worker_canvas_tabs || {};
+
 export const isFeatureEnabled = () => {
   return enabled;
 };
 
 export const getRules = () => {
   return rules;
+};
+
+export const isWorkerCanvasTabsEnabled = () => {
+  return workerCanvasTabsEnabled;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/custom-components/CapacityContainer/CapacityContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-capacity/custom-components/CapacityContainer/CapacityContainer.tsx
@@ -9,7 +9,7 @@ import { SectionHeader } from './CapacityContainerStyles';
 import TaskRouterService, {
   WorkerChannelCapacityResponse,
 } from '../../../../utils/serverless/TaskRouter/TaskRouterService';
-import { getRules } from '../../config';
+import { getRules, isWorkerCanvasTabsEnabled } from '../../config';
 import CapacityChannel from '../CapacityChannel';
 import { StringTemplates } from '../../flex-hooks/strings';
 
@@ -131,9 +131,11 @@ export default function CapacityContainer(props: OwnProps) {
 
   return (
     <Stack orientation="vertical" spacing="space0">
-      <SectionHeader>
-        <Template source={templates[StringTemplates.ChannelCapacity]} />
-      </SectionHeader>
+      {isWorkerCanvasTabsEnabled() ? null : (
+        <SectionHeader>
+          <Template source={templates[StringTemplates.ChannelCapacity]} />
+        </SectionHeader>
+      )}
       {workerChannels.length > 0 &&
         workerChannels.map((workerChannel) => (
           <CapacityChannel

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/config.ts
@@ -1,15 +1,7 @@
 import { getFeatureFlags } from '../../utils/configuration';
 
-const { enabled: supervisorCapacityEnabled = false } = getFeatureFlags()?.features?.supervisor_capacity || {};
-const { enabled: attributeViewerEnabled = false } = getFeatureFlags()?.features?.attribute_viewer || {};
-const { enabled: workerDetailsEnabled = false } = getFeatureFlags()?.features?.worker_details || {};
+const { enabled = false } = getFeatureFlags()?.features?.worker_canvas_tabs || {};
 
-export const isSupervisorCapacityEnabled = () => {
-  return supervisorCapacityEnabled;
-};
-export const isAttributeViewerEnabled = () => {
-  return attributeViewerEnabled;
-};
-export const isWorkerDetailsEnabled = () => {
-  return workerDetailsEnabled;
+export const isFeatureEnabled = () => {
+  return enabled;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/custom-components/WorkerCanvasTabs/WorkerCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/custom-components/WorkerCanvasTabs/WorkerCanvasTabs.tsx
@@ -42,8 +42,8 @@ const WorkerCanvasTabs = ({ worker, fragments }: Props) => {
   const { ...tabState } = useTabState();
 
   return (
-    <Box overflow="auto" padding="space40" width="100%">
-      <Tabs selectedId={randomId} baseId="options" orientation="horizontal" state={tabState}>
+    <Box height="100%" borderLeftStyle="solid" borderColor="colorBorderWeak" borderWidth="borderWidth10">
+      <Tabs selectedId={randomId} baseId="options" state={tabState}>
         <TabList aria-label="horizontal tabs">
           <Tab id={randomId} element="WORKER_CANVAS_TAB">
             <Template source={templates[StringTemplates.WorkerCanvasTabSkills]} />

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/custom-components/WorkerCanvasTabs/WorkerCanvasTabs.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/custom-components/WorkerCanvasTabs/WorkerCanvasTabs.tsx
@@ -1,24 +1,43 @@
 import { Box } from '@twilio-paste/core/Box';
 import { Tabs, Tab, TabList, TabPanel, TabPanels, useTabState } from '@twilio-paste/core/tabs';
 import { useUID } from '@twilio-paste/core/uid-library';
-import { Actions, IWorker, Template, templates, WorkerSkills } from '@twilio/flex-ui';
+import { IWorker, Template, templates, ContentFragmentProps, WorkerSkills, Actions } from '@twilio/flex-ui';
+import React from 'react';
 
-import WorkerAttributes from '../../../attribute-viewer/custom-components/WorkerAttributes';
-import CapacityContainer from '../../../supervisor-capacity/custom-components/CapacityContainer';
-import WorkerDetailsContainer from '../../../worker-details/custom-components/WorkerDetailsContainer/WorkerDetailsContainer';
-import { isAttributeViewerEnabled, isSupervisorCapacityEnabled, isWorkerDetailsEnabled } from '../../config';
 import { StringTemplates } from '../../flex-hooks/strings';
+
+interface Props {
+  worker?: IWorker;
+  fragments: React.ReactElement<
+    ContentFragmentProps & {
+      children?: React.ReactNode;
+    },
+    string | React.JSXElementConstructor<any>
+  >[];
+}
+
+interface TabbedContentFragmentProps extends ContentFragmentProps {
+  tabTitle: string;
+}
+
+const hasTabTitle = (
+  fragment: React.ReactElement<
+    ContentFragmentProps & {
+      children?: React.ReactNode;
+    },
+    string | React.JSXElementConstructor<any>
+  >,
+): boolean => {
+  const title = (fragment.props as TabbedContentFragmentProps)?.tabTitle;
+  return !(title === '' || title === undefined || title === null);
+};
 
 const handleClose = () => {
   Actions.invokeAction('SelectWorkerInSupervisor', { worker: undefined });
   Actions.invokeAction('SetComponentState', { name: 'SupervisorCanvasTabs', state: { selectedTabName: undefined } });
 };
 
-interface Props {
-  worker?: IWorker;
-}
-
-const WorkerCanvasTabs = ({ worker }: Props) => {
+const WorkerCanvasTabs = ({ worker, fragments }: Props) => {
   const randomId = useUID();
   const { ...tabState } = useTabState();
 
@@ -29,37 +48,23 @@ const WorkerCanvasTabs = ({ worker }: Props) => {
           <Tab id={randomId} element="WORKER_CANVAS_TAB">
             <Template source={templates[StringTemplates.WorkerCanvasTabSkills]} />
           </Tab>
-          {isSupervisorCapacityEnabled() && (
-            <Tab element="WORKER_CANVAS_TAB">
-              <Template source={templates[StringTemplates.WorkerCanvasTabCapacity]} />
+          {fragments.map((fragment) => (
+            <Tab key={(fragment.props.children as React.ReactElement).key} element="WORKER_CANVAS_TAB">
+              {hasTabTitle(fragment) ? (
+                <Template source={templates[(fragment.props as TabbedContentFragmentProps).tabTitle]} />
+              ) : (
+                (fragment.props.children as React.ReactElement).key
+              )}
             </Tab>
-          )}
-          {isAttributeViewerEnabled() && (
-            <Tab element="WORKER_CANVAS_TAB">
-              <Template source={templates[StringTemplates.WorkerCanvasTabAttributes]} />
-            </Tab>
-          )}
-          {isWorkerDetailsEnabled() && (
-            <Tab element="WORKER_CANVAS_TAB">
-              <Template source={templates[StringTemplates.WorkerCanvasTabDetails]} />
-            </Tab>
-          )}
+          ))}
         </TabList>
         <TabPanels>
           <TabPanel>{worker && <WorkerSkills key="skills" worker={worker} onClose={handleClose} />}</TabPanel>
-          {isSupervisorCapacityEnabled() && (
-            <TabPanel>
-              <CapacityContainer key="worker-capacity-container" worker={worker} />
+          {fragments.map((fragment) => (
+            <TabPanel key={(fragment.props.children as React.ReactElement).key}>
+              {React.createElement((fragment.props.children as any)?.type, { worker })}
             </TabPanel>
-          )}
-          {isAttributeViewerEnabled() && (
-            <TabPanel>
-              <WorkerAttributes key="worker-attributes" worker={worker} />
-            </TabPanel>
-          )}
-          {isWorkerDetailsEnabled() && (
-            <TabPanel>{worker && <WorkerDetailsContainer key="update-worker" worker={worker} />}</TabPanel>
-          )}
+          ))}
         </TabPanels>
       </Tabs>
     </Box>

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/components/WorkerCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/components/WorkerCanvas.tsx
@@ -19,7 +19,7 @@ export const componentHook = function addWorkerCanvasTabs(flex: typeof Flex, _ma
       .concat([])
       .toSorted((a, b) => (a.props.sortOrder || 10000) - (b.props.sortOrder || 9999));
 
-    // remove the fragments from the WorkerCanvas to prevent horizontal rendering
+    // remove the fragments from the WorkerCanvas to prevent vertical rendering
     fragments.forEach((fragment) => {
       if (fragment?.props?.children && (fragment.props.children as React.ReactElement).key) {
         const key = (fragment.props.children as React.ReactElement).key as string;

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/components/WorkerCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/components/WorkerCanvas.tsx
@@ -1,4 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
+import { Box } from '@twilio-paste/core/Box';
+import React from 'react';
 
 import { FlexComponent } from '../../../../types/feature-loader';
 import WorkerCanvasTabs from '../../custom-components/WorkerCanvasTabs/WorkerCanvasTabs';
@@ -10,6 +12,28 @@ export const componentHook = function addWorkerCanvasTabs(flex: typeof Flex, _ma
   // Remove Skills Caption and Workerskills
   flex.WorkerCanvas.Content.remove('skills-title');
   flex.WorkerCanvas.Content.remove('skills');
-  // Add Workerskills as a Tab
-  flex.WorkerCanvas.Content.add(<WorkerCanvasTabs key="worker-canvas-tabs" />);
+
+  flex.WorkerCanvas.Content.addWrapper((OriginalComponent) => (originalProps) => {
+    // preserve the fragments from the WorkerCanvas
+    const fragments = flex.WorkerCanvas.Content.fragments
+      .concat([])
+      .toSorted((a, b) => (a.props.sortOrder || 10000) - (b.props.sortOrder || 9999));
+
+    // remove the fragments from the WorkerCanvas to prevent horizontal rendering
+    fragments.forEach((fragment) => {
+      if (fragment?.props?.children && (fragment.props.children as React.ReactElement).key) {
+        const key = (fragment.props.children as React.ReactElement).key as string;
+        flex.WorkerCanvas.Content.remove(key);
+      }
+    });
+
+    return (
+      <>
+        <Box>
+          <OriginalComponent {...originalProps} />
+          <WorkerCanvasTabs key="worker-canvas-tabs" worker={originalProps.worker} fragments={fragments} />
+        </Box>
+      </>
+    );
+  });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/strings/es-mx.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/strings/es-mx.json
@@ -1,7 +1,3 @@
 {
-  "PSWorkerCanvasTabSkills": "Habilidades",
-  "PSWorkerCanvasTabCapacity": "Capacidad",
-  "PSWorkerCanvasTabAttributes": "Atributos",
-  "PSWorkerCanvasTabTeamName": "Equipo",
-  "PSWorkerCanvasTabDetails": "Detalles"
+  "PSWorkerCanvasTabSkills": "Habilidades"
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/strings/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/flex-hooks/strings/index.ts
@@ -3,19 +3,11 @@ import esMX from './es-mx.json';
 // Export the template names as an enum for better maintainability when accessing them elsewhere
 export enum StringTemplates {
   WorkerCanvasTabSkills = 'PSWorkerCanvasTabSkills',
-  WorkerCanvasTabCapacity = 'PSWorkerCanvasTabCapacity',
-  WorkerCanvasTabAttributes = 'PSWorkerCanvasTabAttributes',
-  WorkerCanvasTabTeamName = 'PSWorkerCanvasTabTeamName',
-  WorkerCanvasTabDetails = 'PSWorkerCanvasTabDetails',
 }
 
 export const stringHook = () => ({
   'en-US': {
     [StringTemplates.WorkerCanvasTabSkills]: 'Skills',
-    [StringTemplates.WorkerCanvasTabCapacity]: 'Capacity',
-    [StringTemplates.WorkerCanvasTabAttributes]: 'Attributes',
-    [StringTemplates.WorkerCanvasTabTeamName]: 'Team',
-    [StringTemplates.WorkerCanvasTabDetails]: 'Details',
   },
   'es-MX': esMX,
 });

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-canvas-tabs/index.ts
@@ -1,7 +1,9 @@
 import { FeatureDefinition } from '../../types/feature-loader';
+import { isFeatureEnabled } from './config';
 // @ts-ignore
 import hooks from './flex-hooks/**/*.*';
 
 export const register = (): FeatureDefinition => {
+  if (!isFeatureEnabled()) return {};
   return { name: 'worker-canvas-tabs', hooks: typeof hooks === 'undefined' ? [] : hooks };
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-details/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-details/config.ts
@@ -11,24 +11,36 @@ const {
 
 const { teams = [], departments = [] } = getFeatureFlags().common || {};
 
+const { enabled: workerCanvasTabsEnabled = false } = getFeatureFlags()?.features?.worker_canvas_tabs || {};
+
 export const isFeatureEnabled = () => {
   return enabled;
 };
+
 export const editTeam = () => {
   return edit_team;
 };
+
 export const editDepartment = () => {
   return edit_department;
 };
+
 export const getTextAttributes = () => {
   return text_attributes;
 };
+
 export const getBooleanAttributes = () => {
   return boolean_attributes;
 };
+
 export const getTeams = () => {
   return teams;
 };
+
 export const getDepartments = () => {
   return departments;
+};
+
+export const isWorkerCanvasTabsEnabled = () => {
+  return workerCanvasTabsEnabled;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-details/custom-components/WorkerDetailsContainer/WorkerDetailsContainer.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-details/custom-components/WorkerDetailsContainer/WorkerDetailsContainer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-unused-collection */
-import { IWorker, Template, templates } from '@twilio/flex-ui';
+import { IWorker, Template, Theme, styled, templates } from '@twilio/flex-ui';
 import React, { useState, useEffect } from 'react';
 import { Flex as FlexBox } from '@twilio-paste/core/flex';
 import { Box } from '@twilio-paste/core/box';
@@ -9,6 +9,7 @@ import { Stack } from '@twilio-paste/core/stack';
 import { Table, TBody, Tr, Td } from '@twilio-paste/core/table';
 import { Switch, SwitchGroup } from '@twilio-paste/core/switch';
 
+import { StringTemplates } from '../../flex-hooks/strings';
 import TaskRouterService from '../../../../utils/serverless/TaskRouter/TaskRouterService';
 import {
   getTeams,
@@ -17,12 +18,13 @@ import {
   editDepartment,
   getTextAttributes,
   getBooleanAttributes,
+  isWorkerCanvasTabsEnabled,
 } from '../../config';
 import AttributeSelect from './AttributeSelect';
 import AttributeCustom from './AttributeCustom';
 
 interface OwnProps {
-  worker: IWorker;
+  worker?: IWorker;
 }
 
 const WorkerDetailsContainer = ({ worker }: OwnProps) => {
@@ -83,8 +85,24 @@ const WorkerDetailsContainer = ({ worker }: OwnProps) => {
     }
   };
 
+  const SectionHeader = styled('div')`
+    flex: 0 0 auto;
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1.25rem;
+    margin: 1.25rem 1rem 0.5rem;
+    padding: 0.5rem 0px;
+    border-bottom: 1px solid ${(props) => (props.theme as Theme).tokens.borderColors.colorBorderWeak};
+    color: ${(props) => (props.theme as Theme).tokens.textColors.colorText};
+  `;
+
   return (
     <Stack orientation="vertical" spacing="space0">
+      {isWorkerCanvasTabsEnabled() ? null : (
+        <SectionHeader>
+          <Template source={templates[StringTemplates.PSWorkerDetailsContainerName]} />
+        </SectionHeader>
+      )}
       <Table variant="borderless">
         <TBody>
           <Tr key="agent_name">

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/components/WorkerCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/components/WorkerCanvas.tsx
@@ -1,7 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 import { ContentFragmentProps } from '@twilio/flex-ui';
 
-import CapacityContainer from '../../custom-components/CapacityContainer';
+import WorkerDetailsContainer from '../../custom-components/WorkerDetailsContainer/WorkerDetailsContainer';
 import { FlexComponent } from '../../../../types/feature-loader';
 import { StringTemplates } from '../strings';
 
@@ -10,8 +10,8 @@ interface TabbedContentFragmentProps extends ContentFragmentProps {
 }
 
 export const componentName = FlexComponent.WorkerCanvas;
-export const componentHook = function addCapacityToWorkerCanvas() {
-  Flex.WorkerCanvas.Content.add(<CapacityContainer key="worker-capacity-container" />, {
-    tabTitle: StringTemplates.ChannelCapacity,
+export const componentHook = function addDetailsToWorkerCanvas() {
+  Flex.WorkerCanvas.Content.add(<WorkerDetailsContainer key="worker-details-container" />, {
+    tabTitle: StringTemplates.PSWorkerDetailsContainerName,
   } as TabbedContentFragmentProps);
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/strings/es-mx.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/strings/es-mx.json
@@ -4,5 +4,6 @@
   "PSWorkerDetailsDepartment": "Departamento",
   "PSWorkerDetailsLocation": "Lugar",
   "PSWorkerDetailsManager": "Gerente",
-  "PSWorkerDetailsSettings": "Ajustes de Configuración"
+  "PSWorkerDetailsSettings": "Ajustes de Configuración",
+  "PSWorkerDetailsContainerName": "Detalles"
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/strings/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/worker-details/flex-hooks/strings/index.ts
@@ -10,6 +10,7 @@ export enum StringTemplates {
   PSWorkerDetailsLocation = 'PSWorkerDetailsLocation',
   PSWorkerDetailsManager = 'PSWorkerDetailsManager',
   PSWorkerDetailsSettings = 'PSWorkerDetailsSettings',
+  PSWorkerDetailsContainerName = 'PSWorkerDetailsContainerName',
 }
 
 export const stringHook = () => ({
@@ -20,6 +21,7 @@ export const stringHook = () => ({
     [StringTemplates.PSWorkerDetailsLocation]: 'Location',
     [StringTemplates.PSWorkerDetailsManager]: 'Manager',
     [StringTemplates.PSWorkerDetailsSettings]: 'Configuration Settings',
+    [StringTemplates.PSWorkerDetailsContainerName]: 'Details',
   },
   'es-MX': esMX,
 });


### PR DESCRIPTION
### Summary

Revised the implementation for worker canvas tabs to honor the patterns in the template.  This enables the following

- features behave safely independently of other features
- worker cavas tabs will work with plugins running adjacent to the plugin that add to worker canvas

This PR back to the original PR is to enable a coherent review of the changes made.  A final review can be performed on the original PR once these changes are merged.

### Checklist

- [x] Tested changes end to end
