### PR TITLE
Fix custom-hold-music with native XWT participants

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/custom-hold-music/flex-hooks/actions/HoldParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-hold-music/flex-hooks/actions/HoldParticipant.ts
@@ -14,7 +14,7 @@ export const actionHook = function setHoldMusicBeforeHoldParticipant(flex: typeo
       return;
     }
 
-    // Override hold handling for participants from the native XWT functionality due to Flex ignoring payload.holdMusicUrl
+    // Override hold handling for participants from the native XWT functionality due to Flex ignoring payload.holdMusicUrl: SEFLEX-3875
     // Find the full participant object based on the targetSid
     const participant = payload?.task?.conference?.participants?.find(
       (p: any) => payload.targetSid === (payload.targetSid.startsWith('UT') ? p.participantSid : p.callSid),

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-hold-music/flex-hooks/actions/HoldParticipant.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-hold-music/flex-hooks/actions/HoldParticipant.ts
@@ -1,12 +1,33 @@
 import * as Flex from '@twilio/flex-ui';
 
+import ProgrammableVoiceService from '../../../../utils/serverless/ProgrammableVoice/ProgrammableVoiceService';
 import { getHoldMusicUrl } from '../../config';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.HoldParticipant;
 export const actionHook = function setHoldMusicBeforeHoldParticipant(flex: typeof Flex, _manager: Flex.Manager) {
-  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, _abortFunction) => {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
     payload.holdMusicUrl = getHoldMusicUrl();
+
+    if (!payload.targetSid || !payload.task) {
+      return;
+    }
+
+    // Override hold handling for participants from the native XWT functionality due to Flex ignoring payload.holdMusicUrl
+    // Find the full participant object based on the targetSid
+    const participant = payload?.task?.conference?.participants?.find(
+      (p: any) => payload.targetSid === (payload.targetSid.startsWith('UT') ? p.participantSid : p.callSid),
+    );
+
+    // Only Native XWT participants are of the 'external' type, ignore if this participant is something else
+    if (!participant || participant.participantType !== 'external') {
+      return;
+    }
+
+    const conferenceSid = payload.task.conference?.conferenceSid || payload.task.attributes?.conference?.sid;
+    abortFunction();
+    console.log('[custom-hold-music] Holding participant', participant.callSid);
+    await ProgrammableVoiceService.holdParticipant(conferenceSid, participant.callSid);
   });
 };


### PR DESCRIPTION
### Summary

When using native external warm transfer, the HoldParticipant action's holdMusicUrl payload property is ignored. Override the handling for these participants to allow custom-hold-music to take effect. See SEFLEX-3875 for more details.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
