### PR TITLE
Support attributes in CBM transfers

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-action/chatTransferTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-action/chatTransferTask.ts
@@ -27,8 +27,7 @@ const handleChatTransferAction = async (payload: TransferActionPayload) => {
     return;
   }
 
-  const removeInvitingAgent = payload?.options?.mode === 'COLD';
-  const transferChatAPIPayload = await buildInviteParticipantAPIPayload(task, targetSid, removeInvitingAgent);
+  const transferChatAPIPayload = await buildInviteParticipantAPIPayload(task, targetSid, payload?.options);
 
   if (!transferChatAPIPayload) {
     Notifications.showNotification(NotificationIds.ChatTransferFailedGeneric);
@@ -43,7 +42,7 @@ const handleChatTransferAction = async (payload: TransferActionPayload) => {
   try {
     await ChatTransferService.sendTransferChatAPIRequest(transferChatAPIPayload);
 
-    if (removeInvitingAgent) {
+    if (payload?.options?.mode === 'COLD') {
       Notifications.showNotification(NotificationIds.ChatTransferTaskSuccess);
     } else {
       Notifications.showNotification(NotificationIds.ChatParticipantInvited);

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
@@ -1,9 +1,11 @@
 import { ITask, Manager, ConversationState, TaskHelper } from '@twilio/flex-ui';
+import merge from 'lodash/merge';
 
 import TaskService from '../../../utils/serverless/TaskRouter/TaskRouterService';
 import { EncodedParams } from '../../../types/serverless';
 import ApiService from '../../../utils/serverless/ApiService';
 import { getWorkerName } from './inviteTracker';
+import { TransferOptions } from '../types/ActionPayloads';
 
 const manager: any | undefined = Manager.getInstance();
 
@@ -104,12 +106,18 @@ export const buildRemovePartiticipantAPIPayload = (task: ITask, flexInteractionP
 export const buildInviteParticipantAPIPayload = async (
   task: ITask,
   targetSid: string,
-  removeInvitingAgent: boolean,
+  options?: TransferOptions,
 ): Promise<TransferRESTPayload | null> => {
   const { taskSid } = task;
   const conversationId = task.attributes?.conversations?.conversation_id || task.taskSid;
-  const jsonAttributes = JSON.stringify(task.attributes);
   const transferTargetSid = targetSid;
+  const removeInvitingAgent = options?.mode === 'COLD';
+
+  let newAttributes = task.attributes;
+  if (options?.attributes) {
+    newAttributes = merge({}, newAttributes, JSON.parse(options.attributes));
+  }
+  const jsonAttributes = JSON.stringify(newAttributes);
 
   let transferQueueName = '';
   let transferWorkerName = '';


### PR DESCRIPTION
### Summary

The `conversation-transfer` feature declares an `attributes` property in the `TransferOptions` type, but we never actually append those attributes to the new task! This adds support for the `attributes` property in CBM transfers.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
