### PR TITLE
Fix error viewing chat in Flex Insights

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/canned-responses/custom-components/CannedResponsesDropdown/CannedResponsesDropdown.tsx
@@ -56,7 +56,7 @@ const CannedResponsesDropdown: React.FunctionComponent<CannedResponsesDropdownPr
   return (
     <Box>
       {isLoading && <SkeletonLoader />}
-      {Boolean(responseCategories) && !isLoading && (
+      {Boolean(responseCategories) && !isLoading && task && (
         <>
           <MenuButton {...menu} variant="reset" disabled={isDisabled} element="CANNED_RESPONSES_MENU_BUTTON">
             <ChatIcon decorative title={templates[StringTemplates.CannedResponses]()} />


### PR DESCRIPTION
### Summary

For some reason MessageInput and MessageInputActions are rendered in some chats in Flex Insights, so the canned responses menu would also attempt to render.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
