### PR TITLE
Fix ActivityManager code running while disabled

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helper/ActivityManager.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/activity-reservation-handler/helper/ActivityManager.ts
@@ -1,6 +1,6 @@
 import { Actions, Manager } from '@twilio/flex-ui';
 
-import { getSystemActivityNames } from '../config';
+import { getSystemActivityNames, isFeatureEnabled } from '../config';
 import FlexHelper from '../../../utils/flex-helper';
 import { CallbackPromise, PendingActivity } from '../types/ActivityManager';
 import { updatePendingActivity } from '../flex-hooks/reducers/ActivityReservationHandler';
@@ -40,6 +40,10 @@ class ActivityManager {
     this.currentRequests = [];
     this.runningRequests = 0;
     this.maxConcurrentRequests = maxConcurrentRequests;
+
+    if (!isFeatureEnabled()) {
+      return;
+    }
 
     const pendingActivity = this.#getPendingActivity();
 


### PR DESCRIPTION
### Summary

When `activity-reservation-handler` is disabled, the constructor of the `ActivityManager` still runs due to being included by webpack. The effective result of this is an unexpected `SetActivity` action being invoked at initialization when the worker has a task.

This PR adds a check to the constructor to not run when the feature is disabled.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
