### PR TITLE
[SE-15] Add audit logging utility, add admin-ui audit log

### DIFF
--- a/docs/docs/building/template-utilities/audit-logging.md
+++ b/docs/docs/building/template-utilities/audit-logging.md
@@ -4,7 +4,7 @@ title: Audit logging
 
 Location: `plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts`
 
-When users make configuration changes, it can be difficult afterwards to track who made the change and identify what changed. `AuditHelper.ts` exports a `saveAuditEvent` function which will save an audit event to a Sync map named after the provided `feature` parameter. The individual audit events will be saved with a TTL using the `audit_log_ttl` [common configuration](../building/template-utilities/configuration#common-configuration) property, which by default is two weeks. Each audit event will include a timestamp, as well as the name of the currently logged in worker.
+When users make configuration changes, it can be difficult afterwards to track who made the change and identify what changed. `AuditHelper.ts` exports a `saveAuditEvent` function which will save an audit event to a Sync map named after the provided `feature` parameter. The individual audit events will be saved with a TTL using the `audit_log_ttl` [common configuration](configuration#common-configuration) property, which by default is two weeks. Each audit event will include a timestamp, as well as the name of the currently logged in worker.
 
 When calling the `saveAuditEvent` function, the following parameters are required:
 

--- a/docs/docs/building/template-utilities/audit-logging.md
+++ b/docs/docs/building/template-utilities/audit-logging.md
@@ -1,0 +1,20 @@
+---
+title: Audit logging
+---
+
+Location: `plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts`
+
+When users make configuration changes, it can be difficult afterwards to track who made the change and identify what changed. `AuditHelper.ts` exports a `saveAuditEvent` function which will save an audit event to a Sync map named after the provided `feature` parameter. The individual audit events will be saved with a TTL using the `audit_log_ttl` [common configuration](../building/template-utilities/configuration#common-configuration) property, which by default is two weeks. Each audit event will include a timestamp, as well as the name of the currently logged in worker.
+
+When calling the `saveAuditEvent` function, the following parameters are required:
+
+- **`feature`**: The name of the feature saving the audit log. The audit log will be saved to a Sync map named `AuditLog_feature`.
+- **`event`**: A string describing the event being logged, which will be included in the audit log.
+
+You may also optionally provide these parameters as well:
+
+- **`oldValue`**: For events representing a configuration change, this can be an object representing the original configuration to be included in the audit log.
+- **`newValue`**: For events representing a configuration change, this can be an object representing the updated configuration to be included in the audit log.
+
+For examples of how to use the audit logger, see the following features:
+- **admin-ui**: `plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/helpers.ts`

--- a/docs/docs/building/template-utilities/audit-logging.md
+++ b/docs/docs/building/template-utilities/audit-logging.md
@@ -4,11 +4,13 @@ title: Audit logging
 
 Location: `plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts`
 
-When users make configuration changes, it can be difficult afterwards to track who made the change and identify what changed. `AuditHelper.ts` exports a `saveAuditEvent` function which will save an audit event to a Sync map named after the provided `feature` parameter. The individual audit events will be saved with a TTL using the `audit_log_ttl` [common configuration](configuration#common-configuration) property, which by default is two weeks. Each audit event will include a timestamp, as well as the name of the currently logged in worker.
+When users make configuration changes, it can be difficult afterwards to track who made the change and identify what changed. `AuditHelper.ts` exports a `saveAuditEvent` function which will save an audit event to a Sync list named after the provided `feature` parameter. The individual audit events will be saved with a TTL using the `audit_log_ttl` [common configuration](configuration#common-configuration) property, which by default is two weeks. Each audit event will include a timestamp, as well as the name of the currently logged in worker.
+
+Audit logs can be viewed within the Twilio Console > Sync > Services > Default Service > Lists. You may also retrieve them via [the Sync List APIs](https://www.twilio.com/docs/sync/api/list-resource).
 
 When calling the `saveAuditEvent` function, the following parameters are required:
 
-- **`feature`**: The name of the feature saving the audit log. The audit log will be saved to a Sync map named `AuditLog_feature`.
+- **`feature`**: The name of the feature saving the audit log. The audit log will be saved to a Sync list named `AuditLog_feature`.
 - **`event`**: A string describing the event being logged, which will be included in the audit log.
 
 You may also optionally provide these parameters as well:

--- a/docs/docs/building/template-utilities/configuration.md
+++ b/docs/docs/building/template-utilities/configuration.md
@@ -68,6 +68,7 @@ If you have two features which need to share a piece of configuration, consider 
 The following common configuration properties are included by default:
 
 - **`log_level`** - The minimum log level to output to the browser console. `info` by default; may be set to `debug`, `log`, `warn`, `info`, or `error`
+- **`audit_log_ttl`** - The number of seconds before audit events should be removed from Sync. `1209600` (two weeks) by default.
 - **`teams`** - Array of team names used by various features to populate team lists, matching the values used in worker attributes.
 - **`departments`** - Array of department names used by various features to populate department lists, matching the values used in worker attributes.
 

--- a/docs/docs/building/template-utilities/configuration.md
+++ b/docs/docs/building/template-utilities/configuration.md
@@ -68,7 +68,7 @@ If you have two features which need to share a piece of configuration, consider 
 The following common configuration properties are included by default:
 
 - **`log_level`** - The minimum log level to output to the browser console. `info` by default; may be set to `debug`, `log`, `warn`, `info`, or `error`
-- **`audit_log_ttl`** - The number of seconds before audit events should be removed from Sync. `1209600` (two weeks) by default.
+- **`audit_log_ttl`** - The number of seconds before audit events should be removed from Sync. `1209600` (two weeks) by default. Set to `0` to keep items indefinitely.
 - **`teams`** - Array of team names used by various features to populate team lists, matching the values used in worker attributes.
 - **`departments`** - Array of department names used by various features to populate department lists, matching the values used in worker attributes.
 

--- a/docs/docs/feature-library/admin-ui.md
+++ b/docs/docs/feature-library/admin-ui.md
@@ -25,6 +25,8 @@ This feature is enabled by default and requires no further configuration.
 
 If you are using an infrastructure-as-code deployment strategy, exposing a configuration interface outside of the code repository is undesirable. For such deployments, it is suggested to disable this feature, and set the `OVERWRITE_CONFIG=true` environment variable as part of the flex-config deployment (this is set up as an input variable on the `Deploy Flex` github actions script). This will result in the repository flex-config as the source of truth.
 
+By default, the admin UI saves [audit logs](../building/template-utilities/audit-logging) for all configuration changes. This can be disabled by setting `"enable_audit_logging": false` in your flex-config `ui_attributes` file's `admin_ui` section.
+
 ## How does it work?
 
 This feature uses the Flex Configuration API to retrieve and store global feature settings. To store per-user setting overrides, worker attributes are stored for only the overridden features, in order to prevent reaching the maximum worker attributes size. Only configuration that has already been deployed is available in the interface--that means flex-config must have been deployed first (which it should be if the setup instructions were followed).

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -8,6 +8,7 @@
     "serverless_functions_domain": "<YOUR_SERVERLESS_DOMAIN>",
     "common": {
       "log_level": "info",
+      "audit_log_ttl": 1209600,
       "teams": [
         "Blue Team",
         "Red Team",
@@ -265,7 +266,8 @@
         "enabled_for_agents": false
       },
       "admin_ui": {
-        "enabled": true
+        "enabled": true,
+        "enable_audit_logging": true
       },
       "localization": {
         "enabled": false,

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/config.ts
@@ -1,8 +1,13 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import AdminUiConfig from './types/ServiceConfiguration';
 
-const { enabled = false } = (getFeatureFlags()?.features?.admin_ui as AdminUiConfig) || {};
+const { enabled = false, enable_audit_logging = false } =
+  (getFeatureFlags()?.features?.admin_ui as AdminUiConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
+};
+
+export const isAuditLoggingEnabled = () => {
+  return enable_audit_logging;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/custom-components/AdminView/AdminView.tsx
@@ -20,8 +20,13 @@ import { StringTemplates } from '../../flex-hooks/strings';
 import { AdminViewWrapper, FeatureCardWrapper } from './AdminView.Styles';
 import { getFeatureFlagsUser } from '../../../../utils/configuration';
 import FeatureCard from '../FeatureCard';
-import AdminUiService from '../../utils/AdminUiService';
-import { saveUserConfig, saveGlobalConfig, shouldShowFeature, featureCommon } from '../../utils/helpers';
+import {
+  saveUserConfig,
+  saveGlobalConfig,
+  shouldShowFeature,
+  featureCommon,
+  getGlobalConfig,
+} from '../../utils/helpers';
 import { subscribe, unsubscribe, publishMessage, SyncStreamEvent } from '../../../../utils/sdk-clients/sync/SyncClient';
 import { AdminUiNotification } from '../../flex-hooks/notifications';
 import FeatureModal from '../FeatureModal';
@@ -83,7 +88,7 @@ const AdminView = () => {
 
   const reloadGlobalConfig = async () => {
     try {
-      const newGlobalConfig = (await AdminUiService.fetchUiAttributes()).configuration.custom_data || {};
+      const newGlobalConfig = (await getGlobalConfig())?.custom_data || {};
       setGlobalConfig(newGlobalConfig);
     } catch (error) {
       console.log('admin-ui: Unable to load global config', error);

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/types/ServiceConfiguration.ts
@@ -1,3 +1,4 @@
 export default interface AdminUiConfig {
   enabled: boolean;
+  enable_audit_logging: boolean;
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/helpers.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/admin-ui/utils/helpers.ts
@@ -1,11 +1,14 @@
 import { Actions, Manager, Notifications } from '@twilio/flex-ui';
+import merge from 'lodash/merge';
 
 import { CustomWorkerAttributes } from '../../../types/task-router/Worker';
-import { isFeatureEnabled } from '../config';
+import { isFeatureEnabled, isAuditLoggingEnabled } from '../config';
 import { AdminUiNotification } from '../flex-hooks/notifications';
 import AdminUiService from './AdminUiService';
+import { saveAuditEvent } from '../../../utils/helpers/AuditHelper';
+import { getFeatureFlags } from '../../../utils/configuration';
 
-const acronyms = ['id', 'ui', 'sip', 'pstn', 'sms', 'crm', 'sla', 'cbm', 'url'];
+const acronyms = ['id', 'ui', 'sip', 'pstn', 'sms', 'crm', 'sla', 'cbm', 'url', 'ttl'];
 const hiddenFeatures = ['admin_ui'];
 const docsBaseUrl = 'https://twilio-professional-services.github.io/flex-project-template';
 
@@ -54,17 +57,24 @@ export const formatDocsUrl = (name: string): string => {
 
 const updateWorkerSetting = async (feature: string, config: any) => {
   let updatePayload = {};
+  let originalConfig = {};
+
+  // We need the original config for the audit log
+  const workerClient = Manager.getInstance().workerClient;
+  const attributes = workerClient?.attributes as CustomWorkerAttributes;
 
   if (feature === featureCommon) {
     updatePayload = {
       common: config,
     };
+    originalConfig = { common: { ...attributes?.config_overrides?.common } };
   } else {
     updatePayload = {
       features: {
         [feature]: config,
       },
     };
+    originalConfig = { features: { [feature]: { ...attributes?.config_overrides?.features[feature] } } };
   }
 
   await Actions.invokeAction('SetWorkerAttributes', {
@@ -73,6 +83,7 @@ const updateWorkerSetting = async (feature: string, config: any) => {
       config_overrides: updatePayload,
     },
   });
+  auditLog(false, originalConfig, merge({}, originalConfig, updatePayload));
 };
 
 const resetWorkerSetting = async (feature: string) => {
@@ -83,6 +94,7 @@ const resetWorkerSetting = async (feature: string) => {
   }
 
   const attributes = workerClient.attributes as CustomWorkerAttributes;
+  const originalConfig = { ...attributes?.config_overrides };
 
   if (feature === featureCommon) {
     if (attributes?.config_overrides?.common) {
@@ -93,6 +105,14 @@ const resetWorkerSetting = async (feature: string) => {
   }
 
   await workerClient.setAttributes(attributes);
+  auditLog(false, originalConfig, attributes?.config_overrides);
+};
+
+const auditLog = (global: boolean, oldValue: any, newValue: any) => {
+  if (!isAuditLoggingEnabled()) {
+    return;
+  }
+  saveAuditEvent('admin-ui', `update-${global ? 'global' : 'worker'}`, oldValue, newValue);
 };
 
 export const saveUserConfig = async (feature: string, config: any): Promise<boolean> => {
@@ -119,7 +139,8 @@ export const saveUserConfig = async (feature: string, config: any): Promise<bool
 export const saveGlobalConfig = async (feature: string, config: any, mergeFeature: boolean): Promise<any> => {
   let returnVal = false;
   try {
-    let updatePayload = {};
+    let updatePayload = {} as any;
+    let originalConfig = {};
 
     if (feature === featureCommon) {
       updatePayload = {
@@ -127,6 +148,7 @@ export const saveGlobalConfig = async (feature: string, config: any, mergeFeatur
           common: config,
         },
       };
+      originalConfig = { common: { ...getFeatureFlags()?.common } };
     } else {
       updatePayload = {
         custom_data: {
@@ -135,11 +157,13 @@ export const saveGlobalConfig = async (feature: string, config: any, mergeFeatur
           },
         },
       };
+      originalConfig = { features: { [feature]: { ...getFeatureFlags()?.features[feature] } } };
     }
 
     const updateResponse = await AdminUiService.updateUiAttributes(JSON.stringify(updatePayload), mergeFeature);
     if (updateResponse?.configuration?.custom_data) {
       returnVal = updateResponse.configuration.custom_data;
+      auditLog(true, originalConfig, merge({}, originalConfig, updatePayload.custom_data));
     } else {
       console.error('admin-ui: Unexpected response upon updating global config', updateResponse);
     }

--- a/plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts
+++ b/plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts
@@ -1,0 +1,30 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Manager } from '@twilio/flex-ui';
+
+import SyncClient from '../sdk-clients/sync/SyncClient';
+import { getFeatureFlags } from '../configuration';
+
+const AUDIT_MAP_PREFIX = 'AuditLog';
+const { audit_log_ttl = 1209600 } = getFeatureFlags().common || {};
+
+export const saveAuditEvent = async (feature: string, event: string, oldValue?: any, newValue?: any) => {
+  const data = {
+    timestamp: new Date().toString(),
+    worker: Manager.getInstance().workerClient?.name ?? 'Unknown',
+    event,
+    oldValue,
+    newValue,
+  };
+
+  // Validate that the data does not exceed 16 KiB
+  if (data.oldValue || data.newValue) {
+    const size = new Blob([JSON.stringify(data)]).size;
+    if (size >= 16384) {
+      data.oldValue = 'Removed due to excessive size';
+      data.newValue = 'Removed due to excessive size';
+    }
+  }
+
+  const map = await SyncClient.map(`${AUDIT_MAP_PREFIX}_${feature}`);
+  await map.set(uuidv4(), data, { ttl: audit_log_ttl });
+};

--- a/plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts
+++ b/plugin-flex-ts-template-v2/src/utils/helpers/AuditHelper.ts
@@ -7,6 +7,11 @@ import { getFeatureFlags } from '../configuration';
 const AUDIT_MAP_PREFIX = 'AuditLog';
 const { audit_log_ttl = 1209600 } = getFeatureFlags().common || {};
 
+const performSave = async (feature: string, key: string, data: any) => {
+  const map = await SyncClient.map(`${AUDIT_MAP_PREFIX}_${feature}`);
+  await map.set(key, data, { ttl: audit_log_ttl });
+};
+
 export const saveAuditEvent = async (feature: string, event: string, oldValue?: any, newValue?: any) => {
   const data = {
     timestamp: new Date().toString(),
@@ -25,6 +30,11 @@ export const saveAuditEvent = async (feature: string, event: string, oldValue?: 
     }
   }
 
-  const map = await SyncClient.map(`${AUDIT_MAP_PREFIX}_${feature}`);
-  await map.set(uuidv4(), data, { ttl: audit_log_ttl });
+  const key = uuidv4();
+  try {
+    await performSave(feature, key, data);
+  } catch (error) {
+    console.log('[AuditHelper] Retrying audit event save due to error.', error);
+    await performSave(feature, key, data);
+  }
 };


### PR DESCRIPTION
### Summary

Adds a simple audit event logging utility that features can use to provide an audit log. Audit logs are saved as Sync maps named per-feature. The items saved to the log have a TTL configured per the `audit_log_ttl` common config setting, which can be set via admin-ui / flex-config.

Updated the admin-ui feature to utilize the new audit logging util to save events for worker config and global config changes.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
