### PR TITLE
Simplify and remove deprecated methods when rejecting an internal call

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
@@ -7,11 +7,12 @@ import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.RejectTask;
 export const actionHook = function handleInternalRejectTask(flex: typeof Flex, _manager: Flex.Manager) {
-  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
     if (!isInternalCall(payload.task)) {
       return;
     }
 
+    abortFunction();
     await InternalCallService.rejectInternalTask(payload.task);
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/actions/RejectTask.tsx
@@ -7,12 +7,11 @@ import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.RejectTask;
 export const actionHook = function handleInternalRejectTask(flex: typeof Flex, _manager: Flex.Manager) {
-  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
     if (!isInternalCall(payload.task)) {
       return;
     }
 
-    abortFunction();
     await InternalCallService.rejectInternalTask(payload.task);
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/helpers/InternalCallService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/helpers/InternalCallService.ts
@@ -26,10 +26,9 @@ class InternalCallService extends ApiService {
 
   rejectInternalTask = async (task: ITask) => {
     return new Promise((resolve, reject) => {
-      const taskSid = task.attributes.conferenceSid;
-
       const encodedParams = {
-        taskSid,
+        taskSid: task.taskSid,
+        conferenceSid: task.attributes.conference?.sid,
         Token: encodeURIComponent(this.manager.user.token),
       };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/helpers/InternalCallService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/helpers/InternalCallService.ts
@@ -25,10 +25,6 @@ class InternalCallService extends ApiService {
   };
 
   rejectInternalTask = async (task: ITask) => {
-    await (task.sourceObject as Reservation).accept();
-    await task.wrapUp();
-    await task.complete();
-
     return new Promise((resolve, reject) => {
       const taskSid = task.attributes.conferenceSid;
 
@@ -46,7 +42,7 @@ class InternalCallService extends ApiService {
         },
       )
         .then((response) => {
-          console.log('Outbound call has been placed into wrapping');
+          console.log('[internal-call] Outbound call has been placed into wrapping');
           resolve(response);
         })
         .catch((error) => {


### PR DESCRIPTION
### Summary

For some reason, the internal-call feature was designed so that when the receiving agent rejects an internal call, the task is accepted then immediately completed. This PR simplifies the process to cancel the task as part of the necessary cleanup serverless function.

@trogers-twilio I git-blame'd this back to the [original commit](https://github.com/twilio-professional-services/flex-dialpad-addon-plugin/blame/8d72c1e29c6f7d5bfbadcce7c1bdb6295e179224/src/customActions/internalCall/index.js#L33) 4 years ago. Do you have an idea as to why this might have been implemented this way? AFAICT it was not necessary but I could be missing something.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
