### PR TITLE
Fix eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:plugin": "cd plugin-flex-ts-template-v2 && twilio flex:plugins:start --port=3000",
     "start": "npm-run-all --parallel start:serverless start:plugin",
     "start:docs": "cd docs && npm run start",
-    "lint": "eslint ./plugin-flex-ts-template-v2 ./serverless-functions ./services",
+    "lint": "eslint ./plugin-flex-ts-template-v2 ./serverless-functions ./addons",
     "lint:fix": "npm run lint -- --fix",
     "lint:report": "npm run lint -- --output-file eslint_report.json --format json"
   },


### PR DESCRIPTION
### Summary

A forgotten directory rename has resulted in `npm run lint` no longer working correctly. Fixed the directory name.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
