### PR TITLE
[SE-46] Maintain task channel for conversation transfer

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/helpers/APIHelper.ts
@@ -12,9 +12,9 @@ const manager: any | undefined = Manager.getInstance();
 
 export interface RemoveParticipantRESTPayload {
   conversationSid: string;
-  flexInteractionSid: string; // KDxxx sid for inteactions API
+  flexInteractionSid: string; // KDxxx sid for interactions API
   flexInteractionChannelSid: string; // UOxxx sid for interactions API
-  flexInteractionParticipantSid: string; // UTxxx sid for interactions API for the transferrring agent to remove
+  flexInteractionParticipantSid: string; // UTxxx sid for interactions API for the transferring agent to remove
 }
 
 export interface TransferRESTPayload {
@@ -28,7 +28,8 @@ export interface TransferRESTPayload {
   workersToIgnore: object; // {key: value} - where key is the taskrouter attribute to set and value is a string array of names of agents in conversation to make sure they don't get reservations to join again
   flexInteractionSid: string; // KDxxx sid for inteactions API
   flexInteractionChannelSid: string; // UOxxx sid for interactions API
-  removeFlexInteractionParticipantSid: string; // UTxxx sid for interactions API for the transferrring agent to remove them from conversation
+  removeFlexInteractionParticipantSid: string; // UTxxx sid for interactions API for the transferring agent to remove them from conversation
+  taskChannelUniqueName: string; // Task channel to use for the new task
 }
 
 const _getMyParticipantSid = (participants: any): string => {
@@ -109,7 +110,7 @@ export const buildInviteParticipantAPIPayload = async (
   targetSid: string,
   options?: TransferOptions,
 ): Promise<TransferRESTPayload | null> => {
-  const { taskSid } = task;
+  const { taskSid, taskChannelUniqueName } = task;
   const conversationId = task.attributes?.conversations?.conversation_id || task.taskSid;
   const transferTargetSid = targetSid;
   const removeInvitingAgent = options?.mode === 'COLD';
@@ -170,6 +171,7 @@ export const buildInviteParticipantAPIPayload = async (
     flexInteractionSid,
     flexInteractionChannelSid,
     removeFlexInteractionParticipantSid,
+    taskChannelUniqueName,
   };
 };
 
@@ -197,6 +199,7 @@ class ChatTransferService extends ApiService {
       flexInteractionSid: encodeURIComponent(requestPayload.flexInteractionSid),
       flexInteractionChannelSid: encodeURIComponent(requestPayload.flexInteractionChannelSid),
       removeFlexInteractionParticipantSid: encodeURIComponent(requestPayload.removeFlexInteractionParticipantSid),
+      taskChannelUniqueName: encodeURIComponent(requestPayload.taskChannelUniqueName),
     };
 
     return this.fetchJsonWithReject<TransferRESTResponse>(

--- a/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
+++ b/serverless-functions/src/functions/features/conversation-transfer/flex/invite-participant.js
@@ -30,6 +30,10 @@ const requiredParameters = [
     key: 'flexInteractionChannelSid',
     purpose: 'UOxxx sid for interactions API',
   },
+  {
+    key: 'taskChannelUniqueName',
+    purpose: 'task channel to use for the new task',
+  },
 ];
 
 const getRoutingParams = (
@@ -39,6 +43,7 @@ const getRoutingParams = (
   transferTargetSid,
   transferQueueName,
   workersToIgnore,
+  taskChannelUniqueName,
 ) => {
   const originalTaskAttributes = JSON.parse(jsonAttributes);
   const newAttributes = {
@@ -55,7 +60,7 @@ const getRoutingParams = (
 
   return {
     properties: {
-      task_channel_unique_name: 'chat',
+      task_channel_unique_name: taskChannelUniqueName,
       workspace_sid: context.TWILIO_FLEX_WORKSPACE_SID,
       workflow_sid: context.TWILIO_FLEX_CHAT_TRANSFER_WORKFLOW_SID,
       attributes: newAttributes,
@@ -85,6 +90,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       flexInteractionSid,
       flexInteractionChannelSid,
       removeFlexInteractionParticipantSid,
+      taskChannelUniqueName,
     } = event;
 
     const routingParams = getRoutingParams(
@@ -94,6 +100,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
       transferTargetSid,
       transferQueueName,
       workersToIgnore,
+      taskChannelUniqueName,
     );
 
     const {


### PR DESCRIPTION
### Summary

Previously, the task channel was hard-coded as `chat`. Now, it maintains whatever the original task used.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
