### PR TITLE
Allow teams view scrolling with nested wrappers

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/flex-hooks/components/TeamsViewTiles.Styles.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/flex-hooks/components/TeamsViewTiles.Styles.tsx
@@ -4,6 +4,7 @@ export const TeamsViewWrapper = styled('div')`
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
+  overflow: auto;
   h1 {
     display: none;
   }


### PR DESCRIPTION
### Summary

The metrics-data-tiles feature adds a wrapper div to the Teams view. If another feature also adds a wrapper to the Teams view, scrolling can break.

This fixes the issue so that developers can add another feature that also wraps the teams view without regressions.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
