### PR TITLE
Disable focus workaround in Flex UI >= 2.7.1

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/inline-media/custom-components/InlineMedia.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/inline-media/custom-components/InlineMedia.tsx
@@ -1,3 +1,5 @@
+import { VERSION } from '@twilio/flex-ui';
+
 import InlineMediaAttachment from './InlineMediaAttachment';
 
 interface OwnProps {
@@ -6,6 +8,13 @@ interface OwnProps {
 }
 const InlineMedia = ({ message, updateFocus }: OwnProps) => {
   const setFocus = () => {
+    try {
+      // The focus workaround is no longer needed as of Flex UI 2.7.1
+      const versionNum = Number(VERSION?.replaceAll('.', ''));
+      if (!isNaN(versionNum) && versionNum >= 271) {
+        return;
+      }
+    } catch {}
     if (updateFocus) {
       updateFocus(message.index, true);
     }


### PR DESCRIPTION
### Summary

The message focus bug was fixed in Flex UI 2.7.1 by FLXAGNTUI-93. Disable the workaround for 2.7.1 or later.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
