### PR TITLE
[SE-17] Revise park timeout for SMS

### DIFF
--- a/docs/docs/feature-library/park-interaction.md
+++ b/docs/docs/feature-library/park-interaction.md
@@ -35,7 +35,8 @@ You may need a different use case then what this plugin does today. For example,
 This feature is based in the instructions given on our doc on how to [Park an Interaction](https://www.twilio.com/docs/flex/developer/conversations/park-an-interaction). In the legacy Flex this functionality was known as "long-lived channels".
 
 ### Parked Interactions List details
-- This feature leverages Sync MapItems to store the state of recently parked interactions, with a time-to-live (TTL) of 24 hours
+- This feature leverages Sync MapItems to store the state of recently parked interactions
+  - Non-SMS interactions are stored with a time-to-live (TTL) of 24 hours due to restrictions imposed by third-party platforms
 - Attempting to unpark a closed or failed conversation will result in an error
 - While unparking an interaction, the associated Sync MapItem is deleted, for both scenarios (customer or worker-initiated). The `unpark-interaction` serverless function checks if the conversation has `mapSid` and `mapItemKey` attributes, which are only added when it's being parked and the `show_list` option is enabled
 - If the unparking is worker-initiated from the list, `queue_id` and `worder_sid` attributes are added to the request, so the interaction is routed directly to the worker. Otherwise, if customer-initiated, these are not added

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/utils/ParkInteractionService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/utils/ParkInteractionService.ts
@@ -1,11 +1,9 @@
 import ApiService from '../../../utils/serverless/ApiService';
 import { EncodedParams } from '../../../types/serverless';
-import { FetchedRecording } from '../../../types/serverless/twilio-api';
 import { isListEnabled } from '../config';
 
 export interface ParkInteractionResponse {
   success: boolean;
-  recording: FetchedRecording;
 }
 
 export interface ParkedInteraction {
@@ -36,7 +34,6 @@ interface Customers {
 
 interface UnparkInteractionResponse {
   success: boolean;
-  recording: FetchedRecording;
 }
 
 class ParkInteractionService extends ApiService {
@@ -52,7 +49,7 @@ class ParkInteractionService extends ApiService {
     queueName: string,
     queueSid: string,
     taskAttributes: string,
-  ): Promise<FetchedRecording> => {
+  ): Promise<ParkInteractionResponse> => {
     return new Promise((resolve, reject) => {
       const encodedParams: EncodedParams = {
         channelSid: encodeURIComponent(channelSid),
@@ -80,7 +77,7 @@ class ParkInteractionService extends ApiService {
         },
       )
         .then((resp: ParkInteractionResponse) => {
-          resolve(resp.recording);
+          resolve(resp);
         })
         .catch((error) => {
           console.log('Error parking interaction', error);
@@ -89,7 +86,7 @@ class ParkInteractionService extends ApiService {
     });
   };
 
-  unparkInteraction = async (ConversationSid: string, WebhookSid: string): Promise<any> => {
+  unparkInteraction = async (ConversationSid: string, WebhookSid: string): Promise<UnparkInteractionResponse> => {
     return new Promise((resolve, reject) => {
       const encodedParams: EncodedParams = {
         ConversationSid: encodeURIComponent(ConversationSid),
@@ -106,7 +103,7 @@ class ParkInteractionService extends ApiService {
         },
       )
         .then((resp: any) => {
-          resolve(resp.recording);
+          resolve(resp);
         })
         .catch((error) => {
           console.log('Error unparking interaction', error);

--- a/serverless-functions/src/functions/features/park-interaction/flex/park-interaction.js
+++ b/serverless-functions/src/functions/features/park-interaction/flex/park-interaction.js
@@ -75,7 +75,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
               .syncMaps(syncMap.data?.sid || `ParkedInteractions_${workerSid}`)
               .syncMapItems.create({
                 key: conversationSid,
-                ttl: 86400, // One day
+                ttl: channelType === 'whatsapp' ? 86400 : 0, // WhatsApp rules dictate that a non-templated message cannot be sent more than 24 hours after the last inbound message.
                 data: {
                   interactionSid,
                   flexInteractionChannelSid: channelSid,

--- a/serverless-functions/src/functions/features/park-interaction/flex/park-interaction.js
+++ b/serverless-functions/src/functions/features/park-interaction/flex/park-interaction.js
@@ -75,7 +75,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
               .syncMaps(syncMap.data?.sid || `ParkedInteractions_${workerSid}`)
               .syncMapItems.create({
                 key: conversationSid,
-                ttl: channelType === 'whatsapp' ? 86400 : 0, // WhatsApp rules dictate that a non-templated message cannot be sent more than 24 hours after the last inbound message.
+                ttl: channelType === 'sms' ? 0 : 86400, // SMS is the only channel known to reliably last over 24 hours
                 data: {
                   interactionSid,
                   flexInteractionChannelSid: channelSid,


### PR DESCRIPTION
### Summary

WhatsApp and Messenger have a 24-hour maximum after the last message sent, and web clients also have their own timeout. However, SMS conversations work great past 24 hours, so let's remove the timeout for those only.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
