### PR TITLE
Fix flex-hooks docs format to match prettier rules

### DIFF
--- a/docs/docs/building/flex-hooks/actions.md
+++ b/docs/docs/building/flex-hooks/actions.md
@@ -1,22 +1,16 @@
 Use an actions hook to register actions in the [Flex Actions Framework](https://www.twilio.com/docs/flex/developer/ui/use-ui-actions).
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
-import { FlexActionEvent, FlexAction } from "../../../../types/feature-loader";
+import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.CompleteTask;
-export const actionHook = function exampleCompleteTaskHook(
-  flex: typeof Flex,
-  manager: Flex.Manager
-) {
-  flex.Actions.addListener(
-    `${actionEvent}${actionName}`,
-    async (payload, abortFunction) => {
-      // your code here
-    }
-  );
+export const actionHook = function exampleCompleteTaskHook(flex: typeof Flex, manager: Flex.Manager) {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
+    // your code here
+  });
 };
 ```
 

--- a/docs/docs/building/flex-hooks/channels.md
+++ b/docs/docs/building/flex-hooks/channels.md
@@ -1,24 +1,21 @@
 Use a channels hook to register new [task channel definitions](https://www.twilio.com/docs/flex/developer/ui/task-channel-definitions).
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
-import PhoneCallbackIcon from "@material-ui/icons/PhoneCallback";
+import * as Flex from '@twilio/flex-ui';
+import PhoneCallbackIcon from '@material-ui/icons/PhoneCallback';
 
-import { TaskAttributes } from "../../../../types/task-router/Task";
+import { TaskAttributes } from '../../../../types/task-router/Task';
 
-export const channelHook = function createCallbackChannel(
-  flex: typeof Flex,
-  manager: Flex.Manager
-) {
+export const channelHook = function createCallbackChannel(flex: typeof Flex, manager: Flex.Manager) {
   const channelDefinition = flex.DefaultTaskChannels.createDefaultTaskChannel(
-    "callback",
+    'callback',
     (task) => {
       const { taskType } = task.attributes as TaskAttributes;
-      return task.taskChannelUniqueName === "voice" && taskType === "callback";
+      return task.taskChannelUniqueName === 'voice' && taskType === 'callback';
     },
-    "CallbackIcon",
-    "CallbackIcon",
-    "palegreen"
+    'CallbackIcon',
+    'CallbackIcon',
+    'palegreen',
   );
 
   const { templates } = channelDefinition;
@@ -28,13 +25,11 @@ export const channelHook = function createCallbackChannel(
       ...templates,
       TaskListItem: {
         ...templates?.TaskListItem,
-        firstLine: (task: Flex.ITask) =>
-          `${task.queueName}: ${task.attributes.name}`,
+        firstLine: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
       },
       TaskCanvasHeader: {
         ...templates?.TaskCanvasHeader,
-        title: (task: Flex.ITask) =>
-          `${task.queueName}: ${task.attributes.name}`,
+        title: (task: Flex.ITask) => `${task.queueName}: ${task.attributes.name}`,
       },
       IncomingTaskCanvas: {
         ...templates?.IncomingTaskCanvas,

--- a/docs/docs/building/flex-hooks/chat-orchestrator.md
+++ b/docs/docs/building/flex-hooks/chat-orchestrator.md
@@ -1,23 +1,17 @@
 Use a chat orchestrator hook to modify chat orchestration via `ChatOrchestrator.setOrchestrations`.
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
-import { FlexOrchestrationEvent } from "../../../../types/feature-loader";
+import { FlexOrchestrationEvent } from '../../../../types/feature-loader';
 
-export const chatOrchestratorHook = (
-  flex: typeof Flex,
-  manager: Flex.Manager
-) => ({
+export const chatOrchestratorHook = (flex: typeof Flex, manager: Flex.Manager) => ({
   event: FlexOrchestrationEvent.completed,
   handler: handleChatComplete,
 });
 
 const handleChatComplete = (task: Flex.ITask): any => {
-  return [
-    Flex.ChatOrchestratorEvent.DeactivateConversation,
-    Flex.ChatOrchestratorEvent.LeaveConversation,
-  ];
+  return [Flex.ChatOrchestratorEvent.DeactivateConversation, Flex.ChatOrchestratorEvent.LeaveConversation];
 };
 ```
 

