### PR TITLE
Fix endless ringing in ring-notification

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/ring-notification/helpers/audioPlayerManagerHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/ring-notification/helpers/audioPlayerManagerHelper.ts
@@ -9,6 +9,10 @@ class AudioPlayerManagerHelper {
     const custom_data = getFeatureFlags() || {};
     let domain = `${custom_data.serverless_functions_protocol ?? 'https'}://${custom_data.serverless_functions_domain}`;
     if (custom_data.serverless_functions_port) domain += `:${custom_data.serverless_functions_port}`;
+    if (this._mediaId) {
+      // AudioPlayerManager supports playing one media at a time, and we already are playing something. If we try to play more, it will get queued and potentially play indefinitely.
+      return;
+    }
     this._mediaId = Flex.AudioPlayerManager.play({
       url: `${domain}/features/ring-notification/phone_ringing.mp3`,
       repeatable: true,
@@ -18,6 +22,7 @@ class AudioPlayerManagerHelper {
   stop = (): void => {
     if (this._mediaId) {
       Flex.AudioPlayerManager.stop(this._mediaId);
+      this._mediaId = undefined;
     }
   };
 }


### PR DESCRIPTION
### Summary

When receiving multiple tasks, and they are both alerting at the same time, we would overwrite the `mediaId` of the first task, so we could not stop it when accepting. We avoid that scenario by returning in the `play` function if we are already playing.

As an initial attempt at the fix, I tried stopping the initial media when the second `play` was invoked, however, I found that in the case multiple reservations come to you at the same time, the `stop` would not actually prevent it playing when it was called before the audio file loaded. This may be an issue with the Flex `AudioPlayerManager`, but I did not look into this much further as the solution I landed upon seems to work well.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
