### PR TITLE
Update metrics-data-tiles to use updated APIs

### DIFF
--- a/docs/docs/feature-library/metrics-data-tiles.md
+++ b/docs/docs/feature-library/metrics-data-tiles.md
@@ -6,11 +6,12 @@ title: metrics-data-tiles
 ## Overview
 The Flex Real Time Queues view provides a few standard Data Tiles that aggregate the queue data at the contact center level:
 
+* Agents: Bar chart with the number of available, unavailable, and offline agents.
 * Active Tasks: The number of tasks that are currently being handled.
 * Waiting Tasks: The number of tasks that are waiting to be handled.
 * Longest Wait: The amount of time in seconds for the longest waiting task.
 
-These three Data Tiles are contained within the AggregatedDataTiles component at the top of the Queues View page. This rectangular box also contains the Bar Chart with the breakdown of the agents by status (Unavailable, Available, Offline)
+These Data Tiles are contained within the AggregatedDataTiles component at the top of the Queues View page.
 
 As you can see from [this example in our Flex documentation](https://www.twilio.com/docs/flex/developer/ui/queues-view-programmability#add-or-remove-individual-data-tiles), you can add custom DataTiles to display custom metrics and KPIs. 
 
@@ -58,9 +59,10 @@ This feature uses the list of Team names as configured in the common configurati
 
 This feature can be enabled via the `flex-config` attributes. Just set the `metrics_data_tiles` `enabled` flag to `true` and set up the desired configuration.
 
-* To enable specific data tiles on the Real-time Queues View set `_data_tile = true`
-* You can change the Channel colors are needed. 
-* The Enhanced Agent Activity tile replaces the native Bar Chart so if you enable it you can disable the Bar Chart.
+* To enable specific data tiles on the Real-time Queues View set the appropriate tile to `true`
+* You can change the Channel colors are needed.
+* The Enhanced Agent Activity tile replaces the native Bar Chart so if you enable it you can disable the Bar Chart by setting `"agents_by_activity_bar_chart": false`
+* The native All Channels tile may be redundant with the other tiles enabled, so you may disable this if you'd like by setting `"all_channels_data_tile": false`
 * Configure activities to match the names of the Activities as defined in TaskRouter. The Flex UI includes a [set of icons](https://www.twilio.com/docs/flex/developer/ui/v1/icons#default-icons)
  that are used to enhance the display of the individual activities.
 
@@ -73,11 +75,9 @@ Note: The Teams View can only display up to 200 agents, so the worker data avail
      "metrics_data_tiles": {
         "enabled": false,
         "queues_view_tiles": {
-          "active_tasks_data_tile": false,
-          "waiting_tasks_data_tile": false,
-          "longest_wait_time_data_tile": false,
+          "all_channels_data_tile": true,
+          "all_channels_sla_data_tile": false,
           "agents_by_activity_bar_chart": true,
-          "all_channels_data_tile": false,
           "enhanced_agent_by_activity_pie_chart": false
         },
         "teams_view_tiles": {

--- a/docs/docs/feature-library/metrics-data-tiles.md
+++ b/docs/docs/feature-library/metrics-data-tiles.md
@@ -60,7 +60,7 @@ This feature uses the list of Team names as configured in the common configurati
 This feature can be enabled via the `flex-config` attributes. Just set the `metrics_data_tiles` `enabled` flag to `true` and set up the desired configuration.
 
 * To enable specific data tiles on the Real-time Queues View set the appropriate tile to `true`
-* You can change the Channel colors are needed.
+* You can change the Channel colors as needed.
 * The Enhanced Agent Activity tile replaces the native Bar Chart so if you enable it you can disable the Bar Chart by setting `"agents_by_activity_bar_chart": false`
 * The native All Channels tile may be redundant with the other tiles enabled, so you may disable this if you'd like by setting `"all_channels_data_tile": false`
 * Configure activities to match the names of the Activities as defined in TaskRouter. The Flex UI includes a [set of icons](https://www.twilio.com/docs/flex/developer/ui/v1/icons#default-icons)

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -293,11 +293,9 @@
       "metrics_data_tiles": {
         "enabled": false,
         "queues_view_tiles": {
-          "active_tasks_data_tile": false,
-          "waiting_tasks_data_tile": false,
-          "longest_wait_time_data_tile": false,
+          "all_channels_data_tile": true,
+          "all_channels_sla_data_tile": false,
           "agents_by_activity_bar_chart": true,
-          "all_channels_data_tile": false,
           "enhanced_agent_by_activity_pie_chart": false
         },
         "teams_view_tiles": {

--- a/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/config.ts
@@ -4,12 +4,10 @@ import DataTilesConfig from './types/ServiceConfiguration';
 const {
   enabled = false,
   queues_view_tiles = {
-    active_tasks_data_tile: false,
-    waiting_tasks_data_tile: false,
-    longest_wait_time_data_tile: false,
-    agents_by_activity_bar_chart: false,
-    all_channels_data_tile: false,
-    enhanced_agent_by_activity_pie_chart: true,
+    all_channels_data_tile: true,
+    all_channels_sla_data_tile: false,
+    agents_by_activity_bar_chart: true,
+    enhanced_agent_by_activity_pie_chart: false,
   },
   teams_view_tiles = {
     task_summary_tile: false,
@@ -63,14 +61,8 @@ export const isFeatureEnabled = () => {
   return enabled;
 };
 
-export const isActiveTasksEnabled = () => {
-  return queues_view_tiles.active_tasks_data_tile;
-};
-export const isWaitingTasksEnabled = () => {
-  return queues_view_tiles.waiting_tasks_data_tile;
-};
-export const isLongestWaitTimeEnabled = () => {
-  return queues_view_tiles.longest_wait_time_data_tile;
+export const isAllChannelsEnabled = () => {
+  return queues_view_tiles.all_channels_data_tile;
 };
 export const isAgentsByActivityEnabled = () => {
   return queues_view_tiles.agents_by_activity_bar_chart;
@@ -113,7 +105,7 @@ export const getTaskSummaryChannels = () => {
 };
 
 export const isAllChannels_SLAEnabled = () => {
-  return queues_view_tiles.all_channels_data_tile;
+  return queues_view_tiles.all_channels_sla_data_tile;
 };
 export const isEnhancedAgentsByActivityPieChartEnabled = () => {
   return queues_view_tiles.enhanced_agent_by_activity_pie_chart;

--- a/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/flex-hooks/components/QueuesViewDataTiles.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/flex-hooks/components/QueuesViewDataTiles.tsx
@@ -7,9 +7,7 @@ import ChannelSLATile from '../../custom-components/ChannelSLATile/ChannelSLATil
 import AllChannelsSLATile from '../../custom-components/AllChannelsSLATile/AllChannelsSLATile';
 import AgentActivityTile from '../../custom-components/AgentActivityTile/AgentActivityTile';
 import {
-  isActiveTasksEnabled,
-  isWaitingTasksEnabled,
-  isLongestWaitTimeEnabled,
+  isAllChannelsEnabled,
   isAgentsByActivityEnabled,
   getChannelsConfig,
   getChannelColors,
@@ -60,16 +58,15 @@ export const componentHook = function addDataTiles(flex: typeof Flex) {
     );
   }
 
-  if (!isActiveTasksEnabled()) {
-    flex.QueuesStats.AggregatedQueuesDataTiles.Content.remove('active-tasks-tile');
-  }
-  if (!isWaitingTasksEnabled()) {
-    flex.QueuesStats.AggregatedQueuesDataTiles.Content.remove('waiting-tasks-tile');
-  }
-  if (!isLongestWaitTimeEnabled()) {
-    flex.QueuesStats.AggregatedQueuesDataTiles.Content.remove('longest-wait-time-tile');
-  }
-  if (!isAgentsByActivityEnabled()) {
-    flex.QueuesStats.AggregatedQueuesDataTiles.Content.remove('agents-by-activity-chart-tile');
+  if (!isAllChannelsEnabled() || !isAgentsByActivityEnabled()) {
+    flex.QueuesStats.AggregatedQueuesDataTiles.defaultProps.dataTileFilter = (id) => {
+      if (id === 'agents-by-activity-chart-tile' && !isAgentsByActivityEnabled()) {
+        return false;
+      }
+      if (id === 'all' && !isAllChannelsEnabled()) {
+        return false;
+      }
+      return true;
+    };
   }
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/metrics-data-tiles/types/ServiceConfiguration.ts
@@ -1,11 +1,9 @@
 export default interface DataTilesConfig {
   enabled: boolean;
   queues_view_tiles: {
-    active_tasks_data_tile: boolean;
-    waiting_tasks_data_tile: boolean;
-    longest_wait_time_data_tile: boolean;
-    agents_by_activity_bar_chart: boolean;
     all_channels_data_tile: boolean;
+    all_channels_sla_data_tile: boolean;
+    agents_by_activity_bar_chart: boolean;
     enhanced_agent_by_activity_pie_chart: boolean;
   };
   teams_view_tiles: {

--- a/scripts/validate-environment.mjs
+++ b/scripts/validate-environment.mjs
@@ -10,7 +10,7 @@ const REQUIRED_ENV_VARS = ["ENVIRONMENT", "TWILIO_API_KEY", "TWILIO_API_SECRET",
 
 // As documented, we support currently-maintained versions of Flex UI 2.x only
 // This value should be incremented over time as we drop support for older versions
-const VALID_UI_VERSIONS = '>=2.4.0';
+const VALID_UI_VERSIONS = '>=2.5.0';
 
 const validateEnvVarsPresent = () => {
   let valid = true;
@@ -77,7 +77,7 @@ const validateAccountSid = (flexConfig) => {
 }
 
 const validateUiVersion = (flexConfig) => {
-  if (semver.intersects(flexConfig.ui_version.replace('.n', '.*'), VALID_UI_VERSIONS)) {
+  if (semver.intersects(flexConfig.ui_version.replace('.n', '.*').replace('.auto', '.*'), VALID_UI_VERSIONS)) {
     console.log(`✅ Flex UI version ${flexConfig.ui_version} is supported`);
     return;
   }


### PR DESCRIPTION
### Summary

This fixes the behavior on Flex UI 2.5 and newer. The oldest supported release is 2.6.3 so we do not need to be concerned about supporting both new and old APIs. I have bumped the minimum deployment version as a safeguard.

Because the default tiles have changed, I have slightly modified the config schema to better represent the default tiles and the custom tiles.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
