### PR TITLE
Add ability to exclude tasks from dual-channel recording

### DIFF
--- a/docs/docs/feature-library/dual-channel-recording.md
+++ b/docs/docs/feature-library/dual-channel-recording.md
@@ -33,11 +33,16 @@ There are various ways to enable call recordings with Twilio Flex. Let's outline
 
 ## setup and dependencies
 
-Enabling the feature in the flex-config asset for your environment. There is also a `channel` configuration property to choose which perspective should be recorded--the customer perspective or the worker perspective. For example, if the customer is on hold and `channel` is set to `customer`, the recording will contain hold music. If `channel` is set to `worker`, the recording will not contain hold music and the worker will be heard instead.
+The feature is enabled via flex-config asset for your environment. There is also a `channel` configuration property to choose which perspective should be recorded--the customer perspective or the worker perspective. For example, if the customer is on hold and `channel` is set to `customer`, the recording will contain hold music. If `channel` is set to `worker`, the recording will not contain hold music and the worker will be heard instead.
 
-If enabling the dual channel recording feature - you should also **disable** the call recording flag in the Flex Configuration of your twilio console.
+If enabling the dual channel recording feature - you should also **disable** the call recording flag in the Flex Configuration within Twilio Console > Flex > Manage > Voice.
 
-Twilio Console > Flex > Manage > Voice
+You may also optionally specify task attributes and/or queues that should exclude a task from being recorded:
+- To exclude recording tasks based on the task attributes present, set the `exclude_attributes` configuration property to an array of key/value pair objects. For example, to prevent recording outbound calls:
+  ```
+  "exclude_attributes": [{ "key":"direction", "value":"outbound" }]
+  ```
+- To exclude recording tasks based on queue name or queue SID, set the `exclude_queues` configuration property to an array or queue names or SIDs.
 
 ## how it works
 

--- a/docs/docs/feature-library/dual-channel-recording.md
+++ b/docs/docs/feature-library/dual-channel-recording.md
@@ -37,7 +37,7 @@ The feature is enabled via flex-config asset for your environment. There is also
 
 If enabling the dual channel recording feature - you should also **disable** the call recording flag in the Flex Configuration within Twilio Console > Flex > Manage > Voice.
 
