### PR TITLE
FEAT: Force conference region

### DIFF
--- a/docs/docs/feature-library/force-conference-region.md
+++ b/docs/docs/feature-library/force-conference-region.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: force-conference-region
+title: force-conference-region
+---
+
+This feature provides adds the ability to set the _conference region_ which is used by Flex when a call task is accepted to establish a conference. By default the conference is established based on the incoming call Region/Edge which is generally the lowest latency to the caller. 
+
+## known issue workaround
+In certain circumstances the region that is chosen when the conference is established may be incorrect. This can occur when a call has been transferred into Twilio from another Twilio account using the `<Application/>` TwiML verb. 
+
+For example, in this scenario a call that lands on an edge (e.g. Sydney in AU1 region) in Account A may be transferred to a Flex agent in Account B (also connected to the Sydney edge in AU1).  The transfer of the call uses the Application Connect method to send the call between accounts. Currently, outbound call leg via Application Connect will default to Ashburn (US1), consequently the inbound leg to Account B also shows the Ashburn edge. In this scenario when the call is presented to the agent, Flex will by default choose a low latency conference resource and use the US1 region, even if the agent is connected to a different edge.
+
+### how it works
+This plugin provides a workaround to this issue by setting the `conferenceOptions.region` parameter to a _region_ that is specified by the plugin.
+
+***NOTE** Currently the conference API does not support the `edge` parameter, hence the legacy `region` parameter is used instead. 
+
+Only Twilio regions (not interconnect regions) may be used, see the complete list [here](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions)

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -9,12 +9,7 @@
     "common": {
       "log_level": "info",
       "audit_log_ttl": 1209600,
-      "teams": [
-        "Blue Team",
-        "Red Team",
-        "Gold Team",
-        "VIP Team"
-      ],
+      "teams": ["Blue Team", "Red Team", "Gold Team", "VIP Team"],
       "departments": [
         "General Management",
         "Marketing",
@@ -251,10 +246,7 @@
         "per_queue": {
           "exampleQueueName": {
             "require_disposition": true,
-            "dispositions": [
-              "Promotional Sale",
-              "Renewal"
-            ],
+            "dispositions": ["Promotional Sale", "Renewal"],
             "text_attributes": [],
             "select_attributes": []
           }
@@ -427,6 +419,9 @@
           "side_nav_hover_background": "rgb(225, 227, 234)"
         },
         "component_theme_overrides": {}
+      },
+      "force_conference_region": {
+        "enabled": false
       }
     }
   }

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -421,7 +421,8 @@
         "component_theme_overrides": {}
       },
       "force_conference_region": {
-        "enabled": false
+        "enabled": false,
+        "region": ""
       }
     }
   }

--- a/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/config.ts
@@ -1,0 +1,13 @@
+import { getFeatureFlags } from '../../utils/configuration';
+import ForceConferenceRegionConfig from './types/ServiceConfiguration';
+
+const { enabled = false, region } =
+  (getFeatureFlags()?.features?.force_conference_region as ForceConferenceRegionConfig) || {};
+
+export const isFeatureEnabled = () => {
+  return enabled;
+};
+
+export const getRegion = () => {
+  return region;
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/flex-hooks/actions/BeforeAcceptTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/flex-hooks/actions/BeforeAcceptTask.ts
@@ -1,0 +1,21 @@
+import * as Flex from '@twilio/flex-ui';
+
+import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
+import { getRegion } from '../../config';
+
+export const actionEvent = FlexActionEvent.before;
+export const actionName = FlexAction.AcceptTask;
+export const actionHook = function setConferenceRegion(flex: typeof Flex, _manager: Flex.Manager) {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, _abortFunction) => {
+    if (!Flex.TaskHelper.isCallTask(payload.task ?? Flex.TaskHelper.getTaskByTaskSid(payload.sid))) {
+      return;
+    }
+
+    // Set the conference region for the initial call based on configuration
+    const region = getRegion();
+    if (region && region !== '') {
+      console.log(`[force-conference-region] Setting conferenceOptions.region = ${region}`);
+      payload.conferenceOptions.region = region;
+    }
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/flex-hooks/actions/BeforeAcceptTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/flex-hooks/actions/BeforeAcceptTask.ts
@@ -16,6 +16,8 @@ export const actionHook = function setConferenceRegion(flex: typeof Flex, _manag
     if (region && region !== '') {
       console.log(`[force-conference-region] Setting conferenceOptions.region = ${region}`);
       payload.conferenceOptions.region = region;
+    } else {
+      console.log(`[force-conference-region] Region not set for call`);
     }
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/index.ts
@@ -1,0 +1,9 @@
+import { FeatureDefinition } from '../../types/feature-loader';
+import { isFeatureEnabled } from './config';
+// @ts-ignore
+import hooks from './flex-hooks/**/*.*';
+
+export const register = (): FeatureDefinition => {
+  if (!isFeatureEnabled()) return {};
+  return { name: 'force-conference-region', hooks: typeof hooks === 'undefined' ? [] : hooks };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/force-conference-region/types/ServiceConfiguration.ts
@@ -1,0 +1,4 @@
+export default interface ForceConferenceRegionConfig {
+  enabled: boolean;
+  region: string;
+}


### PR DESCRIPTION
### Summary

This feature provides adds the ability to set the _conference region_ which is used by Flex when a call task is accepted to establish a conference. By default the conference is established based on the incoming call Region/Edge which is generally the lowest latency to the caller. 

### Checklist

- [X] Tested changes end to end
- [X] Updated documentation
- [X] Requested one or more reviewers
