### PR TITLE
[SE-45] Document configuration helper functions

### DIFF
--- a/docs/docs/building/template-utilities/configuration.md
+++ b/docs/docs/building/template-utilities/configuration.md
@@ -23,6 +23,21 @@ When running Flex locally, the configuration from [hosted Flex configuration](ht
 The `appConfig.js` file is created for you as part of the initial local environment setup script, which executes when running `npm install` in the root template directory. The file is automatically populated with the feature config from the `flex-config/ui_attributes.common.json` file at the time of creation, as long as the file does not already exist.
 :::
 
+### Reading configuration within Flex
+
+Several helper functions are available for reading configuration, and can be imported from `plugin-flex-ts-template-v2/src/utils/configuration/index.ts`. The exported functions from this file are as follows:
+
+- `getFeatureFlagsGlobal`: Fetches the `custom_data` object from the [hosted Flex configuration](https://www.twilio.com/docs/flex/developer/config/flex-configuration-rest-api#ui_attributes), providing all of the global feature configuration and global common configuration for the template. If running locally, any values contained within `plugin-flex-ts-template-v2/public/appConfig.js` will also be returned, overriding the corresponding hosted Flex configuration values.
+
+- `getFeatureFlagsUser`: Fetches the `config_overrides` object from the current worker's attributes. This object contains any configuration values that were set on the worker level, overriding the corresponding global configuration values.
+
+- `getFeatureFlags`: Returns the complete effective configuration. **This is the function you should use in most cases when determining a configuration value.** For each configuration value, the value returned will be as follows:
+  - If a override has been configured on the worker, that will be returned.
+  - If no worker override has been configured, and the plugin is running locally, and the value is configured in `appConfig.js`, the value from `appConfig.js` will be returned.
+  - Otherwise, the hosted Flex configuration value will be returned.
+
+- `getUserLanguage`: Returns the currently configured language, using the same order of precedence as `getFeatureFlags`. If the configured value is `default`, the browser's language will be returned. Otherwise, if no value is configured, `en-US` will be returned.
+
 ### Configuration management
 
 #### The `custom_data` object

--- a/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
@@ -7,10 +7,22 @@ const manager = Flex.Manager.getInstance();
 const { custom_data: globalSettings } = manager.configuration as UIAttributes;
 export const defaultLanguage = 'en-US';
 
+/**
+ * Fetches the `custom_data` object from the hosted Flex configuration,
+ * providing all of the global feature configuration and global common
+ * configuration for the template.
+ * If running locally, any values contained within `appConfig.js` will also be
+ * returned, overriding the corresponding hosted Flex configuration values.
+ */
 export const getFeatureFlagsGlobal = () => {
   return globalSettings;
 };
 
+/**
+ * Fetches the `config_overrides` object from the current worker's attributes.
+ * This object contains any configuration values that were set on the worker
+ * level, overriding the corresponding global configuration values.
+ */
 export const getFeatureFlagsUser = () => {
   const { config_overrides: workerSettings } = manager.workerClient?.attributes as CustomWorkerAttributes;
   return workerSettings;
@@ -18,10 +30,26 @@ export const getFeatureFlagsUser = () => {
 
 const mergedSettings = merge(globalSettings, getFeatureFlagsUser());
 
+/**
+ * Returns the complete effective configuration. **This is the function you
+ * should use in most cases when determining a configuration value.** For each
+ * configuration value, the value returned will be as follows:
+ * - If a override has been configured on the worker, that will be returned.
+ * - If no worker override has been configured, and the plugin is running
+ * locally, and the value is configured in `appConfig.js`, the value from
+ * `appConfig.js` will be returned.
+ * - Otherwise, the hosted Flex configuration value will be returned.
+ */
 export const getFeatureFlags = () => {
   return mergedSettings;
 };
 
+/**
+ * Returns the currently configured language, using the same order of
+ * precedence as `getFeatureFlags`. If the configured value is `default`, the
+ * browser's language will be returned. Otherwise, if no value is configured,
+ * `en-US` will be returned.
+ */
 export const getUserLanguage = () => {
   let { language } = getFeatureFlags();
 


### PR DESCRIPTION
### Summary

Adds documentation for the functions exported by `plugin-flex-ts-template-v2/src/utils/configuration/index.ts`.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
