### PR TITLE
Fix conversation-transfer issues from Support

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/WrapupTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/WrapupTask.ts
@@ -1,0 +1,31 @@
+import * as Flex from '@twilio/flex-ui';
+
+import { FlexActionEvent, FlexAction } from '../../../../types/feature-loader';
+import { AppState } from '../../../../types/manager';
+import { ConversationTransferState } from '../states';
+import { reduxNamespace } from '../../../../utils/state';
+import { NotificationIds } from '../notifications/TransferResult';
+
+export const actionEvent = FlexActionEvent.before;
+export const actionName = FlexAction.WrapupTask;
+export const actionHook = function preventWrapupForPendingTransfer(flex: typeof Flex, manager: Flex.Manager) {
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload, abortFunction) => {
+    let task = payload.task;
+    if (!task && payload.sid) {
+      task = Flex.TaskHelper.getTaskByTaskSid(payload.sid);
+    }
+    if (!task) {
+      return;
+    }
+
+    const state = manager.store.getState() as AppState;
+    const index = (state[reduxNamespace].conversationTransfer as ConversationTransferState).pendingTransfers.findIndex(
+      (sid) => sid === task.sid,
+    );
+
+    if (index >= 0) {
+      Flex.Notifications.showNotification(NotificationIds.TransferPendingError);
+      abortFunction();
+    }
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/WrapupTask.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/actions/WrapupTask.ts
@@ -18,6 +18,10 @@ export const actionHook = function preventWrapupForPendingTransfer(flex: typeof 
       return;
     }
 
+    if (!Flex.TaskHelper.isCBMTask(payload.task)) {
+      return;
+    }
+
     const state = manager.store.getState() as AppState;
     const index = (state[reduxNamespace].conversationTransfer as ConversationTransferState).pendingTransfers.findIndex(
       (sid) => sid === task.sid,

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/TaskCanvasHeader.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/components/TaskCanvasHeader.tsx
@@ -1,5 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
-import { ITask, TaskHelper, StateHelper } from '@twilio/flex-ui';
+import { ITask, TaskHelper } from '@twilio/flex-ui';
 
 import { isColdTransferEnabled, isMultiParticipantEnabled } from '../../config';
 import TransferButton from '../../custom-components/TransferButton';
@@ -24,15 +24,7 @@ export const componentHook = function addConvTransferButtons(flex: typeof Flex) 
 
   const replaceEndTaskButton = (task: ITask) => {
     if (TaskHelper.isCBMTask(task) && task.taskStatus === 'assigned') {
-      // more than two participants or are there any active invites?
-      const conversationState = StateHelper.getConversationStateForTask(task);
-      if (
-        conversationState &&
-        (conversationState.participants.size > 2 ||
-          ConversationsHelper.countOfOutstandingInvitesForConversation(conversationState))
-      ) {
-        return true;
-      }
+      return ConversationsHelper.allowLeave(task);
     }
     return false;
   };

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/notifications/TransferResult.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/notifications/TransferResult.ts
@@ -14,6 +14,7 @@ export enum NotificationIds {
   ChatCancelParticipantInviteFailed = 'ChatCancelParticipantInviteFailed',
   ChatCancelParticipantInviteSuccess = 'ChatCancelParticipantInviteSuccess',
   ChatCancelParticipantInviteFailedInviteOutstanding = 'ChatCancelParticipantInviteFailedInviteOutstanding',
+  TransferPendingError = 'PSConvTransferPendingError',
 }
 
 export const notificationHook = () => [
@@ -91,6 +92,13 @@ export const notificationHook = () => [
     id: NotificationIds.ChatCancelParticipantInviteFailedInviteOutstanding,
     closeButton: true,
     content: StringTemplates.ChatParticipantInviteOutstanding,
+    timeout: 3000,
+    type: NotificationType.error,
+  },
+  {
+    id: NotificationIds.TransferPendingError,
+    closeButton: true,
+    content: StringTemplates.TransferPendingError,
     timeout: 3000,
     type: NotificationType.error,
   },

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/states/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/states/index.ts
@@ -1,0 +1,24 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface ConversationTransferState {
+  pendingTransfers: Array<string>;
+}
+
+const initialState = { pendingTransfers: [] } as ConversationTransferState;
+
+const conversationTransferSlice = createSlice({
+  name: 'conversationTransfer',
+  initialState,
+  reducers: {
+    addPendingTransfer(state, action: PayloadAction<string>) {
+      state.pendingTransfers.push(action.payload);
+    },
+    removePendingTransfer(state, action: PayloadAction<string>) {
+      state.pendingTransfers = state.pendingTransfers.filter((sid) => sid !== action.payload);
+    },
+  },
+});
+
+export const { addPendingTransfer, removePendingTransfer } = conversationTransferSlice.actions;
+export const reducerHook = () => ({ conversationTransfer: conversationTransferSlice.reducer });

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/ChatTransferStrings.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/ChatTransferStrings.ts
@@ -26,6 +26,7 @@ export enum StringTemplates {
   InvitedParticipants = 'PSConvTransferInvitedParticipants',
   CancelInvite = 'PSConvTransferCancelInvite',
   LeaveChat = 'PSConvTransferLeaveChat',
+  TransferPendingError = 'PSConvTransferPendingError',
 }
 
 export const stringHook = () => ({
@@ -52,6 +53,7 @@ export const stringHook = () => ({
     [StringTemplates.InvitedParticipants]: 'Invited Participants',
     [StringTemplates.CancelInvite]: 'Cancel invite to {{name}}',
     [StringTemplates.LeaveChat]: 'Leave',
+    [StringTemplates.TransferPendingError]: 'Please wait a moment before attempting to leave the chat.',
   },
   'es-MX': esMX,
   'pt-BR': ptBR,

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/ChatTransferStrings.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/ChatTransferStrings.ts
@@ -43,7 +43,7 @@ export const stringHook = () => ({
     [StringTemplates.ChatCancelParticipantInviteSuccess]: 'Participant invite canceled',
     [StringTemplates.ChatParticipantInviteOutstanding]:
       'Inviting participant failed. There is already an outstanding invite for the chat.',
-    [StringTemplates.TransferChat]: 'Transfer Chat',
+    [StringTemplates.TransferChat]: 'Transfer',
     [StringTemplates.Participants]: 'Participants',
     [StringTemplates.Agent]: 'Agent',
     [StringTemplates.Customer]: 'Customer',
@@ -51,7 +51,7 @@ export const stringHook = () => ({
     [StringTemplates.Remove]: 'Remove {{name}}',
     [StringTemplates.InvitedParticipants]: 'Invited Participants',
     [StringTemplates.CancelInvite]: 'Cancel invite to {{name}}',
-    [StringTemplates.LeaveChat]: 'Leave Chat',
+    [StringTemplates.LeaveChat]: 'Leave',
   },
   'es-MX': esMX,
   'pt-BR': ptBR,

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/es-es.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/es-es.json
@@ -10,7 +10,7 @@
   "ChatCancelParticipantInviteFailed": "Fallo en la cancelación de invitación del participante",
   "ChatCancelParticipantInviteSuccess": "Invitación de participante cancelada",
   "ChatParticipantInviteOutstanding": "No se pudo invitar al participante. Ya hay una invitación pendiente para el chat.",
-  "PSConvTransferTransferChat": "Transferir Chat",
+  "PSConvTransferTransferChat": "Transferir",
   "PSConvTransferParticipants": "Participantes",
   "PSConvTransferAgent": "Agente",
   "PSConvTransferCustomer": "Cliente",
@@ -18,5 +18,5 @@
   "PSConvTransferRemove": "Eliminar {{name}}",
   "PSConvTransferInvitedParticipants": "Participantes Invitados",
   "PSConvTransferCancelInvite": "Cancelar invitación a {{name}}",
-  "PSConvTransferLeaveChat": "Salir del Chat"
+  "PSConvTransferLeaveChat": "Salir"
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/es-mx.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/es-mx.json
@@ -10,7 +10,7 @@
   "ChatCancelParticipantInviteFailed": "Fallo al cancelar la invitación del participante",
   "ChatCancelParticipantInviteSuccess": "Invitación de participante cancelada",
   "ChatParticipantInviteOutstanding": "Falló la invitación del participante. Ya hay una invitación pendiente para el chat.",
-  "PSConvTransferTransferChat": "Transferir Chat",
+  "PSConvTransferTransferChat": "Transferir",
   "PSConvTransferParticipants": "Participantes",
   "PSConvTransferAgent": "Agente",
   "PSConvTransferCustomer": "Cliente",
@@ -18,5 +18,5 @@
   "PSConvTransferRemove": "Eliminar {{name}}",
   "PSConvTransferInvitedParticipants": "Participantes Invitados",
   "PSConvTransferCancelInvite": "Cancelar invitación a {{name}}",
-  "PSConvTransferLeaveChat": "Salir del chat"
+  "PSConvTransferLeaveChat": "Salir"
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/pt-br.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/conversation-transfer/flex-hooks/strings/pt-br.json
@@ -10,7 +10,7 @@
   "ChatCancelParticipantInviteFailed": "Erro ao cancelar convite de participante",
   "ChatCancelParticipantInviteSuccess": "Convite do participante cancelado",
   "ChatParticipantInviteOutstanding": "Convite de participante falhou. Já há um convite pendente para o chat.",
-  "PSConvTransferTransferChat": "Transferir Chat",
+  "PSConvTransferTransferChat": "Transferir",
   "PSConvTransferParticipants": "Participantes",
   "PSConvTransferAgent": "Agente",
   "PSConvTransferCustomer": "Cliente",
@@ -18,5 +18,5 @@
   "PSConvTransferRemove": "Remover {{name}}",
   "PSConvTransferInvitedParticipants": "Participantes convidados",
   "PSConvTransferCancelInvite": "Cancelar convite para {{name}}",
-  "PSConvTransferLeaveChat": "Sair do Chat"
+  "PSConvTransferLeaveChat": "Sair"
 }

--- a/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkButton/ParkButton.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/park-interaction/custom-components/ParkButton/ParkButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Actions, IconButton, ITask, styled, templates, StateHelper } from '@twilio/flex-ui';
+import { Actions, IconButton, ITask, styled, templates } from '@twilio/flex-ui';
 
 import { ConversationsHelper } from '../../../../utils/helpers';
 import { StringTemplates } from '../../flex-hooks/strings';
@@ -15,18 +15,7 @@ interface TransferButtonProps {
 const ParkButton = (props: TransferButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
 
-  const allowPark = () => {
-    // more than two participants or are there any active invites?
-    const conversationState = StateHelper.getConversationStateForTask(props.task);
-    if (
-      conversationState &&
-      (conversationState.participants.size > 2 ||
-        ConversationsHelper.countOfOutstandingInvitesForConversation(conversationState))
-    ) {
-      return false;
-    }
-    return true;
-  };
+  const allowPark = !ConversationsHelper.allowLeave(props.task);
 
   const parkInteraction = async () => {
     setIsLoading(true);
@@ -39,11 +28,11 @@ const ParkButton = (props: TransferButtonProps) => {
       <IconButton
         icon="Hold"
         key="park-interaction-button"
-        disabled={isLoading || !allowPark()}
+        disabled={isLoading || !allowPark}
         onClick={parkInteraction}
         variant="secondary"
         title={
-          allowPark()
+          allowPark
             ? templates[StringTemplates.ParkInteraction]()
             : templates[StringTemplates.MultipleParticipantsError]()
         }

--- a/plugin-flex-ts-template-v2/src/utils/helpers/ConversationsHelper.ts
+++ b/plugin-flex-ts-template-v2/src/utils/helpers/ConversationsHelper.ts
@@ -7,6 +7,35 @@ class ConversationsHelper {
     const { invites = undefined } = (conversation?.source?.attributes as any as InvitedParticipants) || {};
     return Object.keys(invites || {}).length;
   };
+
+  allowLeave = (task: Flex.ITask) => {
+    // more than two participants or are there any active invites?
+    const conversationState = Flex.StateHelper.getConversationStateForTask(task);
+    let numBoundParticipants = 0;
+    if (conversationState?.participants) {
+      // Gather the count of participants that have a binding. These participants are not internal.
+      // Therefore, we will use subtraction to consider only one bound participant as part of the total count.
+      conversationState.participants.forEach((participant) => {
+        if (!participant.source?.bindings) {
+          return;
+        }
+        for (const binding of Object.values(participant.source.bindings)) {
+          if (binding) {
+            numBoundParticipants += 1;
+            break;
+          }
+        }
+      });
+    }
+    if (
+      conversationState &&
+      (conversationState.participants.size - (numBoundParticipants > 1 ? numBoundParticipants - 1 : 0) > 2 ||
+        this.countOfOutstandingInvitesForConversation(conversationState))
+    ) {
+      return true;
+    }
+    return false;
+  };
 }
 const ConversationsHelperSingleton = new ConversationsHelper();
 export default ConversationsHelperSingleton;


### PR DESCRIPTION
### Summary

1. Fixed handling of emails. Each email recipient is a conversation participant, so we were erroneously showing the Leave button when the email recipient count pushed the total participant count above two. Fixed this by counting only one participant that has a binding, as we know those participants are external. Also moved this logic to ConversationsHelper so that park-interaction can benefit as well.
2. Fixed a timing hole after the agent chooses to transfer, where they could click the End button while the invite API request is inflight. This would break the task created by the transfer. Fixed this by holding a bit of state while this API request is executed, checked within WrapupTask, which is blocked if the transfer is pending.

Referenced Jiras:
- TECHFLEX-523
- TECHFLEX-582

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
