### PR TITLE
Remove component-specific state from Redux

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/BargeCoachButtons/SupervisorBargeCoachButtonComponent.tsx
@@ -68,7 +68,7 @@ export const SupervisorBargeCoachButtons = ({ task }: SupervisorBargeCoachProps)
     }
 
     const conference = task && task.conference;
-    const conferenceSid = conference?.conferenceSid;
+    const conferenceSid = conference?.conferenceSid || task?.attributes?.conference?.sid;
     if (!conferenceSid) {
       return;
     }

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Template, templates } from '@twilio/flex-ui';
+import { ITask, Template, templates } from '@twilio/flex-ui';
 import { useSelector } from 'react-redux';
 import { Flex } from '@twilio-paste/core/flex';
 import { Box } from '@twilio-paste/core/box';
@@ -10,15 +10,19 @@ import { reduxNamespace } from '../../../../utils/state';
 import { SupervisorBargeCoachState } from '../../flex-hooks/states/SupervisorBargeCoachSlice';
 import { StringTemplates } from '../../flex-hooks/strings/BargeCoachAssist';
 
-export const CoachingStatusPanel = () => {
+type SupervisorBargeCoachProps = {
+  task?: ITask;
+};
+
+export const CoachingStatusPanel = ({ task }: SupervisorBargeCoachProps) => {
   const { supervisorArray } = useSelector(
     (state: AppState) => state[reduxNamespace].supervisorBargeCoach as SupervisorBargeCoachState,
   );
 
-  // If the supervisor array has value in it, that means someone is coaching
-  // We will map each of the supervisors that may be actively coaching
-  // Otherwise we will not display anything if no one is actively coaching
-  if (supervisorArray.length > 0) {
+  const filterSupervisors = (supervisor: any) => supervisor.conference === task?.conference?.conferenceSid;
+
+  // If the supervisor array has value in it for this conference, that means someone is coaching
+  if (supervisorArray.filter(filterSupervisors).length > 0) {
     return (
       <Flex hAlignContent="center" vertical padding="space40">
         <Box
@@ -30,9 +34,9 @@ export const CoachingStatusPanel = () => {
           padding="space40"
         >
           <Template source={templates[StringTemplates.AgentCoachedBy]} />
-          {supervisorArray.map((supervisorArray: { supervisor: string }) => (
+          {supervisorArray.filter(filterSupervisors).map((supervisor: any) => (
             <Text key={`${Math.random()}`} as="p" fontWeight="fontWeightMedium" color="colorTextSuccess">
-              {supervisorArray.supervisor}
+              {supervisor.supervisor}
             </Text>
           ))}
         </Box>

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/CoachingStatusPanel/CoachingStatusPanelComponent.tsx
@@ -19,7 +19,9 @@ export const CoachingStatusPanel = ({ task }: SupervisorBargeCoachProps) => {
     (state: AppState) => state[reduxNamespace].supervisorBargeCoach as SupervisorBargeCoachState,
   );
 
-  const filterSupervisors = (supervisor: any) => supervisor.conference === task?.conference?.conferenceSid;
+  const filterSupervisors = (supervisor: any) =>
+    supervisor.conference === task?.conference?.conferenceSid ||
+    supervisor.conference === task?.attributes?.conference?.sid;
 
   // If the supervisor array has value in it for this conference, that means someone is coaching
   if (supervisorArray.filter(filterSupervisors).length > 0) {

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
@@ -31,7 +31,9 @@ export const SupervisorMonitorPanel = (props: SupervisorMonitorPanelProps) => {
     }
   };
 
-  const filterSupervisors = (supervisor: any) => supervisor.conference === props?.task?.conference?.conferenceSid;
+  const filterSupervisors = (supervisor: any) =>
+    supervisor.conference === props?.task?.conference?.conferenceSid ||
+    supervisor.conference === props?.task?.attributes?.conference?.sid;
 
   const syncUpdates = async (): Promise<any> => {
     const agentWorkerSID = props?.task?.workerSid;

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorMonitorPanel/SupervisorMonitorPanelComponent.tsx
@@ -31,6 +31,8 @@ export const SupervisorMonitorPanel = (props: SupervisorMonitorPanelProps) => {
     }
   };
 
+  const filterSupervisors = (supervisor: any) => supervisor.conference === props?.task?.conference?.conferenceSid;
+
   const syncUpdates = async (): Promise<any> => {
     const agentWorkerSID = props?.task?.workerSid;
     if (!agentWorkerSID) {
@@ -45,10 +47,10 @@ export const SupervisorMonitorPanel = (props: SupervisorMonitorPanelProps) => {
       if (doc.data.supervisors) {
         supervisorArray = [...doc.data.supervisors];
       }
-      setMonitoringSupervisors(supervisorArray);
+      setMonitoringSupervisors(supervisorArray.filter(filterSupervisors));
     });
 
-    setMonitoringSupervisors(doc?.data?.supervisors || []);
+    setMonitoringSupervisors(doc?.data?.supervisors?.filter(filterSupervisors) || []);
     return doc;
   };
 

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/custom-components/SupervisorPrivateModeButton/SupervisorPrivateModeButtonComponent.tsx
@@ -31,7 +31,7 @@ export const SupervisorPrivateToggle = ({ task }: SupervisorPrivateToggleProps) 
   // of the coachingStatusPanel along with updating the Sync Doc appropriately
   const togglePrivateMode = () => {
     const conference = task && task.conference;
-    const conferenceSID = conference?.conferenceSid || '';
+    const conferenceSID = conference?.conferenceSid || task?.attributes?.conference?.sid || '';
     const newValue = !privateMode;
 
     // Caching this to help with browser refresh recovery

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/actions/MonitorCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/actions/MonitorCall.ts
@@ -8,7 +8,7 @@ export const actionEvent = FlexActionEvent.after;
 export const actionHook = async function enableBargeCoachButtonsUponMonitor(flex: typeof Flex) {
   // Listening for supervisor to monitor the call to reset their muted/coaching states
   flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
-    const conferenceSid = payload.task?.conference?.conferenceSid;
+    const conferenceSid = payload.task?.conference?.conferenceSid || payload?.task?.attributes?.conference?.sid;
     if (!conferenceSid) return;
     enterListenMode(conferenceSid);
   });

--- a/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/states/SupervisorBargeCoachSlice.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/supervisor-barge-coach/flex-hooks/states/SupervisorBargeCoachSlice.ts
@@ -4,7 +4,6 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 export interface SupervisorBargeCoachState {
   coaching: boolean;
   muted: boolean;
-  monitorPanelArray: Array<any>;
   supervisorArray: Array<any>;
   privateMode: boolean;
   agentAssistanceButton: boolean;
@@ -15,7 +14,6 @@ export interface SupervisorBargeCoachState {
 const initialState = {
   coaching: false,
   muted: true,
-  monitorPanelArray: [],
   supervisorArray: [],
   privateMode: false,
   agentAssistanceButton: false,


### PR DESCRIPTION
### Summary

When working on #748 I noticed this as a small optimization. It doesn't make sense to store this component's state in Redux, as the data in Redux would get stale anyway if the monitor array changes when the component is not mounted. Moved the state to the component itself instead.

While testing this I noticed that the UI does not handle an agent with multiple calls properly, even though the data model supports it. I fixed that as well.

I have also worked around TECHFLEX-1666.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
