### PR TITLE
Remove unneeded install step

### DIFF
--- a/.github/workflows/flex_deploy.yaml
+++ b/.github/workflows/flex_deploy.yaml
@@ -178,7 +178,6 @@ jobs:
       - name: deploy flex config
         working-directory: flex-config
         run: |
-          npm install
           npm run deploy
 
   deploy-release-plugin:


### PR DESCRIPTION
### Summary

The postinstall script already ran npm install, no need to run it again.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
