### PR TITLE
Fix canned responses menu being cut off

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
@@ -27,6 +27,7 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   const menu = useMenuState({
     placement: 'top-start',
     wrap: 'horizontal',
+    modal: true,
   });
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

Instructs the menu to [use a portal](https://github.com/twilio-labs/paste/discussions/3775#discussioncomment-8495134) so that its container does not cut it off.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
