### PR TITLE
Improve pause-recording robustness

### DIFF
--- a/docs/docs/feature-library/pause-recording.md
+++ b/docs/docs/feature-library/pause-recording.md
@@ -11,7 +11,7 @@ This feature adds a Pause/Resume Recording button to the call canvas to allow th
 
 ## setup and dependencies
 
-Recording must be enabled either via the dual channel recording feature in this repository, or via the "Call Recording" setting in Twilio Console > Flex > Manage > Voice. Do not enable both recording methods simultaneously, or only one of the recordings will be paused.
+Recording must be enabled either via the dual channel recording feature in this repository, or via the "Call Recording" setting in Twilio Console > Flex > Manage > Voice.
 
 There are no additional setup steps required, only enabling the feature in the flex-config asset for your environment.
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/config.ts
@@ -8,7 +8,8 @@ const {
   include_silence = false,
 } = (getFeatureFlags()?.features?.pause_recording as PauseRecordingConfig) || {};
 
-const { enabled: dualChannelEnabled = false, channel } = getFeatureFlags()?.features?.dual_channel_recording || {};
+const { enabled: dualChannelEnabled = false, channel = 'worker' } =
+  getFeatureFlags()?.features?.dual_channel_recording || {};
 
 export const isFeatureEnabled = () => {
   return enabled;
@@ -31,5 +32,5 @@ export const isDualChannelEnabled = () => {
 };
 
 export const getChannelToRecord = () => {
-  return channel;
+  return channel.toLowerCase();
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/notifications/PauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/notifications/PauseRecording.ts
@@ -8,6 +8,7 @@ export enum NotificationIds {
   RESUME_RECORDING = 'PSResumeRecording',
   PAUSE_FAILED = 'PSPauseFailed',
   RESUME_FAILED = 'PSResumeFailed',
+  MISSING_RECORDING = 'PSPauseMissingRecording',
 }
 
 export const notificationHook = (_flex: typeof Flex, _manager: Flex.Manager) => [
@@ -37,6 +38,13 @@ export const notificationHook = (_flex: typeof Flex, _manager: Flex.Manager) => 
     closeButton: true,
     content: StringTemplates.RESUME_FAILED,
     type: NotificationType.error,
+    timeout: 3000,
+  },
+  {
+    id: NotificationIds.MISSING_RECORDING,
+    closeButton: true,
+    content: StringTemplates.MISSING_RECORDING,
+    type: NotificationType.warning,
     timeout: 3000,
   },
 ];

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/strings/PauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/strings/PauseRecording.ts
@@ -13,6 +13,7 @@ export enum StringTemplates {
   RESUME_FAILED = 'PSResumeRecordingFailed',
   PAUSE_TOOLTIP = 'PSPauseRecordingTooltip',
   RESUME_TOOLTIP = 'PSResumeRecordingTooltip',
+  MISSING_RECORDING = 'PSPauseMissingRecording',
 }
 
 export const stringHook = () => ({
@@ -25,6 +26,7 @@ export const stringHook = () => ({
     [StringTemplates.RESUME_FAILED]: 'Failed to resume call recording. Please try again.',
     [StringTemplates.PAUSE_TOOLTIP]: 'Pause Recording',
     [StringTemplates.RESUME_TOOLTIP]: 'Resume Recording',
+    [StringTemplates.MISSING_RECORDING]: 'This call is not being recorded, so there is no recording to pause.',
   },
   'es-MX': esMX,
   'pt-BR': ptBR,

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/PauseRecordingService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/PauseRecordingService.ts
@@ -28,7 +28,7 @@ class PauseRecordingService extends ApiService {
           resolve(resp.recording);
         })
         .catch((error) => {
-          console.log('Error pausing recording', error);
+          console.log('[pause-recording] Error pausing recording', error);
           reject(error);
         });
     });
@@ -54,7 +54,7 @@ class PauseRecordingService extends ApiService {
           resolve(resp.recording);
         })
         .catch((error) => {
-          console.log('Error resuming recording', error);
+          console.log('[pause-recording] Error resuming recording', error);
           reject(error);
         });
     });
@@ -80,7 +80,7 @@ class PauseRecordingService extends ApiService {
           resolve(resp.recording);
         })
         .catch((error) => {
-          console.log('Error pausing recording', error);
+          console.log('[pause-recording] Error pausing recording', error);
           reject(error);
         });
     });
@@ -106,7 +106,7 @@ class PauseRecordingService extends ApiService {
           resolve(resp.recording);
         })
         .catch((error) => {
-          console.log('Error resuming recording', error);
+          console.log('[pause-recording] Error resuming recording', error);
           reject(error);
         });
     });

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/PausedRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/types/PausedRecording.ts
@@ -1,4 +1,5 @@
 export type PausedRecording = {
   reservationSid: string;
-  recordingSid: string;
+  recordingSidDC: string;
+  recordingSidSC: string;
 };


### PR DESCRIPTION
### Summary

- Handle multiple simultaneous recordings (dual-channel and conference recordings at the same time)
- Handle missing recording (instead of showing a failure message, such as when recording is completely disabled, or excluded by rule)
- Improve logs

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
