### PR TITLE
Fix possible missing conference SID

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/HoldParticipant.ts
@@ -16,7 +16,7 @@ export const actionHook = function handleHoldConferenceParticipant(flex: typeof 
       return;
     }
 
-    const conferenceSid = task.conference?.conferenceSid;
+    const conferenceSid = task.conference?.conferenceSid || task.attributes?.conference?.sid;
     abortFunction();
     console.log('Holding participant', participantSid);
     await ConferenceService.holdParticipant(conferenceSid, participantSid);

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/KickParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/KickParticipant.ts
@@ -19,7 +19,7 @@ export const actionHook = function handleKickConferenceParticipant(flex: typeof 
 
       const { task, targetSid } = payload;
 
-      const conference = task.conference?.conferenceSid;
+      const conference = task.conference?.conferenceSid || task.attributes?.conference?.sid;
 
       const participantSid = targetSid;
 

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/UnholdParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/flex-hooks/actions/UnholdParticipant.ts
@@ -18,7 +18,7 @@ export const actionHook = function handleUnholdConferenceParticipant(flex: typeo
 
     console.log('Unholding participant', participantSid);
 
-    const conferenceSid = task.conference?.conferenceSid;
+    const conferenceSid = task.conference?.conferenceSid || task.attributes?.conference?.sid;
     abortFunction();
     await ConferenceService.unholdParticipant(conferenceSid, participantSid);
   });


### PR DESCRIPTION
### Summary

I noticed this was sometimes returning a null conference SID, causing an inability to hold/kick participants.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
