### PR TITLE
Add keyboard shortcuts for call recording pause/resume/toggle

### DIFF
--- a/docs/docs/feature-library/pause-recording.md
+++ b/docs/docs/feature-library/pause-recording.md
@@ -3,7 +3,7 @@ sidebar_label: pause-recording
 title: Pause & Resume Call Recording
 ---
 
-This feature adds a Pause/Resume Recording button to the call canvas to allow the agent to temporarily pause the call recording before the customer provides sensitive information (such as credit card details, bank account, etc.) to the agent and to resume regular call recording afterwards.
+This feature adds a Pause/Resume Recording button and keyboard shortcuts to the call canvas to allow the agent to temporarily pause the call recording before the customer provides sensitive information (such as credit card details, bank account, etc.) to the agent and to resume regular call recording afterwards.
 
 ## flex-user-experience
 
@@ -21,6 +21,24 @@ There are some additional configuration properties you may change if desired:
 - `indicator_banner` - whether recording indicator is displayed temporarily in a notification banner
 - `indicator_permanent` - whether a permanent 'Call Recording Paused' indicator is shown while paused
 
+## keyboard shortcuts
+
+Default keyboard shortcuts have been created but may be remapped using the keyboard shortcut feature. Default the following keys are mapped:
+
+| Key | Full Command     | Action                                     |
+| --- | ---------------- | ------------------------------------------ |
+| 2   | Ctrl + Shift + 2 | Toggle call recording state (pause/resume) |
+| 3   | Ctrl + Shift + 3 | Pause call recording (if started)          |
+| 4   | Ctrl + Shift + 4 | Resume call recording (if paused)          |
+
 ## how it works
 
 This plugin leverages Twilio Functions to perform the actual Pause and Resume action on the call or conference resource. When using the dual channel recording feature, the recording is on the call resource; when using the out-of-box recording feature, the recording is on the conference resource.
+
+Additionally this plugin registers additional Flex Actions that may be invoked by other plugins or features:
+
+| Action                | Payload           |
+| --------------------- | ----------------- |
+| `ToggleCallRecording` | `{ task: ITask }` |
+| `PauseCallRecording`  | `{ task: ITask }` |
+| `ResumeCallRecording` | `{ task: ITask }` |

--- a/docs/docs/feature-library/pause-recording.md
+++ b/docs/docs/feature-library/pause-recording.md
@@ -23,7 +23,7 @@ There are some additional configuration properties you may change if desired:
 
 ## keyboard shortcuts
 
