### PR TITLE
Use new props in custom-transfer-directory

### DIFF
--- a/plugin-flex-ts-template-v2/package-lock.json
+++ b/plugin-flex-ts-template-v2/package-lock.json
@@ -27,7 +27,7 @@
         "@babel/preset-typescript": "^7.12.1",
         "@testing-library/react": "^12.1.5",
         "@twilio/flex-plugin-scripts": "7.1.2",
-        "@twilio/flex-ui": "^2.13.1",
+        "@twilio/flex-ui": "^2.13.2",
         "@types/jest": "^27.5.2",
         "@types/luxon": "^3.1.0",
         "@types/react-redux": "^7.1.1",
@@ -8185,9 +8185,9 @@
       }
     },
     "node_modules/@twilio/flex-ui": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-2.13.1.tgz",
-      "integrity": "sha512-+Cc3W5/x57bVGNljhZ0eI4eL/EpQMEO/j+pDafzoWvj12omek4CQzeTXehx1mNI0MFWtxpt2/HjiOx2TycvLfg==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-2.13.2.tgz",
+      "integrity": "sha512-O7BPpfrjU6ytB6Or0/or4HNaAi9ywltQuE8JFRhEtlvN+75/XC4+jZiUj/mfWu2Y6DqO/hxGQESLchB728YJOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13961,9 +13961,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -25160,9 +25160,9 @@
       }
     },
     "node_modules/response-iterator": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.23.tgz",
-      "integrity": "sha512-yjMcSSqoCqu12XTrhAijj2MeQl7iwlv/ZOh2jWPFdodju5zBNx5RCOByZ7TedV3RlxmTbQ63Q92e4h+AEeoN2A==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.25.tgz",
+      "integrity": "sha512-15K4tT8X35W0zJ5bv3fAf4eEKqOwS7yzd+Bg6YEE9NLltVbPbuTcYo3J2AP6AMQGMJmJkFCG421+kP2/iCBfDA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/plugin-flex-ts-template-v2/package.json
+++ b/plugin-flex-ts-template-v2/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "@testing-library/react": "^12.1.5",
     "@twilio/flex-plugin-scripts": "7.1.2",
-    "@twilio/flex-ui": "^2.13.1",
+    "@twilio/flex-ui": "^2.13.2",
     "@types/jest": "^27.5.2",
     "@types/luxon": "^3.1.0",
     "@types/react-redux": "^7.1.1",

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/QueueDirectoryTab.tsx
@@ -52,6 +52,7 @@ export interface TransferQueue extends IQueue, IRealTimeQueueData {}
 
 export interface OwnProps {
   task: ITask;
+  queues?: Array<IQueue>;
 }
 
 export interface MapItem {
@@ -93,16 +94,18 @@ const QueueDirectoryTab = (props: OwnProps) => {
   // async function to retrieve the task queues from the tr sdk
   // this will trigger the useEffect for a fetchedQueues update
   const fetchSDKTaskQueues = async () => {
-    if (workspaceClient)
-      setFetchedQueues(
-        Array.from(
-          (
-            await workspaceClient.fetchTaskQueues({
-              Ordering: 'DateUpdated:desc',
-            })
-          ).values(),
-        ) as unknown as Array<IQueue>,
-      );
+    if (!workspaceClient) {
+      return;
+    }
+    setFetchedQueues(
+      Array.from(
+        (
+          await workspaceClient.fetchTaskQueues({
+            Ordering: 'DateUpdated:desc',
+          })
+        ).values(),
+      ) as unknown as Array<IQueue>,
+    );
   };
 
   // async function to retrieve queues from the insights client with
@@ -246,8 +249,10 @@ const QueueDirectoryTab = (props: OwnProps) => {
   };
 
   const fetchQueues = () => {
-    // fetch the queues from the taskrouter sdk
-    fetchSDKTaskQueues().catch(logger.error);
+    if (!Array.isArray(props.queues)) {
+      // fetch the queues from the taskrouter sdk
+      fetchSDKTaskQueues().catch(logger.error);
+    }
 
     // fetch the queues from the insights client
     fetchInsightsQueueData().catch(logger.error);
@@ -263,6 +268,13 @@ const QueueDirectoryTab = (props: OwnProps) => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (Array.isArray(props.queues)) {
+      // If Flex UI already fetched queues, use it
+      setFetchedQueues(props.queues);
+    }
+  }, [props.queues]);
 
   // hook when fetchedQueues, insightsQueues are updated
   useEffect(() => {

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/WorkerDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/WorkerDirectoryTab.tsx
@@ -27,6 +27,7 @@ export interface TransferClickPayload {
 
 export interface OwnProps {
   task: ITask;
+  workers?: Array<Worker>;
 }
 
 const WorkerDirectoryTab = (props: OwnProps) => {
@@ -102,7 +103,7 @@ const WorkerDirectoryTab = (props: OwnProps) => {
             address: worker.sid,
             type: 'worker',
             key: uuidv4(),
-          } as DirectoryEntry),
+          }) as DirectoryEntry,
       );
 
     setFilteredWorkers(updatedWorkers);
@@ -137,9 +138,19 @@ const WorkerDirectoryTab = (props: OwnProps) => {
 
   // initial render
   useEffect(() => {
+    if (Array.isArray(props.workers)) {
+      return;
+    }
     // fetch the workers from the taskrouter sdk on initial render
     fetchSDKWorkers().catch(logger.error);
   }, []);
+
+  useEffect(() => {
+    if (Array.isArray(props.workers)) {
+      // If Flex UI already fetched workers, use it
+      setFetchedWorkers(props.workers);
+    }
+  }, [props.workers]);
 
   useEffect(() => {
     filterWorkers();

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/WorkerDirectoryTab.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/custom-components/WorkerDirectoryTab.tsx
@@ -103,7 +103,7 @@ const WorkerDirectoryTab = (props: OwnProps) => {
             address: worker.sid,
             type: 'worker',
             key: uuidv4(),
-          }) as DirectoryEntry,
+          } as DirectoryEntry),
       );
 
     setFilteredWorkers(updatedWorkers);

