### PR TITLE
Fix getCBMParticipantsWrapper retry

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/hooks.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/custom-components/ParticipantsTab/hooks.ts
@@ -46,7 +46,7 @@ const getCBMParticipantsWrapper = async (task: ITask, flexInteractionChannelSid:
     if (!missingMediaProperties) return participants;
     retry += 1;
     console.log('getCBMParticipantsWrapper retry', retry);
-    wait(retryTimer);
+    await wait(retryTimer);
     retryTimer *= 2;
   }
 


### PR DESCRIPTION
### Summary

Fixes the retry logic not waiting for the specified interval, which should improve reliability.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
