### PR TITLE
Update ui_attributes.common.json

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -422,7 +422,7 @@
       "conditional_recording": {
         "enabled": false,
         "exclude_attributes": [],
-        "exclude_queues": [],
+        "exclude_queues": []
       }
     }
   }


### PR DESCRIPTION
This was giving an JSON.parse error because of this extra comma.

### Summary

This fixes the json format of the ui_attributes.common.json file

### Checklist

- [x ] Tested changes end to end
- [ ] Updated documentation
- [ ] Requested one or more reviewers