-Default keyboard shortcuts have been created but may be remapped using the keyboard shortcut feature. Default the following keys are mapped:
+Default keyboard shortcuts have been created but may be remapped using the keyboard shortcut feature. By default, the following keys are mapped:
 
 | Key | Full Command     | Action                                     |
 | --- | ---------------- | ------------------------------------------ |

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/flex-hooks/strings/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/flex-hooks/strings/index.ts
@@ -54,6 +54,9 @@ export enum StringTemplates {
   CustomShortcutNavigateToKeyboardShortcuts = 'KeyboardMgrCustomShortcutNavigateToKeyboardShortcuts',
   CustomShortcutNavigateToTeamsView = 'KeyboardMgrCustomShortcutNavigateToTeamsView',
   CustomShortcutNavigateToQueuesView = 'KeyboardMgrCustomShortcutNavigateToQueuesView',
+  CustomShortcutToggleCallRecording = 'KeyboardMgrCustomShortcutToggleCallRecording',
+  CustomShortcutPauseCallRecording = 'KeyboardMgrCustomShortcutPauseCallRecording',
+  CustomShortcutResumeCallRecording = 'KeyboardMgrCustomShortcutResumeCallRecording',
 }
 
 export const stringHook = () => ({
@@ -112,6 +115,9 @@ export const stringHook = () => ({
     [StringTemplates.CustomShortcutNavigateToKeyboardShortcuts]: 'Navigate to keyboard shortcuts',
     [StringTemplates.CustomShortcutNavigateToTeamsView]: 'Navigate to Teams View',
     [StringTemplates.CustomShortcutNavigateToQueuesView]: 'Navigate to Real-time Queues View',
+    [StringTemplates.CustomShortcutToggleCallRecording]: 'Toggle call recording pause/resume',
+    [StringTemplates.CustomShortcutPauseCallRecording]: 'Pause call recording',
+    [StringTemplates.CustomShortcutResumeCallRecording]: 'Resume call recording',
   },
   'es-ES': esES,
   'es-MX': esMX,

--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/utils/CustomKeyboardShortcuts.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/utils/CustomKeyboardShortcuts.ts
@@ -1,8 +1,38 @@
+import * as Flex from '@twilio/flex-ui';
 import { Actions, Manager } from '@twilio/flex-ui';
 
 import { StringTemplates } from '../flex-hooks/strings';
 
 const manager = Manager.getInstance();
+
+const getCurrentTask = () => {
+  // Get the state of the Flex store
+  const state = manager.store.getState();
+
+  // Find the currently focused task
+  const focusedTaskSid = state.flex.view.selectedTaskSid;
+
+  if (focusedTaskSid) {
+    const task = Flex.TaskHelper.getTaskByTaskSid(focusedTaskSid);
+    console.log(`Returning focused task`, task);
+    return task;
+  }
+
+  console.log(`No focused task found, returning null`);
+  return null;
+};
+
+const toggleCallRecording = () => {
+  Actions.invokeAction('ToggleCallRecording', { task: getCurrentTask() });
+};
+
+const pauseCallRecording = () => {
+  Actions.invokeAction('PauseCallRecording', { task: getCurrentTask() });
+};
+
+const resumeCallRecording = () => {
+  Actions.invokeAction('ResumeCallRecording', { task: getCurrentTask() });
+};
 
 const toggleDialpad = () => {
   Actions.invokeAction('ToggleOutboundDialer');
@@ -50,6 +80,21 @@ const debuggingHelper = () => {
 
 export const presetCustomShortcuts = () => {
   return {
+    2: {
+      action: toggleCallRecording,
+      name: (manager.strings as any)[StringTemplates.CustomShortcutToggleCallRecording],
+      throttle: 1000,
+    },
+    3: {
+      action: pauseCallRecording,
+      name: (manager.strings as any)[StringTemplates.CustomShortcutPauseCallRecording],
+      throttle: 1000,
+    },
+    4: {
+      action: resumeCallRecording,
+      name: (manager.strings as any)[StringTemplates.CustomShortcutResumeCallRecording],
+      throttle: 1000,
+    },
     D: {
       action: toggleDialpad,
       name: (manager.strings as any)[StringTemplates.CustomShortcutToggleDialpad],

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseRecordingButton/PauseRecordingButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseRecordingButton/PauseRecordingButton.tsx
@@ -1,10 +1,9 @@
-import { IconButton, TaskHelper, ITask, templates } from '@twilio/flex-ui';
+import { Actions, IconButton, TaskHelper, ITask, templates } from '@twilio/flex-ui';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import AppState from '../../../../types/manager/AppState';
 import { reduxNamespace } from '../../../../utils/state';
-import { pauseRecording, resumeRecording } from '../../helpers/pauseRecordingHelper';
 import { StringTemplates } from '../../flex-hooks/strings/PauseRecording';
 import { PauseRecordingState } from '../../flex-hooks/states/PauseRecordingSlice';
 
@@ -54,9 +53,9 @@ const PauseRecordingButton = (props: OwnProps) => {
     setWaiting(true);
 
     if (paused) {
-      await resumeRecording(props.task);
+      Actions.invokeAction('ResumeCallRecording', { task: props.task });
     } else {
-      await pauseRecording(props.task);
+      Actions.invokeAction('PauseCallRecording', { task: props.task });
     }
 
     setWaiting(false);

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseRecordingButton/PauseRecordingButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/custom-components/PauseRecordingButton/PauseRecordingButton.tsx
@@ -53,9 +53,9 @@ const PauseRecordingButton = (props: OwnProps) => {
     setWaiting(true);
 
     if (paused) {
-      Actions.invokeAction('ResumeCallRecording', { task: props.task });
+      await Actions.invokeAction('ResumeCallRecording', { task: props.task });
     } else {
-      Actions.invokeAction('PauseCallRecording', { task: props.task });
+      await Actions.invokeAction('PauseCallRecording', { task: props.task });
     }
 
     setWaiting(false);

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
@@ -16,6 +16,6 @@ export const registerPauseCallRecordingAction = async () => {
       return;
     }
 
-    pauseRecording(payload.task);
+    await pauseRecording(payload.task);
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
@@ -1,0 +1,21 @@
+import { Actions, ITask, TaskHelper } from '@twilio/flex-ui';
+
+import { pauseRecording } from '../../helpers/pauseRecordingHelper';
+
+export const registerPauseCallRecordingAction = async () => {
+  Actions.registerAction('PauseCallRecording', async (payload: { task?: ITask }) => {
+    if (!payload || !payload.task) {
+      console.log('No current task passed as payload, cannot pause recording');
+      return;
+    }
+
+    const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
+
+    if (!isLiveCall) {
+      console.log('Current task is not a live call, cannot pause recording');
+      return;
+    }
+
+    pauseRecording(payload.task);
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/pauseRecording.ts
@@ -5,14 +5,14 @@ import { pauseRecording } from '../../helpers/pauseRecordingHelper';
 export const registerPauseCallRecordingAction = async () => {
   Actions.registerAction('PauseCallRecording', async (payload: { task?: ITask }) => {
     if (!payload || !payload.task) {
-      console.log('No current task passed as payload, cannot pause recording');
+      console.log('No task passed as payload, cannot pause recording');
       return;
     }
 
     const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
 
     if (!isLiveCall) {
-      console.log('Current task is not a live call, cannot pause recording');
+      console.log('Task is not a live call, cannot pause recording');
       return;
     }
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
@@ -16,6 +16,6 @@ export const registerResumeCallRecordingAction = async () => {
       return;
     }
 
-    resumeRecording(payload.task);
+    await resumeRecording(payload.task);
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
@@ -5,14 +5,14 @@ import { resumeRecording } from '../../helpers/pauseRecordingHelper';
 export const registerResumeCallRecordingAction = async () => {
   Actions.registerAction('ResumeCallRecording', async (payload: { task?: ITask }) => {
     if (!payload || !payload.task) {
-      console.log('No current task passed as payload, cannot resume recording');
+      console.log('No task passed as payload, cannot resume recording');
       return;
     }
 
     const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
 
     if (!isLiveCall) {
-      console.log('Current task is not a live call, cannot resume recording');
+      console.log('Task is not a live call, cannot resume recording');
       return;
     }
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/resumeRecording.ts
@@ -1,0 +1,21 @@
+import { Actions, ITask, TaskHelper } from '@twilio/flex-ui';
+
+import { resumeRecording } from '../../helpers/pauseRecordingHelper';
+
+export const registerResumeCallRecordingAction = async () => {
+  Actions.registerAction('ResumeCallRecording', async (payload: { task?: ITask }) => {
+    if (!payload || !payload.task) {
+      console.log('No current task passed as payload, cannot resume recording');
+      return;
+    }
+
+    const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
+
+    if (!isLiveCall) {
+      console.log('Current task is not a live call, cannot resume recording');
+      return;
+    }
+
+    resumeRecording(payload.task);
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
@@ -1,4 +1,4 @@
-import { Actions, ITask, Manager, TaskHelper } from '@twilio/flex-ui';
+import { Actions, ITask, Manager } from '@twilio/flex-ui';
 
 import { PauseRecordingState } from '../states/PauseRecordingSlice';
 import AppState from '../../../../types/manager/AppState';
@@ -7,7 +7,7 @@ import { reduxNamespace } from '../../../../utils/state';
 export const registerToggleCallRecordingAction = async () => {
   Actions.registerAction('ToggleCallRecording', async (payload: { task?: ITask }) => {
     if (!payload || !payload.task) {
-      console.log('No current task passed as payload, cannot pause/resume recording');
+      console.log('No task passed as payload, cannot pause/resume recording');
       return;
     }
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
@@ -18,9 +18,9 @@ export const registerToggleCallRecordingAction = async () => {
       pausedRecordings &&
       pausedRecordings.find((pausedRecording) => payload.task && pausedRecording.reservationSid === payload.task.sid)
     ) {
-      Actions.invokeAction('ResumeCallRecording', payload);
+      await Actions.invokeAction('ResumeCallRecording', payload);
     } else {
-      Actions.invokeAction('PauseCallRecording', payload);
+      await Actions.invokeAction('PauseCallRecording', payload);
     }
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
@@ -1,0 +1,33 @@
+import { Actions, ITask, Manager, TaskHelper } from '@twilio/flex-ui';
+
+import { PauseRecordingState } from '../states/PauseRecordingSlice';
+import AppState from '../../../../types/manager/AppState';
+import { reduxNamespace } from '../../../../utils/state';
+
+export const registerToggleCallRecordingAction = async () => {
+  Actions.registerAction('ToggleCallRecording', async (payload: { task?: ITask }) => {
+    if (!payload || !payload.task) {
+      console.log('No current task passed as payload, cannot pause/resume recording');
+      return;
+    }
+
+    const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
+
+    if (!isLiveCall) {
+      console.log('Current task is not a live call, cannot pause/resume recording');
+      return;
+    }
+
+    const state: AppState = Manager.getInstance().store.getState() as AppState;
+    const { pausedRecordings } = state[reduxNamespace].pauseRecording as PauseRecordingState;
+
+    if (
+      pausedRecordings &&
+      pausedRecordings.find((pausedRecording) => payload.task && pausedRecording.reservationSid === payload.task.sid)
+    ) {
+      Actions.invokeAction('ResumeCallRecording', payload);
+    } else {
+      Actions.invokeAction('PauseCallRecording', payload);
+    }
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/custom-action/toggleRecording.ts
@@ -11,13 +11,6 @@ export const registerToggleCallRecordingAction = async () => {
       return;
     }
 
-    const isLiveCall = payload.task ? TaskHelper.isLiveCall(payload.task) : false;
-
-    if (!isLiveCall) {
-      console.log('Current task is not a live call, cannot pause/resume recording');
-      return;
-    }
-
     const state: AppState = Manager.getInstance().store.getState() as AppState;
     const { pausedRecordings } = state[reduxNamespace].pauseRecording as PauseRecordingState;
 

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/events/pluginsInitialized.ts
@@ -1,0 +1,54 @@
+import * as Flex from '@twilio/flex-ui';
+import { Actions } from '@twilio/flex-ui';
+
+import { FlexEvent } from '../../../../types/feature-loader';
+import { isFeatureEnabled } from '../../config';
+import { registerPauseCallRecordingAction } from '../custom-action/pauseRecording';
+import { registerResumeCallRecordingAction } from '../custom-action/resumeRecording';
+import { registerToggleCallRecordingAction } from '../custom-action/toggleRecording';
+
+export const eventName = FlexEvent.pluginsInitialized;
+export const eventHook = function () {
+  if (!isFeatureEnabled()) return;
+
+  registerPauseCallRecordingAction();
+  registerResumeCallRecordingAction();
+  registerToggleCallRecordingAction();
+
+  const getCurrentTask = () => {
+    const manager = Flex.Manager.getInstance();
+
+    // Get the state of the Flex store
+    const state = manager.store.getState();
+
+    // Find the currently focused task
+    const focusedTaskSid = state.flex.view.selectedTaskSid;
+
+    if (focusedTaskSid) {
+      const task = Flex.TaskHelper.getTaskByTaskSid(focusedTaskSid);
+      console.log(`Returning focused task`, task);
+      return task;
+    }
+
+    console.log(`No task found, returning null`);
+    return null;
+  };
+
+  const toggleCallRecording = () => {
+    Actions.invokeAction('ToggleCallRecording', { task: getCurrentTask() });
+  };
+
+  const pauseCallRecording = () => {
+    Actions.invokeAction('PauseCallRecording', { task: getCurrentTask() });
+  };
+
+  const resumeCallRecording = () => {
+    Actions.invokeAction('ResumeCallRecording', { task: getCurrentTask() });
+  };
+
+  Flex.KeyboardShortcutManager.addShortcuts({
+    2: { action: toggleCallRecording, name: 'Toggle call recording pause/resume', throttle: 1000 },
+    3: { action: pauseCallRecording, name: 'Pause call recording', throttle: 1000 },
+    4: { action: resumeCallRecording, name: 'Resume call recording', throttle: 1000 },
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/flex-hooks/events/pluginsInitialized.ts
@@ -1,6 +1,3 @@
-import * as Flex from '@twilio/flex-ui';
-import { Actions } from '@twilio/flex-ui';
-
 import { FlexEvent } from '../../../../types/feature-loader';
 import { isFeatureEnabled } from '../../config';
 import { registerPauseCallRecordingAction } from '../custom-action/pauseRecording';
@@ -14,41 +11,4 @@ export const eventHook = function () {
   registerPauseCallRecordingAction();
   registerResumeCallRecordingAction();
   registerToggleCallRecordingAction();
-
-  const getCurrentTask = () => {
-    const manager = Flex.Manager.getInstance();
-
-    // Get the state of the Flex store
-    const state = manager.store.getState();
-
-    // Find the currently focused task
-    const focusedTaskSid = state.flex.view.selectedTaskSid;
-
-    if (focusedTaskSid) {
-      const task = Flex.TaskHelper.getTaskByTaskSid(focusedTaskSid);
-      console.log(`Returning focused task`, task);
-      return task;
-    }
-
-    console.log(`No task found, returning null`);
-    return null;
-  };
-
-  const toggleCallRecording = () => {
-    Actions.invokeAction('ToggleCallRecording', { task: getCurrentTask() });
-  };
-
-  const pauseCallRecording = () => {
-    Actions.invokeAction('PauseCallRecording', { task: getCurrentTask() });
-  };
-
-  const resumeCallRecording = () => {
-    Actions.invokeAction('ResumeCallRecording', { task: getCurrentTask() });
-  };
-
-  Flex.KeyboardShortcutManager.addShortcuts({
-    2: { action: toggleCallRecording, name: 'Toggle call recording pause/resume', throttle: 1000 },
-    3: { action: pauseCallRecording, name: 'Pause call recording', throttle: 1000 },
-    4: { action: resumeCallRecording, name: 'Resume call recording', throttle: 1000 },
-  });
 };


### PR DESCRIPTION
### Summary

Modification to the pause-recording feature to add keyboard shortcuts (and Flex Actions) for:
- Pause call recording on focused task
- Resume call recording on focused task
- Toggle state between pause and resume

### Checklist

- [X] Tested changes end to end
- [X] Updated documentation
- [X] Requested one or more reviewers
