### PR TITLE
fixed selected tab (when recent contacts disabled)

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/contacts/custom-components/ContactsView.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/contacts/custom-components/ContactsView.tsx
@@ -13,7 +13,10 @@ import ContactsUtil from '../utils/ContactsUtil';
 
 const ContactsView = () => {
   const pageSize = getPageSize();
-  const selectedId = useUID();
+  const recentTabId = useUID();
+  const personalTabId = useUID();
+  const sharedTabId = useUID();
+  const selectedId = isRecentsEnabled() ? recentTabId : isPersonalDirectoryEnabled() ? personalTabId : sharedTabId; // Default to Recents if enabled, else Personal Directory if enabled, else Shared Directory if enabled
 
   return (
     <Flex element="CONTACTS_VIEW_WRAPPER" vertical grow shrink>
@@ -24,17 +27,17 @@ const ContactsView = () => {
         <Tabs selectedId={selectedId} baseId="contacts-tabs">
           <TabList aria-label="Contacts tabs">
             {isRecentsEnabled() && (
-              <Tab id={selectedId}>
+              <Tab id={recentTabId}>
                 <Template code={StringTemplates.Recent} />
               </Tab>
             )}
             {isPersonalDirectoryEnabled() && (
-              <Tab>
+              <Tab id={personalTabId}>
                 <Template code={StringTemplates.MyContacts} />
               </Tab>
             )}
             {isSharedDirectoryEnabled() && (
-              <Tab>
+              <Tab id={sharedTabId}>
                 <Template code={StringTemplates.SharedContacts} />
               </Tab>
             )}


### PR DESCRIPTION
### Summary

Small fix to the Contacts feature to set the correct selected tab (Contact view) when one of the Contact types (recent, personal or shared) is disabled.

### Checklist

- [ ] Tested changes end to end
- [ ] Updated documentation
- [ ] Requested one or more reviewers
