### PR TITLE
Handle jailbreak TR workspace name format

### DIFF
--- a/docs/docs/getting-started/00_install-template.md
+++ b/docs/docs/getting-started/00_install-template.md
@@ -10,7 +10,7 @@ Time to complete: _~8 minutes_
 
 :::info INFO
 
-These steps require a [currently-maintained version of Flex UI 2.x](https://www.twilio.com/docs/flex/flex-ui-eol-reference) to be configured on your Flex account, and the TaskRouter workspace name to be the default "Flex Task Assignment". If you have already deployed plugins from the Flex Plugin Library, please [read this note first](/#flex-plugin-library).
+These steps require a [currently-maintained version of Flex UI 2.x](https://www.twilio.com/docs/flex/flex-ui-eol-reference) to be configured on your Flex account, and the TaskRouter workspace name to be the default (containing "Flex Task Assignment"). If you have already deployed plugins from the Flex Plugin Library, please [read this note first](/#flex-plugin-library).
 
 :::
 

--- a/scripts/common/fetch-cli.mjs
+++ b/scripts/common/fetch-cli.mjs
@@ -56,7 +56,7 @@ export const isMatch = (searchValue, valueToCheck, allowFuzz) => {
     return false;
   }
   
-  if (searchValue.startsWith('/') && searchValue.startsWith('/') && searchValue.length > 2) {
+  if (searchValue.startsWith('/') && searchValue.endsWith('/') && searchValue.length > 2) {
     return new RegExp(searchValue.slice(1, searchValue.length - 1)).test(valueToCheck);
   }
   

--- a/scripts/config/mappings.json
+++ b/scripts/config/mappings.json
@@ -37,7 +37,7 @@
   },
   "TWILIO_FLEX_WORKSPACE_SID": {
     "type": "tr-workspace",
-    "name": "Flex Task Assignment"
+    "name": "/Flex Task Assignment/"
   },
   "TWILIO_FLEX_SYNC_SID": {
     "type": "sync-service",


### PR DESCRIPTION
### Summary

When adding Flex to an existing account, the TaskRouter workspace name is not `Flex Task Assignment`, it is `Flex Task Assignment for {Flex instance SID}`. Changed the mapping to use regex match to handle this.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [x] Requested one or more reviewers
