### PR TITLE
Better handle another worker participant joining

### DIFF
--- a/docs/docs/feature-library/dual-channel-recording.md
+++ b/docs/docs/feature-library/dual-channel-recording.md
@@ -30,6 +30,7 @@ There are various ways to enable call recordings with Twilio Flex. Let's outline
    - Cons:
      - Custom code is required, both on the front end and the backend (facilitated by this feature)
      - If it's desired to record the IVR messaging, that will not be included
+     - If the worker uses the "Join Call" button in Flex UI when multiple instances are open, and the worker call leg is the one being recorded, the recording will not restart when the new instance's call leg starts.
 
 ## setup and dependencies
 

--- a/docs/docs/feature-library/dual-channel-recording.md
+++ b/docs/docs/feature-library/dual-channel-recording.md
@@ -3,6 +3,12 @@ sidebar_label: dual-channel-recording
 title: dual-channel-recording
 ---
 
+:::info Native feature available
+Native dual-channel recording is now available and can be enabled via the Twilio Console. The first agent to join the call will be on the left channel, and the other participants on the right channel. See [the changelog entry](https://www.twilio.com/en-us/changelog/dual-channel-voice-conference-recordings) for more details, including restrictions and instructions to enable.
+
+This template feature will remain available for use cases that are not supported by the native feature.
+:::
+
 There are various ways to enable call recordings with Twilio Flex. Let's outline those methods to better understand when using this custom solution would be preferable.
 
 1. The simplest approach is to turn on "Call Recording" in [Flex Settings](https://www.twilio.com/console/flex/settings) on the Twilio Console. Enabling this setting records the conference and automatically updates the task attribute `conversations.segment_link` with the recording URL so it can be played back in Flex Insights.

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConferenceMonitor/ConferenceMonitor.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConferenceMonitor/ConferenceMonitor.tsx
@@ -30,9 +30,7 @@ class ConferenceMonitor extends React.Component {
 
     const { liveParticipantCount, liveWorkerCount, participants = [] } = conference;
     const liveParticipants = participants.filter((p: ConferenceParticipant) => p.status === 'joined');
-    const myActiveParticipant = liveParticipants.find(
-      (p: ConferenceParticipant) => p.isCurrentWorker && p.status === 'joined',
-    );
+    const myActiveParticipant = liveParticipants.find((p: ConferenceParticipant) => p.isCurrentWorker);
 
     if (
       liveParticipantCount > 2 &&

--- a/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConferenceMonitor/ConferenceMonitor.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conference/custom-components/ConferenceMonitor/ConferenceMonitor.tsx
@@ -30,7 +30,9 @@ class ConferenceMonitor extends React.Component {
 
     const { liveParticipantCount, liveWorkerCount, participants = [] } = conference;
     const liveParticipants = participants.filter((p: ConferenceParticipant) => p.status === 'joined');
-    const myActiveParticipant = liveParticipants.find((p: ConferenceParticipant) => p.isCurrentWorker);
+    const myActiveParticipant = liveParticipants.find(
+      (p: ConferenceParticipant) => p.isCurrentWorker && p.status === 'joined',
+    );
 
     if (
       liveParticipantCount > 2 &&

--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -60,7 +60,7 @@ export const getMyCallSid = (task: ITask): string | null => {
   if (task && task.conference && task.conference.participants) {
     task.conference.participants.forEach((p: ConferenceParticipant) => {
       // Find our worker in the list of participants to get the call SID.
-      if (p.isCurrentWorker && p.callSid) {
+      if (p.isCurrentWorker && p.status === 'joined' && p.callSid) {
         callSid = p.callSid;
       }
     });

--- a/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/pause-recording/helpers/pauseRecordingHelper.ts
@@ -25,7 +25,9 @@ const getDualChannelCallSid = (task: ITask): string | null => {
       break;
     }
     case 'worker': {
-      participantLeg = participants.find((p) => p.participantType === 'worker' && p.isCurrentWorker);
+      participantLeg = participants.find(
+        (p) => p.participantType === 'worker' && p.isCurrentWorker && p.status === 'joined',
+      );
       break;
     }
     default:

--- a/plugin-flex-ts-template-v2/src/feature-library/sip-support/custom-components/CustomMuteButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/sip-support/custom-components/CustomMuteButton.tsx
@@ -16,7 +16,9 @@ const CustomMuteButton = (props: OwnProps) => {
 
   useEffect(() => {
     if (!props.task?.conference) return;
-    const workerParticipant = props.task.conference.participants.find((p) => p.isCurrentWorker);
+    const workerParticipant = props.task.conference.participants.find(
+      (p) => p.isCurrentWorker && p.status === 'joined',
+    );
 
     if (workerParticipant) {
       setMuted(workerParticipant.muted);

--- a/plugin-flex-ts-template-v2/src/feature-library/sip-support/helpers/CallControlHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/sip-support/helpers/CallControlHelper.ts
@@ -12,7 +12,7 @@ export const isWorkerUsingWebRTC = (): boolean => {
 // or from task attributes (for example if the UI was reloaded and note in state)
 export const getLocalParticipantForTask = (task: ITask) => {
   return (
-    task.conference?.participants.find((p) => p.isCurrentWorker)?.callSid ||
+    task.conference?.participants.find((p) => p.isCurrentWorker && p.status === 'joined')?.callSid ||
     task.attributes?.conference?.participants?.worker ||
     task.attributes?.worker_call_sid
   );


### PR DESCRIPTION
### Summary

In Flex UI 2.7 and later, the current worker can have multiple conference participants representing themself when using the "Join Call" button. Therefore, any time we are checking for the current worker participant, we need to also check that they are joined.

Note that the dual-channel-recording feature does not currently handle this when recording the worker call leg and the worker uses the "Join Call" button. There is simply no recording after that point, since the recording is only initiated upon task acceptance. This limitation has been documented, in addition to a notice recommending the new native dual-channel conference recording capability.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
