### PR TITLE
Remove conversation-transfer 2.8.x warning

### DIFF
--- a/docs/docs/feature-library/conversation-transfer.md
+++ b/docs/docs/feature-library/conversation-transfer.md
@@ -18,7 +18,7 @@ The two different features can be enabled/disabled independently. In the case of
 
 ### Multi participant chat
 
-![multiple partcipants](/img/features/conversation-transfer/multi-participant.gif)
+![multiple participants](/img/features/conversation-transfer/multi-participant.gif)
 
 ## Setup
 

--- a/docs/docs/feature-library/conversation-transfer.md
+++ b/docs/docs/feature-library/conversation-transfer.md
@@ -3,10 +3,6 @@ sidebar_label: conversation-transfer
 title: conversation-transfer
 ---
 
-:::danger Flex UI 2.8.x Issue
-There is currently an issue in Flex UI 2.8.x that prevents this feature from working, unless the [custom-transfer-directory feature](custom-transfer-directory) is also enabled. With both features enabled, transfers work properly in Flex UI 2.8.x.
-:::
-
 This feature implements transferring of chats between agents and multiple agents in the same chat. It supports webchat, SMS and whatsapp that use [Flex Conversations](https://www.twilio.com/docs/flex/conversations).
 
 **Config options allows for two different options:**


### PR DESCRIPTION
### Summary

Now that 2.8.2 is released, the warning is obsolete and can be removed.

### Checklist

- [x] Updated documentation
- [x] Requested one or more reviewers
