### PR TITLE
Fix multi-call auto-holding for other channels

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/flex-hooks/actions/AcceptTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/flex-hooks/actions/AcceptTask.ts
@@ -6,7 +6,19 @@ import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
 export const actionEvent = FlexActionEvent.before;
 export const actionName = FlexAction.AcceptTask;
 export const actionHook = function holdOtherCallsOnAcceptTask(flex: typeof Flex) {
-  flex.Actions.addListener(`${actionEvent}${actionName}`, async () => {
-    holdOtherCalls();
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+    let task = null;
+
+    if (payload.task) {
+      task = payload.task;
+    } else if (payload.sid) {
+      task = Flex.TaskHelper.getTaskByTaskSid(payload.sid);
+    } else {
+      return;
+    }
+
+    if (task && Flex.TaskHelper.isCallTask(task)) {
+      holdOtherCalls();
+    }
   });
 };


### PR DESCRIPTION
### Summary

For multi-channel agents with the multi-call feature enabled, previously accepting a non-voice task would auto-hold any active calls. This PR fixes that behavior so the call remains unheld when accepting a non-voice task.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
