### PR TITLE
Update sip-support for Flex UI 2.7+

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/sip-support/flex-hooks/actions/StopMonitoringCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/sip-support/flex-hooks/actions/StopMonitoringCall.ts
@@ -9,11 +9,11 @@ import logger from '../../../../utils/logger';
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.StopMonitoringCall;
 export const actionHook = function handleSipStopMonitoring(flex: typeof Flex, manager: Flex.Manager) {
-  if (isWorkerUsingWebRTC()) {
-    return;
-  }
-
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+    if (isWorkerUsingWebRTC()) {
+      logger.info('[sip-support] Worker is using WebRTC, skipping StopMonitoringCall hook');
+      return;
+    }
     if (!payload.task) {
       logger.error('[sip-support] No task found');
       return;


### PR DESCRIPTION
### Summary

Flex UI 2.7 and 2.8 call WrapupTask instead of HangupCall when the end call button is clicked and the embedded voice client is not used. See TECHFLEX-181

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
