### PR TITLE
Supervisor barge/coach optimizations

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
-import { useFlexSelector, Template, templates } from '@twilio/flex-ui';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import { Template, templates } from '@twilio/flex-ui';
+import { useSelector } from 'react-redux';
 import { Flex } from '@twilio-paste/core/flex';
 import { Stack } from '@twilio-paste/core/stack';
 import { Box } from '@twilio-paste/core/box';
@@ -8,68 +8,13 @@ import { Text } from '@twilio-paste/core/text';
 
 import { AppState } from '../../../../types/manager';
 import { reduxNamespace } from '../../../../utils/state';
-import { Actions, SupervisorBargeCoachState } from '../../flex-hooks/states/SupervisorBargeCoach';
+import { SupervisorBargeCoachState } from '../../flex-hooks/states/SupervisorBargeCoach';
 import { StringTemplates } from '../../flex-hooks/strings/BargeCoachAssist';
-// Import to get Sync Doc updates
-import { SyncDoc } from '../../utils/sync/Sync';
 
 export const CoachingStatusPanel = () => {
-  const dispatch = useDispatch();
-
-  let { supervisorArray } = useSelector(
+  const { supervisorArray } = useSelector(
     (state: AppState) => state[reduxNamespace].supervisorBargeCoach as SupervisorBargeCoachState,
   );
-  const { syncSubscribed } = useSelector(
-    (state: AppState) => state[reduxNamespace].supervisorBargeCoach as SupervisorBargeCoachState,
-  );
-
-  const myWorkerSID = useFlexSelector((state) => state?.flex?.worker?.worker?.sid);
-
-  const syncUpdates = () => {
-    // Let's subscribe to the sync doc as an agent/work and check
-    // if we are being coached, if we are, render that in the UI
-    // otherwise leave it blank
-    const mySyncDoc = `syncDoc.${myWorkerSID}`;
-    SyncDoc.getSyncDoc(mySyncDoc).then((doc: any) => {
-      // We are subscribing to Sync Doc updates here and logging anytime that happens
-      doc.on('updated', (doc: any) => {
-        if (doc.data.supervisors) {
-          supervisorArray = [...doc.data.supervisors];
-          // Current verion of this feature will only show the Agent they are being coached
-          // This could be updated by removing the below logic and including Monitoring and Barge
-          for (let i = 0; i < supervisorArray.length; i++) {
-            if (supervisorArray[i].status === 'monitoring' || supervisorArray[i].status === 'barge') {
-              supervisorArray.splice(i, 1);
-              i -= 1;
-            }
-          }
-        } else {
-          supervisorArray = [];
-        }
-
-        // Set Supervisor's name that is coaching into props
-        dispatch(
-          Actions.setBargeCoachStatus({
-            supervisorArray,
-          }),
-        );
-      });
-    });
-    dispatch(
-      Actions.setBargeCoachStatus({
-        syncSubscribed: true,
-      }),
-    );
-  };
-
-  useEffect(() => {
-    if (!syncSubscribed) {
-      syncUpdates();
-      // Caching this if the browser is refreshed while the agent actively on a call
-      // We will use this to clear up the Sync Doc upon browser refresh
-      localStorage.setItem('myWorkerSID', `${myWorkerSID}`);
-    }
-  });
 
   // If the supervisor array has value in it, that means someone is coaching
   // We will map each of the supervisors that may be actively coaching

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/CallCanvas.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/components/CallCanvas.tsx
@@ -12,6 +12,7 @@ export const componentHook = function addSupervisorCoachingPanelToAgent(flex: ty
   // Adding Coaching Status Panel to notify the agent who is Coaching them
   flex.CallCanvas.Content.add(<CoachingStatusPanel key="coaching-status-panel"> </CoachingStatusPanel>, {
     sortOrder: -1,
+    if: (props) => props.task?.status === 'accepted',
   });
 
   if (!isAgentAssistanceEnabled()) return;
@@ -21,5 +22,6 @@ export const componentHook = function addSupervisorCoachingPanelToAgent(flex: ty
   // Add the Agent Assistance Button to the CallCanvas
   flex.CallCanvas.Content.add(<AgentAssistanceButton key="agent-assistance-button"> </AgentAssistanceButton>, {
     sortOrder: 0,
+    if: (props) => props.task?.status === 'accepted',
   });
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/events/pluginsInitialized.ts
@@ -1,0 +1,50 @@
+import * as Flex from '@twilio/flex-ui';
+
+import { FlexEvent } from '../../../../types/feature-loader';
+import { Actions, SupervisorBargeCoachState } from '../states/SupervisorBargeCoach';
+import { reduxNamespace } from '../../../../utils/state';
+import { SyncDoc } from '../../utils/sync/Sync';
+import { AppState } from '../../../../types/manager';
+
+export const eventName = FlexEvent.pluginsInitialized;
+export const eventHook = function initCoachingSyncDoc(flex: typeof Flex, manager: Flex.Manager) {
+  if (!manager.workerClient) {
+    // Need the worker SID in order to subscribe
+    return;
+  }
+  // Let's subscribe to the sync doc as an agent/worker and check
+  // if we are being coached, so that we can render that in the UI
+  const mySyncDoc = `syncDoc.${manager.workerClient.workerSid}`;
+  SyncDoc.getSyncDoc(mySyncDoc).then((doc: any) => {
+    // We are subscribing to Sync Doc updates here and logging anytime that happens
+    doc.on('updated', (doc: any) => {
+      const { supervisorArray } = (manager.store.getState() as AppState)[reduxNamespace]
+        .supervisorBargeCoach as SupervisorBargeCoachState;
+      let newSupervisorArray: any[] = [];
+      if (doc.data.supervisors) {
+        // Current version of this feature will only show the Agent they are being coached
+        // This could be updated by removing the below logic and including Monitoring and Barge
+        newSupervisorArray = doc.data.supervisors.filter(
+          (supervisor: any) => supervisor.status !== 'barge' && supervisor.status !== 'monitoring',
+        );
+      }
+
+      // Set Supervisor's name that is coaching into props
+      if (newSupervisorArray.length !== 0 || supervisorArray.length !== 0) {
+        manager.store.dispatch(
+          Actions.setBargeCoachStatus({
+            supervisorArray: newSupervisorArray,
+          }),
+        );
+      }
+    });
+  });
+  manager.store.dispatch(
+    Actions.setBargeCoachStatus({
+      syncSubscribed: true,
+    }),
+  );
+  // Caching this if the browser is refreshed while the agent actively on a call
+  // We will use this to clear up the Sync Doc upon browser refresh
+  localStorage.setItem('myWorkerSID', `${manager.workerClient.workerSid}`);
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/jsclient-event-listeners/worker-client/reservationCreated.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/jsclient-event-listeners/worker-client/reservationCreated.ts
@@ -26,8 +26,6 @@ export const jsClientHook = async function cleanStateAndSyncUponAgentHangUp(
         enableBargeinButton: false,
         muted: true,
         agentAssistanceButton: false,
-        syncSubscribed: false,
-        agentAssistanceSyncSubscribed: false,
       }),
     );
     const agentWorkerSID = manager.store.getState().flex?.worker?.worker?.sid || '';

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/sync/Sync.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/utils/sync/Sync.ts
@@ -47,8 +47,8 @@ class SyncDocClass {
           );
           if (removeAgentAssistanceIndex > -1) {
             agentAssistanceArray.splice(removeAgentAssistanceIndex, 1);
+            this.updateSyncDoc(docToUpdate, agentAssistanceArray);
           }
-          this.updateSyncDoc(docToUpdate, agentAssistanceArray);
         }
       })
       .catch((error: any) => {


### PR DESCRIPTION
### Summary

Made changes to reduce Redux and Sync updates:
- Moved sync doc subscription from coaching status panel component to pluginsInitialized hook so that it doesn’t resubscribe for every task
- Skip updating Redux state on doc update if supervisor array is empty before and after the update
- Unmount coaching status panel and assistance button when wrapping
- Stop setting the subscription flags to false at wrapup, as it isnt unsubscribing
- Update assistance doc only if a change was made

@aestellwag could you please help validate that I'm not doing anything here that has failed in the past?

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
