### PR TITLE
Add missing title to conference kick buttons

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
@@ -136,12 +136,14 @@ const ParticipantActionsButtons = (props: OwnProps) => {
           className="ParticipantCanvas-AcceptAction"
           onClick={onKickParticipantConfirmClick}
           variant="secondary"
+          title={templates.CallParticipantStatusKickConfirmation()}
         />
         <IconButton
           icon="Close"
           className="ParticipantCanvas-DeclineAction"
           onClick={hideKickConfirmation}
           variant="secondary"
+          title={templates.CallParticipantStatusKickCancellation()}
         />
       </>
     );


### PR DESCRIPTION
### Summary

Adds the same strings used by the OOB components.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