-You may also optionally specify task attributes and/or queues that should exclude a task from being recorded:
+You may also optionally specify task attributes and/or queues that should exclude a task from being recorded by the dual-channel recording feature:
 - To exclude recording tasks based on the task attributes present, set the `exclude_attributes` configuration property to an array of key/value pair objects. For example, to prevent recording outbound calls:
   ```
   "exclude_attributes": [{ "key":"direction", "value":"outbound" }]

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -112,7 +112,9 @@
       },
       "dual_channel_recording": {
         "enabled": false,
-        "channel": "worker"
+        "channel": "worker",
+        "exclude_attributes": [],
+        "exclude_queues": []
       },
       "pause_recording": {
         "enabled": true,

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/config.ts
@@ -1,8 +1,12 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import DualChannelRecordingConfig from './types/ServiceConfiguration';
 
-const { enabled = false, channel } =
-  (getFeatureFlags()?.features?.dual_channel_recording as DualChannelRecordingConfig) || {};
+const {
+  enabled = false,
+  channel,
+  exclude_attributes = [],
+  exclude_queues = [],
+} = (getFeatureFlags()?.features?.dual_channel_recording as DualChannelRecordingConfig) || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
@@ -10,4 +14,12 @@ export const isFeatureEnabled = () => {
 
 export const getChannelToRecord = () => {
   return channel;
+};
+
+export const getExcludedAttributes = () => {
+  return exclude_attributes;
+};
+
+export const getExcludedQueues = () => {
+  return exclude_queues;
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/actions/CompleteTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/actions/CompleteTask.ts
@@ -1,12 +1,15 @@
 import * as Flex from '@twilio/flex-ui';
 
-import { addMissingCallDataIfNeeded } from '../../helpers/dualChannelHelper';
+import { addMissingCallDataIfNeeded, canRecordTask } from '../../helpers/dualChannelHelper';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.CompleteTask;
 export const actionHook = function handleDualChannelCompleteTask(flex: typeof Flex, _manager: Flex.Manager) {
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+    if (!canRecordTask(payload.task)) {
+      return;
+    }
     // Listening for this event as a last resort check to ensure call
     // and conference metadata are captured on the task
     addMissingCallDataIfNeeded(payload.task);

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/actions/HangupCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/actions/HangupCall.ts
@@ -1,12 +1,15 @@
 import * as Flex from '@twilio/flex-ui';
 
-import { addMissingCallDataIfNeeded } from '../../helpers/dualChannelHelper';
+import { addMissingCallDataIfNeeded, canRecordTask } from '../../helpers/dualChannelHelper';
 import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.HangupCall;
 export const actionHook = function handleDualChannelHangupCall(flex: typeof Flex, _manager: Flex.Manager) {
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+    if (!canRecordTask(payload.task)) {
+      return;
+    }
     // Listening for this event to at least capture the conference SID
     // if the outbound call is canceled before the called party answers
     addMissingCallDataIfNeeded(payload.task);

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/taskAccepted.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/flex-hooks/events/taskAccepted.ts
@@ -1,6 +1,6 @@
 import * as Flex from '@twilio/flex-ui';
 
-import { recordExternalCall, recordInternalCall } from '../../helpers/dualChannelHelper';
+import { canRecordTask, recordExternalCall, recordInternalCall } from '../../helpers/dualChannelHelper';
 import { getChannelToRecord } from '../../config';
 import { FlexEvent } from '../../../../types/feature-loader';
 
@@ -19,6 +19,11 @@ export const eventHook = async (flex: typeof Flex, _manager: Flex.Manager, task:
     return;
   }
 
+  if (!canRecordTask(task)) {
+    console.debug('[dual-channel-recording] Skipping recording for task excluded by configuration', task.sid);
+    return;
+  }
+
   if (client_call && direction === 'outbound') {
     // internal call - always record based on call SID, as conference state is unknown by Flex
     // Record only the outbound leg to prevent duplicate recordings
@@ -26,7 +31,7 @@ export const eventHook = async (flex: typeof Flex, _manager: Flex.Manager, task:
     recordInternalCall(task);
   } else if (client_call) {
     // internal call, inbound leg - skip recording this leg
-    console.debug('Skipping recording for inbound internal call', task.sid);
+    console.debug('[dual-channel-recording] Skipping recording for inbound internal call', task.sid);
   } else {
     // External call
     // Do not await so that event processing is not blocked

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/helpers/dualChannelHelper.ts
@@ -2,10 +2,24 @@ import { ConferenceParticipant, ITask, Manager, TaskHelper } from '@twilio/flex-
 
 import TaskRouterService from '../../../utils/serverless/TaskRouter/TaskRouterService';
 import { FetchedRecording } from '../../../types/serverless/twilio-api';
-import { getChannelToRecord } from '../config';
+import { getChannelToRecord, getExcludedAttributes, getExcludedQueues } from '../config';
 import DualChannelService from './DualChannelService';
 
 const manager = Manager.getInstance();
+
+export const canRecordTask = (task: ITask): boolean => {
+  if (getExcludedQueues().findIndex((queue) => queue === task.queueName || queue === task.queueSid) >= 0) {
+    return false;
+  }
+
+  for (const attribute of getExcludedAttributes()) {
+    if (task.attributes[attribute.key] === attribute.value) {
+      return false;
+    }
+  }
+
+  return true;
+};
 
 const addCallDataToTask = async (task: ITask, callSid: string | null, recording: FetchedRecording | null) => {
   const { conference } = task;

--- a/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/dual-channel-recording/types/ServiceConfiguration.ts
@@ -1,4 +1,11 @@
+interface AttributesQualificationConfig {
+  key: string;
+  value: string;
+}
+
 export default interface DualChannelRecordingConfig {
   enabled: boolean;
   channel: 'customer' | 'worker';
+  exclude_attributes: Array<AttributesQualificationConfig>;
+  exclude_queues: Array<string>;
 }


### PR DESCRIPTION
### Summary

Many customers have compliance requirements that prevent them from recording certain calls. This PR adds configuration options to the dual-channel recording feature which will exclude a call from being recorded using the following criteria:

- Excluded attributes: Array of key/value pairs of task attributes that if present will prevent recording. For example, this could be the "direction" attribute to exclude calls that are in a specific direction, or an attribute can be set from the IVR to prevent the recording.
- Excluded queues: String array of queue names or queue SIDs that will not be recorded.

If any of the exclusions match the task, then the call will not be recorded by the dual-channel recording feature.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
