### PR TITLE
Pin emoji-mart@5.5.2

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -8,11 +8,11 @@
       "name": "plugin-flex-ts-template-v2",
       "version": "0.0.0",
       "dependencies": {
-        "@emoji-mart/react": "^1.1.1",
+        "@emoji-mart/react": "1.1.1",
         "@twilio-paste/core": "^17.0.1",
         "@twilio-paste/icons": "^9.4.2",
         "@twilio/flex-plugin-scripts": "7.0.5",
-        "emoji-mart": "^5.5.2",
+        "emoji-mart": "5.5.2",
         "lodash": "^4.17.20",
         "luxon": "^3.1.1",
         "prop-types": "^15.7.2",

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -19,11 +19,11 @@
     "twilio": "twilio"
   },
   "dependencies": {
-    "@emoji-mart/react": "^1.1.1",
+    "@emoji-mart/react": "1.1.1",
     "@twilio-paste/core": "^17.0.1",
     "@twilio-paste/icons": "^9.4.2",
     "@twilio/flex-plugin-scripts": "7.0.5",
-    "emoji-mart": "^5.5.2",
+    "emoji-mart": "5.5.2",
     "lodash": "^4.17.20",
     "luxon": "^3.1.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
### Summary

emoji-mart 5.6.0 cannot be built by the current Flex plugin toolchain, so let's pin to the last working version for now.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
