### PR TITLE
Fix issue with schedule manager serverless

### DIFF
--- a/addons/serverless-schedule-manager/functions/admin/update.js
+++ b/addons/serverless-schedule-manager/functions/admin/update.js
@@ -1,4 +1,6 @@
-const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+const { prepareFlexFunction, extractStandardResponse } = require(Runtime.getFunctions()[
+  'common/helpers/function-helper'
+].path);
 const ServerlessOperations = require(Runtime.getFunctions()['common/twilio-wrappers/serverless'].path);
 
 const requiredParameters = [


### PR DESCRIPTION
### Summary

Fixes a regression from #191 which caused the function to reference an undeclared variable. This has gone unnoticed because we only run into it when an API call fails.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
