### PR TITLE
Fix text in keyboard-shortcuts in dark mode

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/KeyCommand.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/keyboard-shortcuts/custom-components/KeyboardShortcuts/KeyCommand.tsx
@@ -18,6 +18,7 @@ const KeyCommand = ({ keyCommand }: KeyCommandProps) => {
       fontFamily: 'TwilioSansMono, Courier, monospace',
       border: '2px solid #e4e4e4',
       boxShadow: '2px 2px 2px #e4e4e4',
+      color: '#121c2d',
     }),
   );
 


### PR DESCRIPTION
### Summary

Fixed white-on-white text in the keyboard shortcut component.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
