### PR TITLE
Add some error handling to agent-automation

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/flex-hooks/events/taskReceived.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/flex-hooks/events/taskReceived.ts
@@ -17,8 +17,16 @@ async function selectAndAcceptTask(task: ITask, taskConfig: TaskQualificationCon
   if (taskChannelUniqueName === 'voice' && direction === 'outbound') return;
 
   // Select and accept the task per configuration
-  if (taskConfig.auto_select) await Flex.Actions.invokeAction('SelectTask', { sid });
-  if (taskConfig.auto_accept) await Flex.Actions.invokeAction('AcceptTask', { sid });
+  try {
+    if (taskConfig.auto_select) await Flex.Actions.invokeAction('SelectTask', { sid });
+  } catch (error) {
+    console.error('[agent-automation] Unable to auto select task', error);
+  }
+  try {
+    if (taskConfig.auto_accept) await Flex.Actions.invokeAction('AcceptTask', { sid });
+  } catch (error) {
+    console.error('[agent-automation] Unable to auto accept task', error);
+  }
 }
 
 export const eventName = FlexEvent.taskReceived;


### PR DESCRIPTION
### Summary

Add some error handling to the SelectTask and AcceptTask invocations. This is necessary because Flex throws an error trying to accept a task that has already been accepted (which happens with multiple instances open)

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
