### PR TITLE
Fix error with no repo vars

### DIFF
--- a/scripts/github-set-env.sh
+++ b/scripts/github-set-env.sh
@@ -13,5 +13,5 @@ EOF=_PS_TEMPLATE_VAR_EOF_
 to_envs() { jq -r "to_entries[] | \"\(.key)<<$EOF\n\(.value)\n$EOF\n\""; }
 
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-echo "$VARS_CONTEXT" | to_envs >> $GITHUB_ENV
+[[ -n "$VARS_CONTEXT" ]] && echo "$VARS_CONTEXT" | to_envs >> $GITHUB_ENV
 echo "$SECRETS_CONTEXT" | to_envs >> $GITHUB_ENV


### PR DESCRIPTION
### Summary

Simple script change to skip generating a harmless but misleading error when no repo vars (which are not required by the template) are present.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
