### PR TITLE
Fix error when callback is missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The _Flex Project Template_ is a starting point for Flex solutions of any size. 
 - It can be used for large projects or simple standalone features
 - Many of the most common features requested by Flex customers [are already packaged in the template](https://twilio-professional-services.github.io/flex-project-template/feature-library/overview)
 - Each feature is self-contained and easily removed if desired  
-- Features can be turned on and off using an [adminstration panel](https://twilio-professional-services.github.io/flex-project-template/feature-library/admin-ui)
+- Features can be turned on and off using an [administration panel](https://twilio-professional-services.github.io/flex-project-template/feature-library/admin-ui)
 - You can [deploy this solution and use it to build in just a few minutes](https://twilio-professional-services.github.io/flex-project-template/getting-started/install-template) by providing your account SID, API key, and API secret.
 
 ---

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/custom-components/CallbackAndVoicemail/CallbackAndVoicemail.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/custom-components/CallbackAndVoicemail/CallbackAndVoicemail.tsx
@@ -140,7 +140,7 @@ export const CallbackAndVoicemail = ({ task, allowRequeue, maxAttempts }: Callba
           </Box>
         )}
 
-        {callBackData.transcriptText && !callBackData.isDeleted && (
+        {callBackData?.transcriptText && !callBackData.isDeleted && (
           <Box element="C_AND_V_CONTENT_BOX">
             <Heading element="C_AND_V_CONTENT_HEADING" as="h4" variant="heading40">
               <Template source={templates[StringTemplates.VoicemailTranscript]} />

--- a/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/callback-and-voicemail/utils/callback/CallbackService.ts
@@ -93,7 +93,7 @@ class CallbackService extends ApiService {
       }
     } else {
       Flex.Notifications.showNotification(CallbackNotification.OutboundDialingNotEnabled);
-      throw new Error('Oubound dialing is not enabled');
+      throw new Error('Outbound dialing is not enabled');
     }
     return task;
   }


### PR DESCRIPTION
### Summary

Small fix for a crash that happens when a callback task arrives without `callbackData`.

Also fixed a couple typos I found.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
