### PR TITLE
Fix up Flex state when multi-call device call ends

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -121,6 +121,17 @@ export const handleUnhold = (payload: any) => {
 
 const updateCallState = (manager: Manager, endedCall: Call, device?: Device) => {
   if (MultiCallCalls.length < 1) {
+    if (
+      device &&
+      manager.store.getState().flex?.phone?.activeCall?.parameters.CallSid === endedCall.parameters.CallSid
+    ) {
+      // The call that ended was not the Flex device, and no other calls are in progress, so the state needs to be updated.
+      try {
+        manager.store.dispatch({ type: 'PHONE_REMOVE_CALL' });
+      } catch (error: any) {
+        logger.error('[multi-call] Unable to update phone state', error);
+      }
+    }
     return;
   }
   if (device && manager.store.getState().flex?.phone?.activeCall?.parameters.CallSid !== endedCall.parameters.CallSid) {

--- a/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/multi-call/helpers/MultiCallHelper.ts
@@ -121,10 +121,7 @@ export const handleUnhold = (payload: any) => {
 
 const updateCallState = (manager: Manager, endedCall: Call, device?: Device) => {
   if (MultiCallCalls.length < 1) {
-    if (
-      device &&
-      manager.store.getState().flex?.phone?.activeCall?.parameters.CallSid === endedCall.parameters.CallSid
-    ) {
+    if (device) {
       // The call that ended was not the Flex device, and no other calls are in progress, so the state needs to be updated.
       try {
         manager.store.dispatch({ type: 'PHONE_REMOVE_CALL' });


### PR DESCRIPTION
### Summary

The outbound dialpad button is disabled when there is an active call in Flex state. When a call handled by the Flex device ends, it is removed from state, but when a multi-call device call ends, we were not removing it from state. This means that if the last call to end was not on the Flex device, the user was prevented from placing an outbound call. This PR fixes that.

### Checklist

- [x] Tested changes end to end
- [x] Requested one or more reviewers
