### PR TITLE
Support out-of-box localization

### DIFF
--- a/docs/docs/feature-library/device-manager.md
+++ b/docs/docs/feature-library/device-manager.md
@@ -6,7 +6,7 @@ title: device-manager
 This feature is intended to demonstrate how to use web APIs to select audio devices and apply them for use within Flex, specifically with the Flex Voice Client.
 
 :::caution Deprecated
-This feature has been replaced by [the native device manager feature](https://www.twilio.com/docs/flex/end-user-guide/initial-audio-device-check#how-do-i-switch-audio-devices-public-beta) in Flex UI 2.6 and later. To use the native feature, navigate to Flex > Admin > Features > General Availability (GA), and enable the toggle for Device Manager. It will then be visible after reloading Flex.
+This feature has been replaced by [the native device manager feature](https://www.twilio.com/docs/flex/end-user-guide/initial-audio-device-check#how-do-i-switch-audio-devices) in Flex UI 2.8 and later. To use the native feature, navigate to Flex > Admin > Features, and enable the toggle for Device Manager. It will then be visible after reloading Flex. The template feature remains available as the native feature resets the input device for each call.
 :::
 
 ---
@@ -33,3 +33,5 @@ To enable the `Device Manager` feature, under the `flex-config` attributes set t
     "input_select": true
 }
 ```
+
+It is recommended to also [disable the `initialDeviceCheck` setting](https://www.twilio.com/docs/flex/end-user-guide/initial-audio-device-check#how-do-i-turn-the-audio-device-check-feature-on--off) to prevent the selected input device from being reset for each call.

--- a/docs/docs/feature-library/device-manager.md
+++ b/docs/docs/feature-library/device-manager.md
@@ -6,7 +6,7 @@ title: device-manager
 This feature is intended to demonstrate how to use web APIs to select audio devices and apply them for use within Flex, specifically with the Flex Voice Client.
 
 :::caution Deprecated
-This feature has been replaced by [the native device manager feature](https://www.twilio.com/docs/flex/end-user-guide/initial-audio-device-check#how-do-i-switch-audio-devices-public-beta) in Flex UI 2.6 and later. To use the native feature, navigate to Flex > Admin > Features > Beta, and enable the toggle for Device Manager. It will then be visible after reloading Flex.
+This feature has been replaced by [the native device manager feature](https://www.twilio.com/docs/flex/end-user-guide/initial-audio-device-check#how-do-i-switch-audio-devices-public-beta) in Flex UI 2.6 and later. To use the native feature, navigate to Flex > Admin > Features > General Availability (GA), and enable the toggle for Device Manager. It will then be visible after reloading Flex.
 :::
 
 ---

--- a/docs/docs/feature-library/localization.md
+++ b/docs/docs/feature-library/localization.md
@@ -4,7 +4,7 @@ title: localization
 ---
 
 :::caution Native feature now available
-A new [native localization feature](https://www.twilio.com/docs/flex/end-user-guide/change-display-language) is available in Flex UI 2.10 and later. To use the native feature, navigate to Flex > Admin > Features > Beta, and enable the toggle for "Enable language selection". It will then be available after reloading Flex. The native feature has limited languages available, so the template feature remains available with support for additional languages.
+A new [native localization feature](https://www.twilio.com/docs/flex/end-user-guide/change-display-language) is available in Flex UI 2.10 and later. To use the native feature, navigate to Flex > Admin > Features > Beta, and enable the toggle for "Enable language selection". It will then be available after reloading Flex. The native feature has limited languages available, so the template feature remains available with support for additional languages, however both features cannot be enabled simultaneously.
 :::
 
 ## Feature summary
@@ -38,8 +38,7 @@ This feature replaces the Flex UI strings by appending new strings of the same n
 1. If the global `language` attribute in `flex-config` is set to `default` (which it is by default), and there is no language set on the worker, then the browser language is used if possible.
 2. If the global `language` attribute in `flex-config` is set to a specific language, and there is no language set on the worker, that language is used if supported.
 3. If a language is set on the worker, it is used regardless of the global or browser settings.
-4. If no language is set on the worker or in `flex-config`, and the user has selected a language using the native feature in Flex UI 2.10 or later, that language is used if supported.
-5. As a default fallback, `en-US` is used.
+4. As a default fallback, `en-US` is used.
 
 Languages are defined in the `languages` directory of the feature. Each language is contained within a JSON file that lists all of the translated system strings for that language. The `index.ts` file contains an array of languages, mapping the JSON translations to a display name and key value. To add a new language, add its corresponding JSON file, then add it to the array in `index.ts`.
 

--- a/docs/docs/feature-library/localization.md
+++ b/docs/docs/feature-library/localization.md
@@ -3,6 +3,10 @@ sidebar_label: localization
 title: localization
 ---
 
+:::caution Native feature now available
+A new [native localization feature](https://www.twilio.com/docs/flex/end-user-guide/change-display-language) is available in Flex UI 2.10 and later. To use the native feature, navigate to Flex > Admin > Features > Beta, and enable the toggle for "Enable language selection". It will then be available after reloading Flex. The native feature has limited languages available, so the template feature remains available with support for additional languages.
+:::
+
 ## Feature summary
 
 This feature provides a language selection dropdown in the Flex UI header, as well as several translations for built-in Flex UI strings. You may also extend this feature to support additional languages as needed.
@@ -34,7 +38,8 @@ This feature replaces the Flex UI strings by appending new strings of the same n
 1. If the global `language` attribute in `flex-config` is set to `default` (which it is by default), and there is no language set on the worker, then the browser language is used if possible.
 2. If the global `language` attribute in `flex-config` is set to a specific language, and there is no language set on the worker, that language is used if supported.
 3. If a language is set on the worker, it is used regardless of the global or browser settings.
-4. As a default fallback, `en-US` is used.
+4. If no language is set on the worker or in `flex-config`, and the user has selected a language using the native feature in Flex UI 2.10 or later, that language is used if supported.
+5. As a default fallback, `en-US` is used.
 
 Languages are defined in the `languages` directory of the feature. Each language is contained within a JSON file that lists all of the translated system strings for that language. The `index.ts` file contains an array of languages, mapping the JSON translations to a display name and key value. To add a new language, add its corresponding JSON file, then add it to the array in `index.ts`.
 

--- a/plugin-flex-ts-template-v2/src/feature-library/localization/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/localization/config.ts
@@ -1,12 +1,18 @@
-import { getFeatureFlags } from '../../utils/configuration';
+import { getFeatureFlags, getFlexFeatureFlag } from '../../utils/configuration';
 import LocalizationConfig from './types/ServiceConfiguration';
 
 const { enabled = false, show_menu = true } = (getFeatureFlags()?.features?.localization as LocalizationConfig) || {};
 
+const nativeLocalizationEnabled = getFlexFeatureFlag('localization-beta');
+
 export const isFeatureEnabled = () => {
-  return enabled;
+  return enabled && !isNativeLocalizationEnabled();
 };
 
 export const isMenuEnabled = () => {
   return show_menu;
+};
+
+export const isNativeLocalizationEnabled = () => {
+  return nativeLocalizationEnabled;
 };

--- a/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
@@ -88,6 +88,10 @@ export const getUserLanguage = () => {
     }
   }
 
+  if (!language && manager.localization?.localeTag) {
+    return manager.localization.localeTag;
+  }
+
   if (!language) {
     return defaultLanguage;
   }

--- a/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
+++ b/plugin-flex-ts-template-v2/src/utils/configuration/index.ts
@@ -73,11 +73,15 @@ export const getFeatureFlags = () => {
 
 /**
  * Returns the currently configured language, using the same order of
- * precedence as `getFeatureFlags`. If the configured value is `default`, the
- * browser's language will be returned. Otherwise, if no value is configured,
- * `en-US` will be returned.
+ * precedence as `getFeatureFlags` if native localization is disabled.
+ * If the configured value is `default`, the browser's language will be
+ * returned. Otherwise, if no value is configured, `en-US` will be returned.
  */
 export const getUserLanguage = () => {
+  if (getFlexFeatureFlag('localization-beta') && manager.localization?.localeTag) {
+    return manager.localization.localeTag;
+  }
+
   let { language } = getFeatureFlags();
 
   if (manager.workerClient) {
@@ -86,10 +90,6 @@ export const getUserLanguage = () => {
     if (workerAttrs.language) {
       language = workerAttrs.language;
     }
-  }
-
-  if (!language && manager.localization?.localeTag) {
-    return manager.localization.localeTag;
   }
 
   if (!language) {


### PR DESCRIPTION
### Summary

- Disable the localization feature if the native feature is enabled on the account
- Adjust `getUserLanguage()` helper to return the language set by the native feature when enabled
- Update docs (also updated the device-manager doc due to some outdated info I noticed, as well as some notes regarding TECHFLEX-462).

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
