### PR TITLE
Avoid unnecessary conference state updates

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ParticipantActionsButtons/ParticipantActionsButtons.tsx
@@ -49,44 +49,23 @@ const ParticipantActionsButtons = (props: OwnProps) => {
   const [isKickConfirmationVisible, setIsKickConfirmationVisible] = useState(false);
 
   useEffect(() => {
-    return () => {
-      const { participant } = props;
-      if (participant && participant.status === 'recently_left') {
-        let newViewState: { [index: string]: any } = {};
-
-        if (componentViewState) {
-          newViewState = {
-            ...componentViewState,
-          };
-        }
-
-        if (participant.callSid && newViewState[participant.callSid]) {
-          delete newViewState[participant.callSid];
-        }
-
-        Actions.invokeAction('SetComponentState', {
-          name: 'customParticipants',
-          state: newViewState,
-        });
-      }
-    };
-  }, []);
-
-  useEffect(() => {
     const { participant } = props;
-    if (!participant || !participant.callSid) return;
+    if (!participant?.callSid) return;
 
-    let newViewState: { [index: string]: any } = {};
+    const newViewState: { [index: string]: any } = {};
 
-    if (componentViewState) {
-      newViewState = {
-        ...componentViewState,
+    if (
+      isKickConfirmationVisible ||
+      (componentViewState &&
+        componentViewState[participant.callSid] &&
+        componentViewState[participant.callSid].showKickConfirmation !== isKickConfirmationVisible)
+    ) {
+      newViewState[participant.callSid] = {
+        showKickConfirmation: isKickConfirmationVisible,
       };
+    } else {
+      return;
     }
-
-    newViewState[participant.callSid] = {
-      showKickConfirmation: isKickConfirmationVisible,
-    };
 
     Actions.invokeAction('SetComponentState', {
       name: 'customParticipants',


### PR DESCRIPTION
### Summary

The ParticipantActionsButtons component was creating state for every conference participant unnecessarily. Because SetComponentState merges updates, the state would grow quite large. Changed this to only set state when needed (when the kick buttons are clicked).

Removed code that tried to clean up the state, which doesn't work due to SetComponentState's merge logic.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
