### PR TITLE
Fix flex-config deploy error code

### DIFF
--- a/flex-config/index.mjs
+++ b/flex-config/index.mjs
@@ -141,8 +141,7 @@ async function deployConfigurationData({ auth, environment, overwrite }) {
     })
   } catch (error) {
     console.error("Error caught:", error);
-    console.log("Auth", error.config?.auth);
-    console.log("Data", error.response?.data);
+    process.exitCode = 1;
   }
 }
 

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -422,7 +422,7 @@
       "conditional_recording": {
         "enabled": false,
         "exclude_attributes": [],
-        "exclude_queues": [],
+        "exclude_queues": []
       }
     }
   }

--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -422,7 +422,7 @@
       "conditional_recording": {
         "enabled": false,
         "exclude_attributes": [],
-        "exclude_queues": []
+        "exclude_queues": [],
       }
     }
   }


### PR DESCRIPTION
### Summary

If flex-config deploy failed, we were catching the error and not reporting any obvious failure in the deploy. This change causes the deploy to report a failure and also removes the duplicate logs.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
