### PR TITLE
[SE-22] Run and use Flex Insights proxy

### DIFF
--- a/docs/docs/getting-started/01_run-locally.md
+++ b/docs/docs/getting-started/01_run-locally.md
@@ -38,7 +38,7 @@ npm install
 ```
 5. follow the prompt and provide your auth token
 
-6. Run the serverless functions and plugin together locally by running the following at the top level of the checkout
+6. Run the serverless functions, Insights proxy, and plugin together locally by running the following at the top level of the checkout
 
 ```bash
 npm start

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "install-serverless-plugin": "twilio plugins:install @twilio-labs/plugin-serverless@v3",
     "start:serverless": "cd serverless-functions && twilio serverless:start --inspect=localhost --port=3001 --env .env",
     "start:plugin": "cd plugin-flex-ts-template-v2 && twilio flex:plugins:start --port=3000",
-    "start": "npm-run-all --parallel start:serverless start:plugin",
+    "start": "npm-run-all --parallel start:serverless start:insights start:plugin",
     "start:docs": "cd docs && npm run start",
+    "start:insights": "npx -y @twilio/flex-ui-dev-proxy",
     "lint": "eslint ./plugin-flex-ts-template-v2 ./serverless-functions ./addons",
     "lint:fix": "npm run lint -- --fix",
     "lint:report": "npm run lint -- --output-file eslint_report.json --format json"

--- a/plugin-flex-ts-template-v2/public/appConfig.example.js
+++ b/plugin-flex-ts-template-v2/public/appConfig.example.js
@@ -3,6 +3,9 @@ var appConfig = {
     enabled: true,
     url: '/plugins',
   },
+  insights: {
+    analyticsUrl: 'http://localhost:8081',
+  },
   ytica: false,
   logLevel: 'info',
   showSupervisorDesktopView: true,


### PR DESCRIPTION
### Summary

This change fixes a few problems when running locally:
- Fixes the error banner regarding Insights being unable to load
- Allows accessing Insights from the local plugin so that testing can be performed. For example, when customizing messaging components, it can be useful to test them when opening a chat from Insights, as there is no task object.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
