### PR TITLE
Handle disabled voice client

### DIFF
--- a/plugin-flex-ts-template-v2/src/utils/feature-loader/jsclient-event-listeners.ts
+++ b/plugin-flex-ts-template-v2/src/utils/feature-loader/jsclient-event-listeners.ts
@@ -32,7 +32,7 @@ export const addHook = (flex: typeof Flex, manager: Flex.Manager, feature: strin
       break;
     case FlexJsClient.voiceClient:
       if (event === VoiceEvent.incoming) {
-        manager.voiceClient.on(VoiceEvent.incoming, (call) => {
+        manager.voiceClient?.on(VoiceEvent.incoming, (call) => {
           hook.jsClientHook(flex, manager, call);
         });
       }


### PR DESCRIPTION
### Summary

When the `disableBrowserVoice` option is enabled within `ui_attributes`, then `manager.voiceClient` is undefined.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
