### PR TITLE
Fix CA phone number validation

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/custom-actions/startExternalColdTransfer.ts
@@ -34,6 +34,7 @@ export const registerStartExternalColdTransfer = async () => {
           let errors = validationCheck.invalidReason;
 
           errors = errors?.replace('COUNTRY_DISABLED', templates[StringTemplates.CountryDisabled]());
+          errors = errors?.replace('COUNTRY_UNKNOWN', templates[StringTemplates.CountryUnknown]());
           errors = errors?.replace(
             'HIGH_RISK_SPECIAL_NUMBER_DISABLED',
             templates[StringTemplates.HighRiskSpecialNumberDisabled](),

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/strings/CustomTransferDirectory.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/strings/CustomTransferDirectory.ts
@@ -24,6 +24,7 @@ export enum StringTemplates {
   QueueTooltip = 'PSDirectoryQueueTooltip',
   NA = 'PSDirectoryNA',
   CountryDisabled = 'PSDirectoryCountryDisabled',
+  CountryUnknown = 'PSDirectoryCountryUnknown',
   HighRiskSpecialNumberDisabled = 'PSDirectoryHighRiskSpecialNumberDisabled',
   UpdateList = 'PSDirectoryUpdateList',
 }
@@ -52,6 +53,7 @@ export const stringHook = () => ({
     [StringTemplates.QueueTooltip]: 'Agents: {{agentsAvailable}}, Tasks in queue: {{tasksInQueue}}',
     [StringTemplates.NA]: 'N/A',
     [StringTemplates.CountryDisabled]: 'Dialing to this country has been disabled.',
+    [StringTemplates.CountryUnknown]: 'Unable to determine dialing permissions for this number.',
     [StringTemplates.HighRiskSpecialNumberDisabled]:
       'This number is considered high-risk and dialing it has been disabled.',
     [StringTemplates.UpdateList]: 'Update list',


### PR DESCRIPTION
### Summary

Look up dialing permissions using calling country code rather than ISO code, as phone numbers from some countries (such as Canada) return a different ISO code from the Lookup API than is used by DialingPermissions APIs.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
