### PR TITLE
Replace tzdata with native browser method

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -21,8 +21,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-minimal-pie-chart": "^8.4.0",
-        "rrule": "^2.7.1",
-        "tzdata": "^1.0.35"
+        "rrule": "^2.7.1"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.12.1",
@@ -32529,11 +32528,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/tzdata": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/tzdata/-/tzdata-1.0.38.tgz",
-      "integrity": "sha512-KIgVvZTLt+DWzr3MOENNLCLdsNB+usedRYYHCVfVbA7TDewj8mfjlWmj3Mv6FfdrvfeE6Oprt+qE47YiL90duQ=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -27,13 +27,12 @@
     "emoji-mart": "^5.5.2",
     "lodash": "^4.17.20",
     "luxon": "^3.1.1",
+    "mic-recorder-to-mp3": "^2.2.2",
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "rrule": "^2.7.1",
-    "tzdata": "^1.0.35",
-    "mic-recorder-to-mp3": "^2.2.2",
-    "react-minimal-pie-chart": "^8.4.0"
+    "react-minimal-pie-chart": "^8.4.0",
+    "rrule": "^2.7.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.1",

--- a/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/custom-components/ScheduleEditor/ScheduleEditor.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/schedule-manager/custom-components/ScheduleEditor/ScheduleEditor.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import tzdata from 'tzdata';
 import { ColumnDefinition, DataTable, Manager, SidePanel, templates } from '@twilio/flex-ui';
 import { Alert } from '@twilio-paste/core/alert';
 import { Button } from '@twilio-paste/core/button';
@@ -42,12 +41,7 @@ const ScheduleEditor = (props: OwnProps) => {
   const ScheduleManagerStrings = Manager.getInstance().strings as any;
 
   useEffect(() => {
-    const zones = [];
-    for (const [key] of Object.entries(tzdata.zones)) {
-      zones.push(key);
-    }
-
-    setTimeZones(zones.sort());
+    setTimeZones(Intl.supportedValuesOf('timeZone').sort());
   }, []);
 
   const resetView = () => {


### PR DESCRIPTION
### Summary

The tzdata package was used for listing time zones in the schedule manager. Browsers now have a native method to return this list, so we do not need to use this dependency any longer. Saves about 100 KB.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
