### PR TITLE
Defer setting attribute from auto wrap up

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/agent-automation/custom-components/AutoComplete/AutoComplete.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/agent-automation/custom-components/AutoComplete/AutoComplete.tsx
@@ -57,11 +57,15 @@ const AutoComplete = ({ task }: OwnProps) => {
         window.setTimeout(async () => {
           if (task && Flex.TaskHelper.isInWrapupMode(task)) {
             if (taskConfig.default_outcome) {
-              await TaskRouterService.updateTaskAttributes(task.taskSid, {
-                conversations: {
-                  outcome: taskConfig.default_outcome,
+              await TaskRouterService.updateTaskAttributes(
+                task.taskSid,
+                {
+                  conversations: {
+                    outcome: taskConfig.default_outcome,
+                  },
                 },
-              });
+                true,
+              );
             }
             Flex.Actions.invokeAction('CompleteTask', { sid });
           }


### PR DESCRIPTION
### Summary

When the agent-automation feature automatically wraps a task, it sets a task attribute. There are other features that set attributes upon a task completing, so defer this attribute update to be set at the same time as those, reducing serverless invocations.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
