### PR TITLE
Fix null handling in supervisor alerts

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/supervisorAlertHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/supervisorAlertHelper.ts
@@ -20,7 +20,7 @@ export const alertSupervisorsCheck = () => {
   // If enabled, show notifications for each agent requesting assistance
   // As a customization, this could be further filtered by team etc.
   if (enableAgentAssistanceAlerts) {
-    const agents = agentAssistanceArray?.filter((agent: any) => agent.agentFN !== '');
+    const agents = agentAssistanceArray?.filter((agent: any) => agent.agentFN !== '') ?? [];
     for (const agent of agents) {
       Flex.Notifications.showNotification(NotificationIds.AGENT_ASSISTANCE, agent);
     }


### PR DESCRIPTION
### Summary

The default state on a fresh account was breaking here.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
