### PR TITLE
Fix outbound cold transfer when using dual-channel-recording

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
@@ -52,7 +52,7 @@ export const registerStartExternalColdTransfer = async () => {
 
       try {
         await ProgrammableVoiceService.startColdTransfer(
-          task?.attributes?.call_sid ?? task.attributes.conference.participants.customer,
+          task?.attributes?.conference?.participants?.customer ?? task?.attributes?.call_sid,
           phoneNumber,
           callerId,
         );


### PR DESCRIPTION
### Summary

The custom-transfer-directory feature's cold transfer functionality needs a call SID to initiate the transfer for. Previously this used the call_sid attribute, as this should always be the customer call SID, however due to an issue in the dual-channel-recording feature, this is not currently the case when recording the worker leg and placing an outbound call.

We will fix dual-channel-recording separately, but this is a quick fix to use the known-good SID first.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