--- a/docs/docs/building/flex-hooks/components.md
+++ b/docs/docs/building/flex-hooks/components.md
@@ -1,16 +1,13 @@
 Use a component hook to [modify or add components](https://www.twilio.com/docs/flex/developer/ui/work-with-components-and-props) to Flex UI.
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
-import MyComponentName from "../../custom-components/MyComponentName";
-import { FlexComponent } from "../../../../types/feature-loader";
+import MyComponentName from '../../custom-components/MyComponentName';
+import { FlexComponent } from '../../../../types/feature-loader';
 
 export const componentName = FlexComponent.CallCanvas;
-export const componentHook = function addMyComponentToCallCanvas(
-  flex: typeof Flex,
-  manager: Flex.Manager
-) {
+export const componentHook = function addMyComponentToCallCanvas(flex: typeof Flex, manager: Flex.Manager) {
   flex.CallCanvas.Content.add(<MyComponentName key="my-awesome-component" />, {
     sortOrder: -1,
   });

--- a/docs/docs/building/flex-hooks/css-overrides.md
+++ b/docs/docs/building/flex-hooks/css-overrides.md
@@ -1,16 +1,16 @@
 Use a CSS override hook to set `componentThemeOverrides` for [various Flex UI components](https://assets.flex.twilio.com/docs/releases/flex-ui/2.1.0/theming/Theme/).
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
 export const cssOverrideHook = (flex: typeof Flex, manager: Flex.Manager) => {
   return {
     MainHeader: {
       Container: {
-        ".Twilio-MainHeader-end": {
+        '.Twilio-MainHeader-end': {
           "[data-paste-element='MENU']": {
-            overflowY: "scroll",
-            maxHeight: "90vh",
+            overflowY: 'scroll',
+            maxHeight: '90vh',
           },
         },
       },

--- a/docs/docs/building/flex-hooks/events.md
+++ b/docs/docs/building/flex-hooks/events.md
@@ -1,15 +1,15 @@
 Use an event hook to add your own handler for [Flex events](https://assets.flex.twilio.com/docs/releases/flex-ui/2.1.0/ui-actions/FlexEvent/).
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
-import { FlexEvent } from "../../../../types/feature-loader";
+import { FlexEvent } from '../../../../types/feature-loader';
 
 export const eventName = FlexEvent.taskReceived;
 export const eventHook = function exampleTaskReceivedHandler(
   flex: typeof Flex,
   manager: Flex.Manager,
-  task: Flex.ITask
+  task: Flex.ITask,
 ) {
   // your code here
 };

--- a/docs/docs/building/flex-hooks/jsclient-event-listeners.md
+++ b/docs/docs/building/flex-hooks/jsclient-event-listeners.md
@@ -1,20 +1,17 @@
 Use a JS client event listener hook to add your own handler for events from the various client SDKs within Flex.
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
-import { Conversation } from "@twilio/conversations";
+import * as Flex from '@twilio/flex-ui';
+import { Conversation } from '@twilio/conversations';
 
-import {
-  FlexJsClient,
-  ConversationEvent,
-} from "../../../../../types/feature-loader";
+import { FlexJsClient, ConversationEvent } from '../../../../../types/feature-loader';
 
 export const clientName = FlexJsClient.conversationsClient;
 export const eventName = ConversationEvent.conversationJoined;
 export const jsClientHook = function exampleConversationJoinedHandler(
   flex: typeof Flex,
   manager: Flex.Manager,
-  conversation: Conversation
+  conversation: Conversation,
 ) {
   // your code here
 };

--- a/docs/docs/building/flex-hooks/notification-events.md
+++ b/docs/docs/building/flex-hooks/notification-events.md
@@ -1,15 +1,10 @@
 Use a notification event hook to add your own handler for various [Flex Notification Manager events](https://assets.flex.twilio.com/docs/releases/flex-ui/2.1.0/nsa/NotificationManager/#exports.NotificationEvent).
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
 export const eventName = Flex.NotificationEvent.beforeAddNotification;
-export const notificationEventHook = (
-  flex: typeof Flex,
-  manager: Flex.Manager,
-  notification: any,
-  cancel: any
-) => {
+export const notificationEventHook = (flex: typeof Flex, manager: Flex.Manager, notification: any, cancel: any) => {
   // your code here
 };
 ```

--- a/docs/docs/building/flex-hooks/notifications.md
+++ b/docs/docs/building/flex-hooks/notifications.md
@@ -1,14 +1,14 @@
 Use a notification hook to register your own notification definitions for use in your feature.
 
 ```ts
-import * as Flex from "@twilio/flex-ui";
+import * as Flex from '@twilio/flex-ui';
 
-import { StringTemplates } from "../strings";
+import { StringTemplates } from '../strings';
 
 // Export the notification IDs an enum for better maintainability when accessing them elsewhere
 export enum ExampleNotification {
-  MyNotification = "MyNotification",
-  MyNotification2 = "MyNotification2",
+  MyNotification = 'MyNotification',
+  MyNotification2 = 'MyNotification2',
 }
 
 // Return an array of Flex.Notification

--- a/docs/docs/building/flex-hooks/paste-elements.md
+++ b/docs/docs/building/flex-hooks/paste-elements.md
@@ -1,16 +1,16 @@
 Use a Paste elements hook to register your own element definitions for usage in your feature's UI built with [Twilio Paste](https://paste.twilio.design/).
 
 ```ts
-import { PasteCustomCSS } from "@twilio-paste/customization";
+import { PasteCustomCSS } from '@twilio-paste/customization';
 
 export const pasteElementHook = {
   MY_CUSTOM_ELEMENT: {
-    paddingLeft: "space40",
-    paddingRight: "space40",
-    paddingTop: "space40",
+    paddingLeft: 'space40',
+    paddingRight: 'space40',
+    paddingTop: 'space40',
   },
   MY_OTHER_ELEMENT: {
-    paddingBottom: "space40",
+    paddingBottom: 'space40',
   },
 } as { [key: string]: PasteCustomCSS };
 ```

--- a/docs/docs/building/flex-hooks/reducers.md
+++ b/docs/docs/building/flex-hooks/reducers.md
@@ -1,8 +1,8 @@
 Use this example Redux Toolkit slice as a starting point for keeping Redux state within your feature.
 
 ```ts
-import { createSlice } from "@reduxjs/toolkit";
-import type { PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 
 export interface ExampleState {
   myValue: boolean;
@@ -15,7 +15,7 @@ const initialState = {
 } as ExampleState;
 
 const exampleSlice = createSlice({
-  name: "exampleStateName",
+  name: 'exampleStateName',
   initialState,
   reducers: {
     updateMyValue(state, action: PayloadAction<boolean>) {

--- a/docs/docs/building/flex-hooks/strings.md
+++ b/docs/docs/building/flex-hooks/strings.md
@@ -38,7 +38,7 @@ import { templates } from '@twilio/flex-ui';
 
 const myString = templates[StringTemplates.MyString2]({
   customString: 'apples',
-})
+});
 ```
 
 JSX:
@@ -55,8 +55,8 @@ If you wish to replace built-in Flex UI strings, rather than defining new string
 ```ts
 export const systemStringHook = () => ({
   'es-MX': {
-    "SetYourStatus": "Establece tu estado",
-    "LogOut": "Cerrar sesión",
+    SetYourStatus: 'Establece tu estado',
+    LogOut: 'Cerrar sesión',
   },
 });
 ```

--- a/docs/docs/building/flex-hooks/teams-filters.md
+++ b/docs/docs/building/flex-hooks/teams-filters.md
@@ -1,9 +1,9 @@
 Use a teams filter hook to register your own [filter definitions](https://www.twilio.com/docs/flex/developer/ui/team-view-filters) in the Teams view.
 
 ```ts
-import { FilterDefinition } from "@twilio/flex-ui";
+import { FilterDefinition } from '@twilio/flex-ui';
 
-import { emailFilter } from "../../filters/emailFilter"; // example filter from the teams-view-filters feature
+import { emailFilter } from '../../filters/emailFilter'; // example filter from the teams-view-filters feature
 
 export const teamsFilterHook = async function getSampleFilters() {
   const enabledFilters = [] as Array<FilterDefinition>;


### PR DESCRIPTION
### Summary

It was annoying how when pasting flex-hooks examples into a new file, the editor lit up with prettier rule errors. Formatted the docs so that everything is now consistent.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
