### PR TITLE
[SE-50] Deprecate external directory config option

### DIFF
--- a/docs/docs/feature-library/custom-transfer-directory.md
+++ b/docs/docs/feature-library/custom-transfer-directory.md
@@ -17,9 +17,7 @@ This feature enables the replacement of the queue and worker transfer directorie
 
 It also enables the addition of an external directory, enabling the following behavior
 
-- present a list of external transfer numbers
-  - includes contacts from the `contacts` feature if enabled
-  - each transfer number can independently be configured for warm or cold transfers
+- present a list of external transfer numbers from the `contacts` feature if enabled
   - validation checks performed on transfer numbers with notifications of any validation failures
 
 ## flex-user-experience
@@ -46,25 +44,21 @@ Enable the feature in the flex-config asset for your environment.
   "queue" : {
     "enabled": true, // enable the custom queue tab
     "show_only_queues_with_available_workers": true,
-    "show_real_time_data" : true, // tool tup for queues will show real time data instead of queue name
+    "show_real_time_data" : true, // tool tip for queues will show real time data instead of queue name
     "enforce_queue_filter_from_worker_object": true, // when true, if `worker.attributes.enforcedQueueFilter` is present, it will be enforced, otherwise ignored
     "enforce_global_exclude_filter": false, // when true global_exclude_filter will be applied to exclude any queues matching the filter
     "global_exclude_filter": "SYSTEM" // EXAMPLE to exclude queues containing the word SYSTEM
   },
   "external_directory": {
     "enabled": true, // enable the external directory tab for voice calls
-    "skipPhoneNumberValidation": false, // skip phone number validation
-    "directory": [{  // Array of directory entry
-      "cold_transfer_enabled": true,  // whether cold transfer button shows for entry
-      "warm_transfer_enabled": true,  // whether warm transfer button shows for entry (see further dependencies)
-      "label": "Sample Entry", // label displayed on screen
-      "number": "+10000000000" // number used for entry
-    }]
+    "skipPhoneNumberValidation": false // skip phone number validation
   }
 }
 ```
 
-NOTE: warm transfer for external directory entries only takes effect if either this plugins 'conference' feature is also enabled OR Flex's native warm transfer feature is enabled (currently in beta). If neither of these are enabled then a notification will be posted at login informing the user that warm transfers will not be available.
+NOTE: warm transfer for external directory entries is only available if either the 'conference' feature is also enabled OR Flex's native warm transfer feature is enabled (currently in beta). If neither of these are enabled, a notification will be posted at login informing the user that warm transfers will not be available.
+
+Example worker attribute setting for when the `enforce_queue_filter_from_worker_object` setting is enabled:
 
 ```javascript
 worker.attributes : {

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -219,15 +219,7 @@
         },
         "external_directory": {
           "enabled": true,
-          "skipPhoneNumberValidation": false,
-          "directory": [
-            {
-              "cold_transfer_enabled": true,
-              "warm_transfer_enabled": true,
-              "label": "Sample Entry",
-              "number": "+10000000000"
-            }
-          ]
+          "skipPhoneNumberValidation": false
         }
       },
       "dispositions": {

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/events/pluginsInitialized.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/events/pluginsInitialized.ts
@@ -1,15 +1,20 @@
 import { Notifications } from '@twilio/flex-ui';
 
-import { isExternalDirectoryEnabled, isFeatureEnabled, isVoiceXWTEnabled } from '../../config';
+import { isExternalDirectoryEnabled, isVoiceXWTEnabled, getExternalDirectory } from '../../config';
 import { FlexEvent } from '../../../../types/feature-loader';
 import { registerStartExternalColdTransfer } from '../custom-actions/startExternalColdTransfer';
 import { CustomTransferDirectoryNotification } from '../notifications/CustomTransferDirectory';
 
 export const eventName = FlexEvent.pluginsInitialized;
 export const eventHook = () => {
-  if (isFeatureEnabled()) {
-    registerStartExternalColdTransfer();
-    if (isExternalDirectoryEnabled() && !isVoiceXWTEnabled())
-      Notifications.showNotification(CustomTransferDirectoryNotification.XWTFeatureDependencyMissing);
+  registerStartExternalColdTransfer();
+  if (isExternalDirectoryEnabled() && !isVoiceXWTEnabled()) {
+    Notifications.showNotification(CustomTransferDirectoryNotification.XWTFeatureDependencyMissing);
+  }
+
+  if (getExternalDirectory().length > 0) {
+    console.warn(
+      'custom-transfer-directory: external_directory.directory is deprecated. It is recommended to use the contacts feature to populate the external directory instead.',
+    );
   }
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/types/ServiceConfiguration.ts
@@ -17,6 +17,6 @@ export default interface CustomTransferDirectoryConfig {
   external_directory: {
     enabled: boolean;
     skipPhoneNumberValidation: boolean;
-    directory: Array<ExternalDirectoryEntry>;
+    directory?: Array<ExternalDirectoryEntry>;
   };
 }


### PR DESCRIPTION
### Summary

Given that the contacts feature is the scalable way to save contacts, and that the custom-transfer-directory integrates with the contacts feature, this deprecates the flex-config-based external directory entry support in custom-transfer-directory.

The functionality is still there in case a customer using it updates their copy of the template. A warning log has been added in that case.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