--- a/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/components/WorkerDirectory.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/custom-transfer-directory/flex-hooks/components/WorkerDirectory.tsx
@@ -7,6 +7,22 @@ import QueueDirectoryTab from '../../custom-components/QueueDirectoryTab';
 import ExternalDirectoryTab from '../../custom-components/ExternalDirectoryTab';
 import { StringTemplates } from '../strings/CustomTransferDirectory';
 
+const WorkersTab = (props: any) => {
+  return (
+    <Flex.Tab key="override-workers-transfer-directory" label={props.label}>
+      <WorkerDirectoryTab key="worker-directory-custom-workers-tab" workers={props.workers} />
+    </Flex.Tab>
+  );
+};
+
+const QueuesTab = (props: any) => {
+  return (
+    <Flex.Tab key="override-workers-transfer-directory" label={props.label}>
+      <QueueDirectoryTab key="worker-directory-custom-queue-tab" queues={props.queues} />
+    </Flex.Tab>
+  );
+};
+
 export const componentName = FlexComponent.WorkerDirectory;
 export const componentHook = function replaceQueueDirectory(flex: typeof Flex, manager: Flex.Manager) {
   if (isCustomWorkerTransferEnabled()) {
@@ -15,9 +31,7 @@ export const componentHook = function replaceQueueDirectory(flex: typeof Flex, m
 
     // Add new workers tab
     flex.WorkerDirectory.Tabs.Content.add(
-      <flex.Tab key="override-workers-transfer-directory" label={manager.strings.AgentPanelTitle}>
-        <WorkerDirectoryTab key="worker-directory-custom-workers-tab" />
-      </flex.Tab>,
+      <WorkersTab key="worker-directory-custom-workers-tab" label={manager.strings.AgentPanelTitle} />,
       {
         sortOrder: 0,
       },
@@ -30,9 +44,7 @@ export const componentHook = function replaceQueueDirectory(flex: typeof Flex, m
 
     // Add new Queues tab
     flex.WorkerDirectory.Tabs.Content.add(
-      <flex.Tab key="override-queue-transfer-directory" label={(manager.strings as any)[StringTemplates.Queues]}>
-        <QueueDirectoryTab key="worker-directory-custom-queue-tab" />
-      </flex.Tab>,
+      <QueuesTab key="override-queue-transfer-directory" label={(manager.strings as any)[StringTemplates.Queues]} />,
       {
         sortOrder: 1,
       },


### PR DESCRIPTION
### Summary

Flex UI 2.13 introduced new props to WorkerDirectoryTabs that we can use to reduce TR API requests. Included logic for backwards compatibility with 2.12 and earlier.

Also updated the local Flex UI package because the patch version has fixes around this component.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
