### PR TITLE
[SE-2] Remove phone number 1000 limit

### DIFF
--- a/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
+++ b/serverless-functions/src/functions/common/flex/phone-numbers/list-phone-numbers.js
@@ -8,11 +8,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   try {
     const fetchOutgoingCallerIds = event.IncludeOutgoing === 'true' || false;
 
-    const result = await twilioExecute(context, (client) =>
-      client.incomingPhoneNumbers.list({
-        limit: 1000,
-      }),
-    );
+    const result = await twilioExecute(context, (client) => client.incomingPhoneNumbers.list());
 
     const { data: fullPhoneNumberList } = result;
     let phoneNumbers = fullPhoneNumberList
@@ -23,11 +19,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       : null;
 
     if (fetchOutgoingCallerIds) {
-      const outgoingResult = await twilioExecute(context, (client) =>
-        client.outgoingCallerIds.list({
-          limit: 1000,
-        }),
-      );
+      const outgoingResult = await twilioExecute(context, (client) => client.outgoingCallerIds.list());
 
       if (outgoingResult?.success) {
         const { data: callerIds } = outgoingResult;


### PR DESCRIPTION
### Summary

The 1000 limit in the list-phone-numbers function is unnecessary. The library automatically fetches all pages without specifying a limit (validated with page size 1).

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
