### PR TITLE
Misc supervisor-barge-coach fixes, test fixes

### DIFF
--- a/plugin-flex-ts-template-v2/__mocks__/@twilio/flex-ui.js
+++ b/plugin-flex-ts-template-v2/__mocks__/@twilio/flex-ui.js
@@ -227,6 +227,7 @@ module.exports = {
       },
     },
   ),
+  useFlexSelector: (callback) => callback(getMockedReduxState()),
   // Component wrappers
   withTaskContext: (WrappedComponent) => {
     return () => ({

--- a/plugin-flex-ts-template-v2/jest.config.js
+++ b/plugin-flex-ts-template-v2/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   coverageReporters: ['json', 'lcov', 'text', 'clover', 'cobertura'],
   globalSetup: '<rootDir>/globalSetupTests.js',
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
+  transformIgnorePatterns: ['/node_modules/(?!@twilio-paste/icons/.*)'],
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/strings/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/internal-call/flex-hooks/strings/index.ts
@@ -6,7 +6,6 @@ import zhHans from './zh-hans.json';
 
 // Export the template names as an enum for better maintainability when accessing them elsewhere
 export enum StringTemplates {
-  InternalDial = 'InternalDial',
   CallAgent = 'PSInternalCallCallAgent',
   SelectAgent = 'PSInternalCallSelectAgent',
   CallQueue = 'PSInternalCallCallQueue',
@@ -15,7 +14,6 @@ export enum StringTemplates {
 
 export const stringHook = () => ({
   'en-US': {
-    [StringTemplates.InternalDial]: 'Internal Dial',
     [StringTemplates.CallAgent]: 'Call Agent',
     [StringTemplates.SelectAgent]: 'Select an agent',
     [StringTemplates.CallQueue]: 'Call Queue',

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
@@ -80,11 +80,20 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
     setIsLoading(true);
 
     switch (mode) {
-      case 'barge':
+      case 'barge': {
         // Barge-in will "unmute" their line if the are muted and disable coaching if enabled
-        await enterBargeMode(conferenceSid, participantSid);
+        const agentParticipant = conference?.participants.find(
+          (p) => p.participantType === 'worker' && monitoringTask?.workerSid === p.workerSid,
+        );
+        const agentSid = agentParticipant?.callSid;
+        if (!agentSid) {
+          setIsLoading(false);
+          return;
+        }
+        await enterBargeMode(conferenceSid, participantSid, agentSid);
         break;
-      case 'coaching':
+      }
+      case 'coaching': {
         // Coaching will "unmute" their line if the are muted and coach the specific agent using their call SID
         const agentParticipant = conference?.participants.find(
           (p) => p.participantType === 'worker' && monitoringTask?.workerSid === p.workerSid,
@@ -96,6 +105,7 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
         }
         await enterCoachMode(conferenceSid, participantSid, agentSid);
         break;
+      }
       case 'monitoring':
         // Mute their line and disable coaching
         await enterListenMode(conferenceSid, participantSid);

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/es-mx.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/es-mx.json
@@ -6,6 +6,7 @@
   "PSBargeCoachAgentSeekingAssistance": "Agente buscando asistencia",
   "PSBargeCoachBarge": "Intervenir",
   "PSBargeCoachCoach": "Entrenador",
+  "PSBargeCoachListen": "Escuchar",
   "PSBargeCoachAgentCoachedBy": "Estás siendo entrenado por:",
   "PSBargeCoachActiveSupervisors": "Supervisores activos:",
   "PSBargeCoachNone": "Ninguno",

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/pt-br.json
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/strings/pt-br.json
@@ -6,6 +6,7 @@
   "PSBargeCoachBarge": "Chamada",
   "PSBargeCoachAgentSeekingAssistance": "Agente buscando assistência",
   "PSBargeCoachCoach": "Treinar",
+  "PSBargeCoachListen": "Ouvir",
   "PSBargeCoachAgentCoachedBy": "Você está sendo assistido por:",
   "PSBargeCoachAssistanceAlertsEnabled": "Alertas de Assistência do Agente Habilitados",
   "PSBargeCoachAssistanceAlertsDisabled": "Alertas de Assistência do Agente Desativados",

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/bargeCoachHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/bargeCoachHelper.ts
@@ -60,8 +60,8 @@ export const enterListenMode = async (conferenceSid: string, participantSid?: st
   Manager.getInstance().store.dispatch(listen());
 };
 
-export const enterBargeMode = async (conferenceSid: string, participantSid: string) => {
-  await BargeCoachService.updateParticipantBargeCoach(conferenceSid, participantSid, '', false, false);
+export const enterBargeMode = async (conferenceSid: string, participantSid: string, agentCallSid: string) => {
+  await BargeCoachService.updateParticipantBargeCoach(conferenceSid, participantSid, agentCallSid, false, false);
   updateSyncDoc(conferenceSid, 'barge');
   Manager.getInstance().store.dispatch(barge());
 };

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/browserRefreshHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/helpers/browserRefreshHelper.ts
@@ -57,14 +57,4 @@ export const supervisorBrowserRefresh = async () => {
     SyncDoc.initSyncDocSupervisors(agentWorkerSID, '', myWorkerSID, '', '', 'remove');
     localStorage.removeItem('agentWorkerSID');
   }
-  // This is here if the Supervisor refreshes and has toggled alerts to false
-  // By default alerts set to true
-  const privateToggle = localStorage.getItem('privateToggle');
-  if (privateToggle === 'false') {
-    Flex.Manager.getInstance().store.dispatch(
-      setBargeCoachStatus({
-        coachingStatusPanel: false,
-      }),
-    );
-  }
 };


### PR DESCRIPTION
### Summary

Found these while porting the code to the plugin library.

Misc supervisor-barge-coach fixes:
- Fix coach then barge not working (actual behavior stayed as coaching due to serverless not setting the flag)
- Add missing localization string for Listen
- Fix unused local storage variable being read after refresh

Misc test fixes:
- Fix Paste icons breaking jest
- Fix useFlexSelector with jest

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
